### PR TITLE
add scenario tests framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ __pycache__/
 *.log
 assets
 test_result.html
-
+*venv

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # About 
----
+
 This is a harvester test framework which uses python pytest library. This framework heavily depends on the pytest fixtures which are defined in conftest.py
 
 ## Pre-requisites
--------------
 
 Before running these tests, bring up a virtual harvester environment following the instructions in repo https://github.com/harvester/ipxe-examples/tree/main/vagrant-pxe-harvester
 
@@ -11,13 +10,17 @@ In addition, the tests are executed via [tox][tox] so make sure it is installed,
 either via [Python pip][pip] or vendor package manager.
 
 ## Pytest Fixtures
--------------
+
 They help us set up some helper code that should run before any tests are executed, and are perfect for setting-up resources that are needed by the tests. They are defined in conftest.py under the apis folder.
 
 These fixture are executed at the session level and they are used to provide the authentication and to get the api endpoints before executing tests for a particular api
 
-## Running Tests 
----
+## Running Tests
+
+### API Tests 
+
+API Tests are designed to test REST APIs for one resource (i.e. keypairs,
+vitualmachines, virtualmachineimages, etc) at a time.
 
 To run all the API tests under the `apis` folder, maintain the count of
 harvester_cluster_nodes(1 for single node and 3 for 3-node cluster) in config.yml. It can also be set as an option while executing the pytest.
@@ -27,7 +30,7 @@ For the first time logging pass the --set-admin-password option. For subsequest 
 As mentioned before, the test will be executed via the [tox][tox]
 environments. Currently, both Python3.6 and Python3.8 are supported.
 
-For example, to run the tests in Python3.6 environmentfor the first time,
+For example, to run the tests in a Python3.6 environment for the first time,
 against a freshly installed single node Harvester:
 ```console
 tox -e py36 -- apis --endpoint https://<harvester_node_0 IP>:30443 --html=test_result.html
@@ -38,7 +41,7 @@ To pass the harverster_cluster_nodes as option:
 tox -e py36 -- apis --endpoint https://<harvester_node_0 IP>:30443 --harvester_cluster_nodes 1 --html=test_result.html
 ```
 
-To run the API tests in Python3.8 environment:
+To run the API tests in a Python3.8 environment:
 ```console
 tox -e py38 -- apis --endpoint https://<harvester_node_0 IP>:30443 --html=test_result.html
 ```
@@ -59,6 +62,30 @@ apis/test_vm_templates.py ...                                            [ 81%]
 apis/test_volumes.py ....                                                [100%]
 
 ----------- generated html file: file:///<home Folder>/tests/test_result.html -----------
+```
+
+### Scenario Tests
+
+Scenario tests are designed to test a specific use case or scenario at a time,
+which may involved a combination of resources in an orchestrated workflow.
+
+Like the API tests, the scenario tests are also running inside the
+[tox][tox]-managed environments. Currently, both Python3.6 and Python3.8 are
+supported.
+
+To run the scenario tests in a Python3.6 environment:
+```console
+tox -r -e py36 -- scenarios --endpoint https://<harvester_node_0 IP>:30443 --html=test_result.html
+```
+To run the scenario tests in a Python3.8 environment:
+```console
+tox -r -e py38 -- scenarios --endpoint https://<harvester_node_0 IP>:30443 --html=test_result.html
+```
+By default the tests will cleanup after themselves. If you want to preserve the
+test artifact for debugging purposes, you may specific the `--do-not-cleanup`
+flag. For example:
+```console
+tox -r -e py38 -- scenarios --endpoint https://<harvester_node_0 IP>:30443 --html=test_result.html --do-not-cleanup
 ```
 
 ## Running Linter

--- a/scenarios/__init__.py
+++ b/scenarios/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+

--- a/scenarios/conftest.py
+++ b/scenarios/conftest.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        '--endpoint',
+        action='store',
+        default='https://localhost:8443',
+        help='Harvester API endpoint'
+    )
+    parser.addoption(
+        '--username',
+        action='store',
+        default='admin',
+        help='Harvester username'
+    )
+    parser.addoption(
+        '--password',
+        action='store',
+        default='password',
+        help='Harvester password'
+    )
+    parser.addoption(
+        '--do-not-cleanup',
+        action='store_true',
+        help='Do not cleanup the test artifacts'
+    )
+    # TODO(gyee): may need to add SSL options later

--- a/scenarios/fixtures/__init__.py
+++ b/scenarios/fixtures/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+

--- a/scenarios/fixtures/api_endpoints.py
+++ b/scenarios/fixtures/api_endpoints.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
+from scenarios import utils
+from urllib.parse import urljoin
+import pytest
+
+
+pytest_plugins = [
+   'scenarios.fixtures.api_version',
+  ]
+
+
+# NOTE: see Swagger API doc here
+# https://docs.harvesterhci.io/v0.2/reference/api/
+class HarvesterAPIEndpoints:
+    def __init__(self, endpoint, harvester_api_version,
+                 cdi_api_version, kubevirt_api_version):
+       self.harvester_endpoint = endpoint
+       self.__dict__.update(
+           utils.get_json_object_from_template('api_endpoints',
+                harvester_endpoint=self.harvester_endpoint,
+                harvester_api_version=harvester_api_version,
+                cdi_api_version=cdi_api_version,
+                kubevirt_api_version=kubevirt_api_version
+            )
+        )
+
+
+@pytest.fixture(scope='session')
+def harvester_api_endpoints(request, harvester_api_version,
+                            cdi_api_version, kubevirt_api_version):
+    harvester_endpoint = request.config.getoption('--endpoint')
+    return HarvesterAPIEndpoints(harvester_endpoint, harvester_api_version,
+                                 cdi_api_version, kubevirt_api_version)

--- a/scenarios/fixtures/api_version.py
+++ b/scenarios/fixtures/api_version.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
+import pytest
+
+
+@pytest.fixture(scope='session')
+def harvester_api_version(request):
+    # FIXME(gyee): we need to be able to discover this information from
+    # the Harvester endpoint. Right now, all the Harvester endpoints are
+    # protected.
+    return 'harvesterhci.io/v1beta1'
+
+
+@pytest.fixture(scope='session')
+def cdi_api_version(request):
+    # FIXME(gyee): we need to be able to discover this information from
+    # the Harvester endpoint.
+    return 'cdi.kubevirt.io/v1beta1'
+
+
+@pytest.fixture(scope='session')
+def kubevirt_api_version(request):
+    # FIXME(gyee): we need to be able to discover this information from
+    # the Harvester endpoint.
+    return 'kubevirt.io/v1'

--- a/scenarios/fixtures/image.py
+++ b/scenarios/fixtures/image.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
+from scenarios import utils
+import pytest
+
+
+pytest_plugins = [
+   'scenarios.fixtures.api_endpoints',
+   'scenarios.fixtures.api_version',
+   'scenarios.fixtures.session',
+  ]
+
+
+@pytest.fixture(scope='class')
+def image(request, harvester_api_version, admin_session,
+          harvester_api_endpoints):
+    request_json = utils.get_json_object_from_template('basic_image',
+        description='Leap 15.2 cloud image',
+        url=('http://download.opensuse.org/repositories/Cloud:/Images:/'
+             'Leap_15.2/images/openSUSE-Leap-15.2.x86_64-NoCloud.qcow2')
+    )
+    resp = admin_session.post(harvester_api_endpoints.create_image,
+                              json=request_json)
+    assert resp.status_code == 201, 'Unable to create image'
+    image_data = resp.json()
+    yield image_data
+    if not request.config.getoption('--do-not-cleanup'):
+        resp = admin_session.delete(
+            harvester_api_endpoints.delete_image % (
+                image_data['metadata']['name']))
+        assert resp.status_code == 200, 'Unable to cleanup image'

--- a/scenarios/fixtures/keypair.py
+++ b/scenarios/fixtures/keypair.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import (
+    NoEncryption,
+    Encoding,
+    PrivateFormat,
+    PublicFormat)
+from scenarios import utils
+import pytest
+
+
+pytest_plugins = [
+   'scenarios.fixtures.api_endpoints',
+   'scenarios.fixtures.api_version',
+   'scenarios.fixtures.session',
+  ]
+
+
+def _generate_ssh_keypair():
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=1024,
+        backend=default_backend(),
+    )
+
+    private_key_pem = private_key.private_bytes(
+        Encoding.PEM,
+        PrivateFormat.PKCS8,
+        NoEncryption()
+    )
+
+    public_key = private_key.public_key()
+    public_key_ssh = public_key.public_bytes(
+        Encoding.OpenSSH,
+        PublicFormat.OpenSSH
+    )
+
+    return public_key_ssh.decode('utf-8'), private_key_pem.decode('utf-8')
+
+
+@pytest.fixture(scope='class')
+def keypair(request, harvester_api_version, admin_session,
+            harvester_api_endpoints):
+    public_key, private_key = _generate_ssh_keypair()
+    request_json = utils.get_json_object_from_template('basic_keypair',
+        public_key=public_key
+    )
+    print('---%s---' % (harvester_api_endpoints.create_keypair))
+    resp = admin_session.post(harvester_api_endpoints.create_keypair,
+                              json=request_json)
+    assert resp.status_code == 201, 'Unable to create keypair'
+    keypair_data = resp.json()
+    # NOTE(gyee): inject the private key to the keypair data so tests
+    # have access to it, just in case they want to also test SSH into
+    # the VM. This is not a security concern as this is for test only.
+    keypair_data['spec']['privateKey'] = private_key
+    yield keypair_data
+    if not request.config.getoption('--do-not-cleanup'):
+        resp = admin_session.delete(
+            harvester_api_endpoints.delete_keypair % (
+                keypair_data['metadata']['name']))
+        assert resp.status_code == 200, 'Unable to cleanup keypair'

--- a/scenarios/fixtures/session.py
+++ b/scenarios/fixtures/session.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
+from urllib.parse import urljoin
+import pytest
+import requests
+import urllib3
+
+
+# FIXME(gyee): we need to set the admin password on the first login. Currently,
+# this is done by using K3OS internal mechanism which is not officially
+# supported. This is merely a temporary workaround. This issue is being tracked
+# here https://github.com/harvester/harvester/issues/893. We need to update
+# this code once we have an officially supported public API to bootstrap
+# the local admin account.
+#
+# The workaround is based off
+# https://github.com/harvester/harvester/wiki/Authn-Initialization-Automation
+def _set_admin_password(harvester_api_endpoints, password):
+    # check to see if this is first login
+    resp = requests.get(
+        harvester_api_endpoints.first_login_check, verify=False)
+    assert resp.status_code == 200, 'Unable to lookup first login status'
+    if resp.json()['value'].lower() == 'false':
+        # not first login, no need to set admin password
+        return  
+
+    # need to set admin password
+    # first obtain the token using the default admin password
+    login_data = {'username': 'admin', 'password': 'admin',
+                  'responseType': 'json'}
+    params = {'action': 'login'}
+    resp = requests.post(
+        harvester_api_endpoints.local_auth, verify=False,
+        params=params, json=login_data)
+    assert resp.status_code == 200, ('Unable to authenticate admin with '
+                                     'default password')
+
+    # now reset the admin password
+    bearer_token = 'Bearer ' + resp.json()['token']
+
+    reset_password_data = {'currentPassword': 'admin',
+                           'newPassword': password}
+    params = {'action': 'changepassword'}
+    headers = {'authorization': bearer_token}
+    resp = requests.post(
+        harvester_api_endpoints.reset_password, verify=False, headers=headers,
+        params=params, json=reset_password_data)
+    assert resp.status_code == 200, 'Unable to reset admin password'
+
+
+@pytest.fixture(scope='session')
+def admin_session(request, harvester_api_endpoints):
+    endpoint = request.config.getoption('--endpoint')
+    username = request.config.getoption('--username')
+    password = request.config.getoption('--password')
+
+    # set admin password if needed
+    _set_admin_password(harvester_api_endpoints, password)
+
+    # authenticate admin
+    login_data = {'username': username, 'password': password}
+    params = {'action': 'login'}
+    s = requests.Session()
+    # TODO(gyee): do we need to support other auth methods?
+    # NOTE(gyee): ignore SSL certificate validation for now
+    resp = s.post(harvester_api_endpoints.local_auth, verify=False,
+                  params=params, json=login_data)
+    auth_token = 'Bearer ' + resp.json()['token']
+    s.headers.update({'Authorization': auth_token})
+    return s

--- a/scenarios/fixtures/volume.py
+++ b/scenarios/fixtures/volume.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
+from scenarios import utils
+from uuid import uuid4
+import pytest
+
+
+pytest_plugins = [
+   'scenarios.fixtures.api_endpoints',
+   'scenarios.fixtures.api_version',
+   'scenarios.fixtures.session',
+  ]
+
+
+@pytest.fixture(scope='class')
+def volume(request, kubevirt_api_version, admin_session,
+                      harvester_api_endpoints):
+    request_json = utils.get_json_object_from_template('basic_volume',
+        size=8,
+        description='Test volume'
+    )
+    resp = admin_session.post(harvester_api_endpoints.create_volume,
+                              json=request_json)
+    assert resp.status_code == 201, 'Unable to create a blank volume'
+    volume_data = resp.json()
+    yield volume_data
+    if not request.config.getoption('--do-not-cleanup'):
+        resp = admin_session.delete(
+            harvester_api_endpoints.delete_volume % (
+                volume_data['metadata']['name']))
+        assert resp.status_code == 200, 'Unable to cleanup volume'

--- a/scenarios/templates/api_endpoints.json.j2
+++ b/scenarios/templates/api_endpoints.json.j2
@@ -1,0 +1,19 @@
+{# Harvester APIs #}
+{# see https://docs.harvesterhci.io/v0.2/reference/api/ #}
+
+{
+    "first_login_check": "{{ harvester_endpoint }}/v3/settings/first-login",
+    "local_auth": "{{ harvester_endpoint }}/v3-public/localProviders/local",
+    "reset_password": "{{ harvester_endpoint }}/v3/users",
+    "create_keypair": "{{ harvester_endpoint }}/apis/{{ harvester_api_version }}/namespaces/{{ api_namespace | default('default') }}/keypairs",
+    "delete_keypair": "{{ harvester_endpoint }}/apis/{{ harvester_api_version }}/namespaces/{{ api_namespace | default('default') }}/keypairs/%s",
+    "create_image": "{{ harvester_endpoint }}/apis/{{ harvester_api_version }}/namespaces/{{ api_namespace | default('default') }}/virtualmachineimages",
+    "delete_image": "{{ harvester_endpoint }}/apis/{{ harvester_api_version }}/namespaces/{{ api_namespace | default('default') }}/virtualmachineimages/%s",
+    "create_volume": "{{ harvester_endpoint }}/apis/{{ cdi_api_version }}/namespaces/{{ api_namespace | default('default') }}/datavolumes",
+    "delete_volume": "{{ harvester_endpoint }}/apis/{{ cdi_api_version }}/namespaces/{{ api_namespace | default('default') }}/datavolumes/%s",
+    "create_vm": "{{ harvester_endpoint }}/apis/{{ kubevirt_api_version }}/namespaces/{{ api_namespace | default('default') }}/virtualmachines",
+    "delete_vm": "{{ harvester_endpoint }}/apis/{{ kubevirt_api_version }}/namespaces/{{ api_namespace | default('default') }}/virtualmachines/%s",
+    "get_vm": "{{ harvester_endpoint }}/apis/{{ kubevirt_api_version }}/namespaces/{{ api_namespace | default('default') }}/virtualmachines/%s",
+    "list_vm_instances": "{{ harvester_endpoint }}/apis/{{ kubevirt_api_version }}/namespaces/{{ api_namespace | default('default') }}/virtualmachineinstances",
+    "get_vm_instance": "{{ harvester_endpoint }}/apis/{{ kubevirt_api_version }}/namespaces/{{ api_namespace | default('default') }}/virtualmachineinstances/%s"
+}

--- a/scenarios/templates/basic_image.json.j2
+++ b/scenarios/templates/basic_image.json.j2
@@ -1,0 +1,21 @@
+{# Template for basic image creation request. #}
+
+{% if name is not defined %}
+    {% set name = random_name() %}
+{% endif %}
+
+{
+    "apiVersion": "harvesterhci.io/v1beta1",
+    "kind": "VirtualMachineImage",
+    "metadata": {
+        "annotations": {
+            "field.cattle.io/description": "{{ description | default('') }}"
+        },
+        "name": "{{ name }}",
+        "namespace": "{{ image_namespace | default('default') }}"
+    },
+    "spec": {
+        "displayName": "{{ name }}",
+        "url": "{{ url }}"
+    }
+}

--- a/scenarios/templates/basic_keypair.json.j2
+++ b/scenarios/templates/basic_keypair.json.j2
@@ -1,0 +1,17 @@
+{# Template for basic keypair creation request. #}
+
+{% if name is not defined %}
+    {% set name = random_name() %}
+{% endif %}
+
+{
+    "apiVersion": "harvesterhci.io/v1beta1",
+    "kind": "KeyPair",
+    "metadata": {
+        "name": "{{ name }}",
+        "namespace": "{{ keypair_namespace | default('default') }}"
+    },
+    "spec": {
+        "publicKey": "{{ public_key }}"
+    }
+}

--- a/scenarios/templates/basic_vm.json.j2
+++ b/scenarios/templates/basic_vm.json.j2
@@ -1,0 +1,112 @@
+{# Template for basic VM creation request. Start the VM instance upon #}
+{# creation. #}
+
+{% if name is not defined %}
+    {% set name = random_name() %}
+{% endif %}
+{% set disk_0_name = name ~ "-disk-0-" ~ random_alphanumeric(length=5) %}
+
+{
+    "apiVersion": "kubevirt.io/v1",
+    "kind": "VirtualMachine",
+    "metadata": {
+        "annotations": {
+            "field.cattle.io/description": "{{ description | default('') }}"
+        },
+        "name": "{{ name }}"
+    },
+    "spec": {
+        "dataVolumeTemplates": [
+            {
+                "apiVersion": "cdi.kubevirt.io/v1beta1",
+                "kind": "DataVolume",
+                "metadata": {
+                    "annotations": {
+                        "harvesterhci.io/imageId": "{{ image_namespace | default('default') }}/{{ image_name }}"
+                    },
+                    "name": "{{ disk_0_name }}"
+                },
+                "spec": {
+                    "pvc": {
+                        "accessModes": [
+                            "ReadWriteMany"
+                        ],
+                        "resources": {
+                            "requests": {
+                                "storage": "{{ disk_size_gb | default(10) }}Gi"
+                            }
+                        },
+                        "volumeMode": "Block"
+                    },
+                    "source": {
+                        "blank": {}
+                    }
+                }
+            }
+        ],
+        "running": true,
+        "template": {
+            "metadata": {
+                "annotations": {
+                    "harvesterhci.io/diskNames": "[\"{{ disk_0_name }}\"]",
+                    "harvesterhci.io/sshNames": "[\"{{ ssh_key_name }}\"]"
+                },
+                "labels": {
+                    "harvesterhci.io/vmName": "{{ name }}"
+                }
+            },
+            "spec": {
+                "domain": {
+                    "cpu": {
+                        "cores": {{ cpu | default(1) }},
+                        "sockets": 1,
+                        "threads": 1
+                    },
+                    "devices": {
+                        "disks": [
+                            {
+                                "disk": {
+                                    "bus": "virtio"
+                                },
+                                "name": "disk-0"
+                            },
+                            {
+                                "disk": {
+                                    "bus": "virtio"
+                                },
+                                "name": "cloudinitdisk"
+                            }
+                        ],
+                        "inputs": [
+                            {
+                                "bus": "usb",
+                                "name": "tablet",
+                                "type": "tablet"
+                            }
+                        ]
+                    },
+                    "resources": {
+                        "requests": {
+                            "memory": "{{ memory_gb | default(1) }}Gi"
+                        }
+                    }
+                },
+                "hostname": "{{ hostname | default(name) }}",
+                "volumes": [
+                    {
+                        "dataVolume": {
+                            "name": "{{ disk_0_name }}"
+                        },
+                        "name": "disk-0"
+                    },
+                    {
+                        "cloudInitNoCloud": {
+                            "userData": "#cloud-config\\nssh_authorized_keys:\\n  - >-\\n    {{ ssh_public_key }}\\n"
+                        },
+                        "name": "cloudinitdisk"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/scenarios/templates/basic_volume.json.j2
+++ b/scenarios/templates/basic_volume.json.j2
@@ -1,0 +1,33 @@
+{# Template for basic volume creation request. Default size is 10Gb. #}
+{% if name is not defined %}
+    {% set name = random_name() %}
+{% endif %}
+
+
+{
+    "apiVersion": "cdi.kubevirt.io/v1beta1",
+    "kind": "DataVolume",
+    "metadata": {
+        "annotations": {
+            "field.cattle.io/description": "{{ description | default('') }}"
+        },
+        "name": "{{ name }}",
+        "namespace": "{{ volume_namespace | default('default') }}"
+    },
+    "spec": {
+        "pvc": {
+            "accessModes": [
+                "ReadWriteMany"
+            ],
+            "resources": {
+                "requests": {
+                    "storage": "{{ size | default(10) }}Gi"
+                }
+            },
+            "volumeMode": "Block"
+        },
+        "source": {
+            "blank": {}
+        }
+    }
+}

--- a/scenarios/test_create_vm.py
+++ b/scenarios/test_create_vm.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
+from scenarios import utils
+import pytest
+import time
+
+
+pytest_plugins = [
+   'scenarios.fixtures.image',
+   'scenarios.fixtures.keypair',
+   'scenarios.fixtures.volume',
+  ]
+
+
+@pytest.fixture()
+def basic_vm(request, admin_session, image, keypair, volume,
+             harvester_api_endpoints):
+    request_json = utils.get_json_object_from_template('basic_vm',
+        image_namespace=image['metadata']['namespace'],
+        image_name=image['metadata']['name'],
+        disk_size_gb=10,
+        ssh_key_name=keypair['metadata']['name'],
+        cpu=1,
+        memory_gb=1,
+        ssh_public_key=keypair['spec']['publicKey']
+    )
+    resp = admin_session.post(harvester_api_endpoints.create_vm,
+                              json=request_json)
+    assert resp.status_code == 201, 'Failed to create VM'
+    vm_resp_json = resp.json()
+    yield vm_resp_json
+    if not request.config.getoption('--do-not-cleanup'):
+        resp = admin_session.delete(
+            harvester_api_endpoints.delete_vm % (
+                vm_resp_json['metadata']['name']))
+
+
+def test_create_vm(admin_session, basic_vm, keypair, harvester_api_endpoints):
+    ready = False
+    # VM startup is asynchronous so make sure it is running and it has a
+    # corresponding instance.
+    retries = 10
+    while retries:
+        resp = admin_session.get(harvester_api_endpoints.get_vm % (
+            basic_vm['metadata']['name']))
+        if resp.status_code == 200:
+            resp_json = resp.json()
+            if ('status' in resp_json and 'ready' in resp_json['status'] and
+                    resp_json['status']['ready']):
+                ready = True
+                break
+        retries -= 1
+        # TODO(gyee): should we make the sleep time configurable?
+        time.sleep(30)
+    assert ready, 'Timed out while waiting for VM to be ready.'
+    # NOTE(gyee): seem like the corresponding VM instance has the same name as
+    # the VM. If this assumption is not true, we need to fix this code.
+    resp = admin_session.get(harvester_api_endpoints.get_vm_instance % (
+        basic_vm['metadata']['name']))
+    assert resp.status_code == 200, 'Failed to lookup VM instance %s' % (
+        basic_vm['metadata']['name'])
+    vm_instance_json = resp.json()
+    # TODO(gyee): need to make sure we can SSH into the VM, but only
+    # if the VM has a public IP.

--- a/scenarios/utils.py
+++ b/scenarios/utils.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
+import jinja2
+import json
+import os
+import random
+import string
+import uuid
+
+
+def random_name():
+    """Generate a random alphanumeric name using uuid.uuid4()"""
+    return uuid.uuid4().hex
+
+
+def random_alphanumeric(length=5, upper_case=False):
+    """Generate a random alphanumeric string of given length
+
+    :param length: the size of the string
+    :param upper_case: whether to return the upper case string
+    """
+    if upper_case:
+        return ''.join(random.choice(
+            string.ascii_uppercase + string.digits) for _ in range(length))
+    else:
+        return ''.join(random.choice(
+            string.ascii_lowercase + string.digits) for _ in range(length))
+
+
+def get_json_object_from_template(template_name, **template_args):
+    """Load template from template file
+
+    :param template_name: the name of the template. It is the filename of
+                          template without the file extension. For example, if
+                          you want to load './templates/foo.json.j2', then the
+                          template_name should be 'foo'.
+    :param template_args: dictionary of template argument values for the given
+                          Jinja2 template
+    """
+    # get the current path relative to the ./templates/ directory
+    my_path = os.path.dirname(os.path.realpath(__file__))
+    # NOTE: the templates directory must be at the same level as
+    # utilities.py, and all the templates must have the '.yaml.j2' extension
+    templates_path = os.path.join(my_path, 'templates')
+    template_file = f'{templates_path}/{template_name}.json.j2'
+    # now load the template
+    with open(template_file) as tempfile:
+        template = jinja2.Template(tempfile.read())
+    template.globals['random_name'] = random_name
+    template.globals['random_alphanumeric'] = random_alphanumeric
+    # now render the template
+    rendered = template.render(template_args)
+    return json.loads(rendered)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,11 @@
 pytest
 pytest-html
+pytest-json-report
+jinja2
 bcrypt
 requests
 pycryptodome
 sshpubkeys
 pyyaml
 polling2
+cryptography

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,9 @@ skipsdist = True
 
 [testenv]
 basepython = python3
-setenv = VIRTUAL_ENV={envdir}
+setenv =
+    VIRTUAL_ENV = {envdir}
+    PYTHONWARNINGS = ignore:Unverified HTTPS request
 deps = pytest
        -r{toxinidir}/test-requirements.txt
 commands =


### PR DESCRIPTION
Utilizing pytest and jinja2 templating to simplify the process in
developing scenario tests. Test developers can easily create request
templates and load them into JSON request objects by provide only the
required fields. The templates, along with their corresponding fixtures
are designed to be reusable. With templating, the goal is to reduce the
complexity of having to handcraft the JSON request in every test.