### PR TITLE
Add host management framework to facilitate host test scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,41 @@ flag. For example:
 tox -r -e py38 -- harvester_e2e_tests/scenarios --endpoint https://<harvester_node_0 IP>:30443 --html=test_result.html --do-not-cleanup
 ```
 
+### Adding Host Management Scripts
+
+Some tests required manipulating the hosts where the VMs are running in order to
+test scheduling resiliency and disaster recovery scenarios. Therefore, we need
+external scripts to power-on, power-off, and to reboot a given node. The
+host management scripts are expected to be provided by users out-of-band.
+Reasons are:
+
+1. the scripts are very specific to the Harvester environment. For example,
+   for a virtual vagrant environment, the scripts may simply just performing
+   `vagrant halt <node name>` and `vagrant up <node name>`. However for a
+   baremetal environment managed by IPMI, the scripts may need to
+   use IPMO tools CLI.
+2. for certain environments (i.e. IPMI, RedFish, etc), credential is required.
+
+The host management scripts must all be placed into the same directory and must
+be named `power_on.sh`, `power_off.sh`, and `reboot.sh`. All the scripts must
+accept exactly one parameter, which is the name of the host. Please see the
+`scripts` directory for examples.
+
+Host management tests must be invoked with the `host_management` marker.
+For example, to run the host management tests:
+
+```console
+tox -e py38 -- --endpoint https://192.168.0.30:30443 --wait-timeout 600 --node-scripts-location ./scripts -m "host_management"
+```
+
+---
+**NOTE**
+
+Must also provide the `--node-scripts-location` parameter, which points to the
+directory which contains the host management shell scripts.
+
+---
+
 ## Running delete Host tests
 ----------------------------
 

--- a/harvester_e2e_tests/conftest.py
+++ b/harvester_e2e_tests/conftest.py
@@ -73,6 +73,12 @@ def pytest_addoption(parser):
         action='store',
         help='Rancher API endpoint'
     )
+    parser.addoption(
+        '--node-scripts-location',
+        action='store',
+        help=('External scripts to power-off, power-up, and reboot a given '
+              'Harvester node to facilitate the host-specific tests')
+    )
     # TODO(gyee): may need to add SSL options later
 
 
@@ -86,6 +92,12 @@ def pytest_configure(config):
                     'a multi-node cluster where some hosts have more '
                     'resources then others in order to test VM scheduling '
                     'behavior')
+    )
+    config.addinivalue_line(
+        "markers", ('host_management: mark test to run only if we have '
+                    'host management (power_on.sh, power_off.sh, reboot.sh) '
+                    'scripts provided. These tests are designed to test '
+                    'scheduling resiliency and disaster recovery scenarios. ')
     )
     config.addinivalue_line(
         "markers", ('delete_host: mark test to run in the end when other '

--- a/harvester_e2e_tests/fixtures/vm.py
+++ b/harvester_e2e_tests/fixtures/vm.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
+from harvester_e2e_tests import utils
+import pytest
+
+
+pytest_plugins = [
+    'harvester_e2e_tests.fixtures.image',
+    'harvester_e2e_tests.fixtures.keypair',
+    'harvester_e2e_tests.fixtures.network',
+    'harvester_e2e_tests.fixtures.volume'
+]
+
+
+@pytest.fixture(scope='class')
+def network_data():
+    yaml_data = """#cloud-config
+version: 1
+config:
+  - type: physical
+    name: eth0
+    subnets:
+      - type: dhcp
+  - type: physical
+    name: eth1
+    subnets:
+      - type: dhcp
+"""
+    return yaml_data.replace('\n', '\\n')
+
+
+@pytest.fixture(scope='class')
+def user_data_with_guest_agent(keypair):
+    # set to root user password to 'linux' to test password login in
+    # addition to SSH login
+    yaml_data = """#cloud-config
+chpasswd:
+  list: |
+    root:linux
+  expire: false
+ssh_authorized_keys:
+  - %s
+package_update: true
+packages:
+  - qemu-guest-agent
+runcmd:
+  - - systemctl
+    - enable
+    - '--now'
+    - qemu-guest-agent
+""" % (keypair['spec']['publicKey'])
+    return yaml_data.replace('\n', '\\n')
+
+
+@pytest.fixture(scope='class')
+def basic_vm(request, admin_session, image, keypair,
+             user_data_with_guest_agent, network_data,
+             harvester_api_endpoints):
+    vm_json = utils.create_vm(request, admin_session, image,
+                              harvester_api_endpoints,
+                              keypair=keypair,
+                              network_data=network_data,
+                              user_data=user_data_with_guest_agent)
+    yield vm_json
+    if not request.config.getoption('--do-not-cleanup'):
+        resp = admin_session.get(
+            harvester_api_endpoints.get_vm % (vm_json['metadata']['name']))
+        if resp.status_code != 404:
+            utils.delete_vm(request, admin_session, harvester_api_endpoints,
+                            vm_json)
+
+
+@pytest.fixture(scope='class')
+def vm_with_volume(request, admin_session, image, volume, keypair,
+                   harvester_api_endpoints):
+    vm_json = utils.create_vm(request, admin_session, image,
+                              harvester_api_endpoints,
+                              template='vm_with_volume',
+                              volume=volume,
+                              keypair=keypair)
+    return vm_json

--- a/harvester_e2e_tests/scenarios/test_vm_negatives.py
+++ b/harvester_e2e_tests/scenarios/test_vm_negatives.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
+from harvester_e2e_tests import utils
+import pytest
+
+pytest_plugins = [
+    'harvester_e2e_tests.fixtures.vm'
+]
+
+
+class TestHostDown:
+
+    @pytest.mark.host_management
+    def test_host_shutdown(self, request, admin_session,
+                           harvester_api_endpoints, basic_vm):
+        # make sure the VM instance is successfully created
+        vm_instance_json = utils.lookup_vm_instance(
+            admin_session, harvester_api_endpoints, basic_vm)
+        # abruptly shutdown the node where it is running
+        node_name = vm_instance_json['status']['nodeName']
+        utils.power_off_node(request, admin_session, harvester_api_endpoints,
+                             node_name)
+        # FIXME(gyee): we currently don't know what the expected behavoir is
+        # for an instance where the node is abruptly shutdown. I would've
+        # expected the instance to go into error state. But that doesn't seem
+        # to be the case right now. It seem to get stuck on "PodTerminating".
+        #
+        # See https://github.com/harvester/harvester/issues/913
+        vm_instance_json = utils.lookup_vm_instance(
+            admin_session, harvester_api_endpoints, basic_vm)
+        found = False
+        for condition in vm_instance_json['status']['conditions']:
+            if condition['type'] == 'Ready':
+                assert condition['status'] == 'False', (
+                    'Expecting "False" status, got %s instead' % (
+                        condition['status']))
+                # FIXME(gyee): is 'reason' always present?
+                # assert condition['reason'] == 'PodTerminating', (
+                #    'Expecting "PodTerminating" in reason, got %s instead' % (
+                #        condition['reason']))
+                found = True
+                break
+        assert found, (
+            'Expecting "PodTerminating" in conditions, got %s instead' % (
+                vm_instance_json['status']['conditions']))
+        # power-on the node
+        utils.power_on_node(request, admin_session, harvester_api_endpoints,
+                            node_name)
+
+    @pytest.mark.host_management
+    def test_delete_vm_while_host_shutdown(self, request, admin_session,
+                                           harvester_api_endpoints, basic_vm):
+        # make sure the VM instance is successfully created
+        vm_instance_json = utils.lookup_vm_instance(
+            admin_session, harvester_api_endpoints, basic_vm)
+        # abruptly shutdown the node where it is running
+        node_name = vm_instance_json['status']['nodeName']
+        utils.power_off_node(request, admin_session, harvester_api_endpoints,
+                             node_name)
+        # now try to delete the VM while node is down, this should succeed
+        utils.delete_vm(request, admin_session, harvester_api_endpoints,
+                        basic_vm)
+        # power-on the node
+        utils.power_on_node(request, admin_session, harvester_api_endpoints,
+                            node_name)

--- a/scripts/vagrant/power_off.sh.example
+++ b/scripts/vagrant/power_off.sh.example
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+USAGE="${0}: <hostname>
+
+Where:
+
+  <hostname>: host name of the Vagrant Harvester node
+"
+
+if [ $# -ne 1 ] ; then
+        echo "$USAGE"
+        exit 1
+fi
+
+HOSTNAME=$1
+
+pushd /home/foo/ipxe-examples/vagrant-pxe-harvester
+vagrant ssh-config $HOSTNAME
+vagrant halt $HOSTNAME
+popd
+

--- a/scripts/vagrant/power_on.sh.example
+++ b/scripts/vagrant/power_on.sh.example
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+USAGE="${0}: <hostname>
+
+Where:
+
+  <hostname>: host name of the Vagrant Harvester node
+"
+
+if [ $# -ne 1 ] ; then
+        echo "$USAGE"
+        exit 1
+fi
+
+HOSTNAME=$1
+
+pushd /home/foo/ipxe-examples/vagrant-pxe-harvester
+vagrant up $HOSTNAME
+popd


### PR DESCRIPTION
Add a framework to enable tests which required host manipulations (i.e.
power-off, power-on, and reboot).

This patch also removes the duplicate VM volume tests.