### PR TITLE
Customizable image download location

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -30,4 +30,7 @@ node-scripts-location: 'scripts/vagrant'
 # URL to download the Windows image
 win-image-url: ''
 
+# URL to download all images
+image-cache-url: ''
+
 terraform-scripts-location: 'terraform_test_artifacts'

--- a/harvester_e2e_tests/apis/test_images.py
+++ b/harvester_e2e_tests/apis/test_images.py
@@ -16,9 +16,9 @@
 # you may find current contact information at www.suse.com
 
 from harvester_e2e_tests import utils
+import os
 import polling2
 import pytest
-
 
 pytest_plugins = [
     'harvester_e2e_tests.fixtures.image',
@@ -66,8 +66,11 @@ def test_create_image_no_url(admin_session, harvester_api_endpoints):
 def test_create_image_with_reuse_display_name(request, admin_session,
                                               harvester_api_endpoints):
     name = utils.random_name()
-    url = ('http://download.opensuse.org/repositories/Cloud:/Images:/'
-           'Leap_15.2/images/openSUSE-Leap-15.2.x86_64-NoCloud.qcow2')
+    base_url = request.config.getoption(
+        '--image-cache-url',
+        ('http://download.opensuse.org/repositories/Cloud:/Images:/'
+         'Leap_15.2/images'))
+    url = os.path.join(base_url, 'openSUSE-Leap-15.2.x86_64-NoCloud.qcow2')
     # create the image
     image_json = utils.create_image(request, admin_session,
                                     harvester_api_endpoints, url,

--- a/harvester_e2e_tests/conftest.py
+++ b/harvester_e2e_tests/conftest.py
@@ -99,6 +99,12 @@ def pytest_addoption(parser):
         default=config_data['terraform-scripts-location'],
         help=('External scripts to create resources using terraform')
     )
+    parser.addoption(
+        '--image-cache-url',
+        action='store',
+        default=config_data['image-cache-url'],
+        help=('URL for the local images cache')
+    )
 
     # TODO(gyee): may need to add SSL options later
 

--- a/harvester_e2e_tests/fixtures/image.py
+++ b/harvester_e2e_tests/fixtures/image.py
@@ -16,6 +16,7 @@
 # you may find current contact information at www.suse.com
 
 from harvester_e2e_tests import utils
+import os
 import pytest
 
 
@@ -29,8 +30,11 @@ pytest_plugins = [
 @pytest.fixture(scope='class')
 def ubuntu_image(request, harvester_api_version, admin_session,
                  harvester_api_endpoints):
-    url = ('http://cloud-images.ubuntu.com/releases/focal/release/'
-           'ubuntu-20.04-server-cloudimg-amd64-disk-kvm.img')
+    base_url = request.config.getoption(
+        '--image-cache-url',
+        'http://cloud-images.ubuntu.com/releases/focal/release/')
+    url = os.path.join(base_url,
+                       'ubuntu-20.04-server-cloudimg-amd64-disk-kvm.img')
     image_json = utils.create_image(
         request, admin_session, harvester_api_endpoints, url,
         description='Ubuntu 20.04 Server')
@@ -59,8 +63,11 @@ def windows_image(request, harvester_api_version, admin_session,
 @pytest.fixture(scope='class')
 def k3os_image(request, harvester_api_version, admin_session,
                harvester_api_endpoints):
-    url = ('https://github.com/rancher/k3os/releases/download/v0.20.4-k3s1r0/'
-           'k3os-amd64.iso')
+    base_url = request.config.getoption(
+        '--image-cache-url',
+        'https://github.com/rancher/k3os/releases/download/v0.20.4-k3s1r0')
+    url = os.path.join(base_url,
+                       'k3os-amd64.iso')
     image_json = utils.create_image(
         request, admin_session, harvester_api_endpoints, url,
         description='K3OS')
@@ -73,8 +80,10 @@ def k3os_image(request, harvester_api_version, admin_session,
 @pytest.fixture(scope='class')
 def opensuse_image(request, harvester_api_version, admin_session,
                    harvester_api_endpoints):
-    url = ('https://download.opensuse.org/tumbleweed/iso/'
-           'openSUSE-Tumbleweed-NET-x86_64-Current.iso')
+    base_url = request.config.getoption(
+        '--image-cache-url',
+        'https://download.opensuse.org/tumbleweed/iso')
+    url = os.path.join(base_url, 'openSUSE-Tumbleweed-NET-x86_64-Current.iso')
     image_json = utils.create_image(
         request, admin_session, harvester_api_endpoints, url,
         description='openSUSE Tumbleweed')
@@ -86,12 +95,20 @@ def opensuse_image(request, harvester_api_version, admin_session,
 
 @pytest.fixture(scope='class')
 def image(request, admin_session, harvester_api_endpoints):
-    url = ('http://download.opensuse.org/repositories/Cloud:/Images:/'
-           'Leap_15.2/images/openSUSE-Leap-15.2.x86_64-NoCloud.qcow2')
+    cache_url = request.config.getoption('--image-cache-url')
 
     # when use parameterized fixture, use the URL from the parameter instead
     if getattr(request, 'param', None):
         url = request.param
+        if cache_url:
+            url = os.path.join(cache_url,
+                               url[url.rfind('/') + 1:])
+    else:
+        base_url = ('http://download.opensuse.org/repositories/Cloud:/Images:/'
+                    'Leap_15.2/images')
+        if cache_url:
+            base_url = cache_url
+        url = os.path.join(base_url, 'openSUSE-Leap-15.2.x86_64-NoCloud.qcow2')
 
     image_json = utils.create_image(request, admin_session,
                                     harvester_api_endpoints, url)
@@ -103,8 +120,11 @@ def image(request, admin_session, harvester_api_endpoints):
 
 @pytest.fixture(scope='class')
 def image_using_terraform(request, admin_session, harvester_api_endpoints):
-    url = ('http://download.opensuse.org/repositories/Cloud:/Images:/'
-           'Leap_15.2/images/openSUSE-Leap-15.2.x86_64-NoCloud.qcow2')
+    base_url = request.config.getoption(
+        '--image-cache-url',
+        ('http://download.opensuse.org/repositories/Cloud:/Images:/'
+         'Leap_15.2/images'))
+    url = os.path.join(base_url, 'openSUSE-Leap-15.2.x86_64-NoCloud.qcow2')
 
     # when use parameterized fixture, use the URL from the parameter instead
     if getattr(request, 'param', None):


### PR DESCRIPTION
Some image download locations (i.e. download.opensuse.org) can be
slow at times. To speed up the tests, one can cache the images in a local
server. This change enables alternative image location by introducing the
'--image-cache-url' parameter. For example, to run the tests with a local
image cache server:

tox -e py38 -- harvester_e2e_tests/apis/test_images.py --endpoint https://192.168.0.131:30443 --image-cache-url http://10.84.144.252/harvester_vm_images_for_tests