### PR TITLE
backout changes to conditionally install terraform provider

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ setenv =
 deps = pytest
        -r{toxinidir}/test-requirements.txt
 commands =
-  bash -c 'if [[ "{posargs}" == *"-m terraform"* ]] ; then {toxinidir}/terraform_test_artifacts/terraform_provider_install.sh ; fi'
+  {toxinidir}/terraform_test_artifacts/terraform_provider_install.sh
   find . -type f -name "*.pyc" -delete
   pytest {posargs}
 whitelist_externals =


### PR DESCRIPTION
Lets always install the latest Harvester terraform providers for now.
Tox {posargs} is just a string replacement, which doesn't play well in
bash command if it contains a quote.