### PR TITLE
Fix various tests breakages

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -11,19 +11,16 @@ password: 'admin'
 do-not-cleanup: False
 
 # harvester_cluster_nodes
-harvester_cluster_nodes: 1
+harvester_cluster_nodes: 3
 
 # VLAN ID, will invoke the tests depended on external networking if not set to -1.
-vlan-id: -1
+vlan-id: 1
 
-# Physical NIC for VLAN. Default is "eth0"
-vlan-nic: 'eth0'
+# Physical NIC for VLAN. Default is "harvester-mgmt"
+vlan-nic: 'harvester-mgmt'
 
 #Wait time for polling operations
 wait-timeout: 600
-
-#Rancher API endpoint
-rancher-endpoint: ~
 
 node-scripts-location: 'scripts/vagrant'
 

--- a/harvester_e2e_tests/apis/test_authentication.py
+++ b/harvester_e2e_tests/apis/test_authentication.py
@@ -15,10 +15,8 @@
 # To contact SUSE about this file by physical or electronic mail,
 # you may find current contact information at www.suse.com
 
-import re
 import requests
-from urllib.parse import (urlparse, urlunparse, urljoin)
-
+from urllib.parse import urljoin
 
 pytest_plugins = [
    'harvester_e2e_tests.fixtures.api_endpoints',
@@ -31,15 +29,7 @@ pytest_plugins = [
 def test_rancher_authentication(admin_session, request):
     username = request.config.getoption('--username')
     password = request.config.getoption('--password')
-    # if Rancher URL is not specified, we will use the same host with
-    # port 30444 which is default Rancher API port
-    rancher_endpoint = request.config.getoption('--rancher-endpoint')
-    if not rancher_endpoint:
-        harvester_endpoint = request.config.getoption('--endpoint')
-        o = urlparse(harvester_endpoint)
-        netloc = re.sub(':.*$', ':30444', o.netloc)
-        rancher_endpoint = urlunparse(
-            (o.scheme, netloc, o.path, o.params, o.query, o.fragment))
+    rancher_endpoint = request.config.getoption('--endpoint')
     rancher_auth_url = urljoin(
             rancher_endpoint, '/v3-public/localProviders/local')
     login_data = {'username': username,

--- a/harvester_e2e_tests/apis/test_images.py
+++ b/harvester_e2e_tests/apis/test_images.py
@@ -54,13 +54,9 @@ def test_create_image_no_url(admin_session, harvester_api_endpoints):
     )
     resp = admin_session.post(harvester_api_endpoints.create_image,
                               json=request_json)
-    assert resp.status_code == 201, 'Failed to create image: %s' % (
-        resp.content)
-    image_data = resp.json()
-    resp = admin_session.delete(harvester_api_endpoints.delete_image % (
-        image_data['metadata']['name']))
-    assert resp.status_code == 200, 'Unable to delete image: %s' % (
-        resp.content)
+    assert resp.status_code == 422, (
+        'Expecting HTTP 422 for attempting to create an image with an empty '
+        'URL %s:%s ' % (resp.status_code, resp.content))
 
 
 def test_create_image_with_reuse_display_name(request, admin_session,

--- a/harvester_e2e_tests/apis/test_users.py
+++ b/harvester_e2e_tests/apis/test_users.py
@@ -17,6 +17,7 @@
 
 from harvester_e2e_tests import utils
 import bcrypt
+import pytest
 
 
 pytest_plugins = [
@@ -26,12 +27,14 @@ pytest_plugins = [
   ]
 
 
+@pytest.mark.skip(reason='User management feature is being deferred.')
 def test_create_users(user):
     # user creation is tested implicitly by successfully creating
     # the user fixture
     pass
 
 
+@pytest.mark.skip(reason='User management feature is being deferred.')
 def test_get_user(admin_session, user):
     resp = admin_session.get(user['links']['view'])
     assert resp.status_code == 200, 'Failed to get user: %s' % (resp.content)
@@ -41,6 +44,7 @@ def test_get_user(admin_session, user):
     assert ret_user_data['username'] == user['username']
 
 
+@pytest.mark.skip(reason='User management feature is being deferred.')
 def test_update_user_password(request, admin_session, user):
     request_json = utils.get_json_object_from_template(
         'basic_user', password='UpdatedTestF00Bar')

--- a/harvester_e2e_tests/conftest.py
+++ b/harvester_e2e_tests/conftest.py
@@ -75,12 +75,6 @@ def pytest_addoption(parser):
         help='Wait time for polling operations'
     )
     parser.addoption(
-        '--rancher-endpoint',
-        action='store',
-        default=config_data['rancher-endpoint'],
-        help='Rancher API endpoint'
-    )
-    parser.addoption(
         '--node-scripts-location',
         action='store',
         default=config_data['node-scripts-location'],

--- a/harvester_e2e_tests/utils.py
+++ b/harvester_e2e_tests/utils.py
@@ -681,10 +681,8 @@ def poweroff_host_maintenance_mode(request, admin_session,
     host_poweroff = lookup_host_not_harvester_endpoint(request, admin_session,
                                                        harvester_api_endpoints)
     # Enable Maintenance Mode
-    resp = admin_session.post(
-        host_poweroff['actions']['enableMaintenanceMode'])
-    assert resp.status_code == 204, (
-        'Failed to update node: %s' % (resp.content))
+    enable_maintenance_mode(request, admin_session,
+                            harvester_api_endpoints, host_poweroff)
     node_name = host_poweroff['id']
     poll_for_resource_ready(request, admin_session,
                             harvester_api_endpoints.get_node % (node_name))


### PR DESCRIPTION
1. "rancher-endpoint" config is no longer needed as Rancher auth test cases
   are no longer applicable since v0.3.0.
2. Fix the expectation for creating an image with no URL.
3. Make the default values in config.yml closely match what's in the
   vagrant environment.
4. Skip user tests are user management feature is deferred.
5. Fix host enable/disable maintenance mode.