### PR TITLE
Run host deletion test last

### DIFF
--- a/harvester_e2e_tests/apis/test_hosts.py
+++ b/harvester_e2e_tests/apis/test_hosts.py
@@ -127,6 +127,7 @@ def test_update_using_yaml(request, admin_session, harvester_api_endpoints):
                 harvester_api_endpoints.get_node % (updated_host_data['id']))
 
 
+@pytest.mark.last
 @pytest.mark.delete_host
 def test_delete_host(request, admin_session, harvester_api_endpoints):
     resp = admin_session.get(harvester_api_endpoints.list_nodes)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-ordering
 pytest-html
 pytest-json-report
 jinja2


### PR DESCRIPTION
As deleting the host may reduce the cluster capability and making other tests
unpredictable.