### PR TITLE
Delete the last host

### DIFF
--- a/harvester_e2e_tests/apis/test_hosts.py
+++ b/harvester_e2e_tests/apis/test_hosts.py
@@ -133,7 +133,11 @@ def test_delete_host(request, admin_session, harvester_api_endpoints):
     resp = admin_session.get(harvester_api_endpoints.list_nodes)
     assert resp.status_code == 200, 'Failed to list nodes: %s' % (resp.content)
     host_data = resp.json()
-    host_data_to_delete = host_data['data'][0]
+    # FIXME(gyee): for now only delete the last node in the cluster due to
+    # https://github.com/harvester/harvester/issues/1398
+    # This is assuming that the orders are correct. We'll need to test
+    # deleting the first node after the issue's been resolved.
+    host_data_to_delete = host_data['data'][-1]
     # delete the host
     utils.delete_host(request, admin_session, harvester_api_endpoints,
                       host_data_to_delete)

--- a/harvester_e2e_tests/fixtures/session.py
+++ b/harvester_e2e_tests/fixtures/session.py
@@ -28,9 +28,10 @@ def admin_session(request, harvester_api_endpoints):
     login_data = {'username': username, 'password': password}
     params = {'action': 'login'}
     s = requests.Session()
+    s.verify = False
     # TODO(gyee): do we need to support other auth methods?
     # NOTE(gyee): ignore SSL certificate validation for now
-    resp = s.post(harvester_api_endpoints.local_auth, verify=False,
+    resp = s.post(harvester_api_endpoints.local_auth,
                   params=params, json=login_data)
     assert resp.status_code == 201, 'Failed to authenticate admin user: %s' % (
         resp.content)


### PR DESCRIPTION
For delete host test, delete the last one instead of the first one
to avoid destroying the VIP.

Also, turned off SSL certificate verification for all APIs as we are using
self-signed certificate out-of-the-box.