### PR TITLE
Use a naming convention when creating a VLAN network

### DIFF
--- a/harvester_e2e_tests/utils.py
+++ b/harvester_e2e_tests/utils.py
@@ -979,8 +979,9 @@ def create_keypair_terraform(request, admin_session, harvester_api_endpoints,
 def create_network_terraform(request, admin_session, harvester_api_endpoints,
                              template_name, vlan_id):
 
-    #    name = 'vlan' + str(vlan_id)
-    name = "t-" + random_name()
+    # NOTE(gyee): will name the network with the following convention as
+    # VLAN ID must be unique. vlan_network_<VLAN ID>
+    name = f'vlan-network-{vlan_id}'
     create_tf_from_template(
         request,
         template_name,


### PR DESCRIPTION
As all network must have a unique VLAN ID, we want to name it such that
we won't run into a situation where tests are creating different networks
with the same VLAN ID and failing.