### PR TITLE
Marking backup and restore s3 and NFS separately

### DIFF
--- a/harvester_e2e_tests/apis/test_backup_target.py
+++ b/harvester_e2e_tests/apis/test_backup_target.py
@@ -14,18 +14,97 @@
 #
 # To contact SUSE about this file by physical or electronic mail,
 # you may find current contact information at www.suse.com
+from harvester_e2e_tests import utils
+import time
+import pytest
+
+
 pytest_plugins = [
     'harvester_e2e_tests.fixtures.backuptarget'
 ]
 
 
+@pytest.mark.backups3
 def test_setup_backup_target_s3(backuptarget_s3):
     # NOTE: if the backuptarget is successfully create that means the
     # test is good
     pass
 
 
+@pytest.mark.backupnfs
 def test_setup_backup_target_nfs(backuptarget_nfs):
     # NOTE: if the backuptarget is successfully create that means the
     # test is good
     pass
+
+
+@pytest.mark.backupnfs
+def test_invalid_backup_target_nfs(request, admin_session,
+                                   harvester_api_endpoints):
+    resp = admin_session.get(harvester_api_endpoints.get_backup_target)
+    assert resp.status_code == 200, (
+        'Failed to get Backup Target Settings: %s' % (resp.content))
+    backup_target_data = resp.json()
+    request_json = utils.get_json_object_from_template(
+        'backup_target',
+        storetype='nfs',
+        endpoint='nfs://',
+        accesskeyid='',
+        secretaccesskey='',
+        bucketname='',
+        region=''
+    )
+    resp = utils.poll_for_update_resource(
+        request, admin_session,
+        backup_target_data['links']['update'],
+        request_json,
+        harvester_api_endpoints.get_backup_target)
+    updated_settings_data = resp.json()
+    assert updated_settings_data['value'] == request_json['value'], (
+        'Failed to update Backup Target with NFS')
+    time.sleep(30)
+    resp = admin_session.get(harvester_api_endpoints.get_backup_target)
+    assert resp.status_code == 200, (
+        'Failed to get Backup Target Settings: %s' % (resp.content))
+    backup_target_data = resp.json()
+    assert backup_target_data['metadata']['state']['error'], (
+        'Backup Target Failed with error: %s' % (
+            backup_target_data['metadata']['state']['message']))
+    assert 'NFS path must follow: nfs://server:/path/ format' in (
+        backup_target_data['metadata']['state']['message'])
+
+
+@pytest.mark.backups3
+def test_invalid_backup_target_s3(request, admin_session,
+                                  harvester_api_endpoints):
+    resp = admin_session.get(harvester_api_endpoints.get_backup_target)
+    assert resp.status_code == 200, (
+        'Failed to get Backup Target Settings: %s' % (resp.content))
+    backup_target_data = resp.json()
+    request_json = utils.get_json_object_from_template(
+        'backup_target',
+        storetype='s3',
+        endpoint='',
+        accesskeyid='bogus',
+        secretaccesskey='bogus',
+        bucketname='bogus',
+        region='us-east-2'
+    )
+    resp = utils.poll_for_update_resource(
+        request, admin_session,
+        backup_target_data['links']['update'],
+        request_json,
+        harvester_api_endpoints.get_backup_target)
+    updated_settings_data = resp.json()
+    assert updated_settings_data['value'] == request_json['value'], (
+        'Failed to update Backup Target with S3')
+    time.sleep(30)
+    resp = admin_session.get(harvester_api_endpoints.get_backup_target)
+    assert resp.status_code == 200, (
+        'Failed to get Backup Target Settings: %s' % (resp.content))
+    backup_target_data = resp.json()
+    assert backup_target_data['metadata']['state']['error'], (
+        'Backup Target Failed with error: %s' % (
+            backup_target_data['metadata']['state']['message']))
+    assert 'operation error S3: ListBucket' in (
+        backup_target_data['metadata']['state']['message'])

--- a/harvester_e2e_tests/conftest.py
+++ b/harvester_e2e_tests/conftest.py
@@ -172,8 +172,12 @@ def pytest_configure(config):
                     'and terraform provider scripts provided')
     )
     config.addinivalue_line(
-        "markers", ('backup: mark test to run only to execute the backup and '
-                    'Restore tests')
+        "markers", ('backupnfs: mark test to run only the backup and restore'
+                    'tests for NFS backup target')
+    )
+    config.addinivalue_line(
+        "markers", ('backups3: mark test to run only the backup and restore'
+                    'tests for S3 backup target')
     )
 
 
@@ -198,4 +202,18 @@ def pytest_collection_modifyitems(config, items):
             'AWS credentials or NFS endpoint are not available'))
         for item in items:
             if 'backup' in item.keywords:
+                item.add_marker(skip_backup)
+
+    if config.getoption('--accessKeyId') == '':
+        skip_backup = pytest.mark.skip(reason=(
+            'AWS credentials are not available'))
+        for item in items:
+            if 'backups3' in item.keywords:
+                item.add_marker(skip_backup)
+
+    if config.getoption('--nfs-endpoint') == '':
+        skip_backup = pytest.mark.skip(reason=(
+            'NFS endpoint is not available'))
+        for item in items:
+            if 'backupnfs' in item.keywords:
                 item.add_marker(skip_backup)

--- a/harvester_e2e_tests/fixtures/backuptarget.py
+++ b/harvester_e2e_tests/fixtures/backuptarget.py
@@ -17,7 +17,7 @@
 
 from harvester_e2e_tests import utils
 import pytest
-
+import time
 
 pytest_plugins = [
     'harvester_e2e_tests.fixtures.api_endpoints',
@@ -53,6 +53,14 @@ def backuptarget_s3(request, kubevirt_api_version, admin_session,
         request_json,
         harvester_api_endpoints.get_backup_target)
     updated_settings_data = resp.json()
+    time.sleep(30)
+    resp = admin_session.get(harvester_api_endpoints.get_backup_target)
+    assert resp.status_code == 200, (
+        'Failed to get Backup Target Settings: %s' % (resp.content))
+    backup_target_data = resp.json()
+    assert not backup_target_data['metadata']['state']['error'], (
+        'Backup Target Failed with error: %s' % (
+            backup_target_data['metadata']['state']['message']))
     assert updated_settings_data['value'] == request_json['value'], (
         'Failed to update Backup Target with S3')
     yield updated_settings_data
@@ -82,6 +90,14 @@ def backuptarget_nfs(request, kubevirt_api_version, admin_session,
         request_json,
         harvester_api_endpoints.get_backup_target)
     updated_settings_data = resp.json()
+    time.sleep(30)
+    resp = admin_session.get(harvester_api_endpoints.get_backup_target)
+    assert resp.status_code == 200, (
+        'Failed to get Backup Target Settings: %s' % (resp.content))
+    backup_target_data = resp.json()
+    assert not backup_target_data['metadata']['state']['error'], (
+        'Backup Target Failed with error: %s' % (
+            backup_target_data['metadata']['state']['message']))
     assert updated_settings_data['value'] == request_json['value'], (
         'Failed to update Backup Target with NFS')
     yield updated_settings_data

--- a/harvester_e2e_tests/scenarios/test_vm_networking.py
+++ b/harvester_e2e_tests/scenarios/test_vm_networking.py
@@ -804,7 +804,7 @@ def test_create_vm_using_terraform(request, admin_session,
 
 
 @pytest.mark.skip("https://github.com/harvester/harvester/issues/1339")
-@pytest.mark.backup
+@pytest.mark.backups3
 def test_backup_restore_new_vm(request, admin_session,
                                harvester_api_endpoints,
                                keypair, vm_with_one_vlan,
@@ -821,7 +821,7 @@ def test_backup_restore_new_vm(request, admin_session,
 
 
 @pytest.mark.skip("https://github.com/harvester/harvester/issues/1339")
-@pytest.mark.backup
+@pytest.mark.backups3
 def test_backup_restore_existing_vm(request, admin_session,
                                     harvester_api_endpoints,
                                     keypair, vm_with_one_vlan,
@@ -834,7 +834,7 @@ def test_backup_restore_existing_vm(request, admin_session,
 
 
 @pytest.mark.skip("https://github.com/harvester/harvester/issues/1339")
-@pytest.mark.backup
+@pytest.mark.backups3
 def test_chained_del_middle_backup(request, admin_session,
                                    harvester_api_endpoints,
                                    keypair, vm_with_one_vlan,
@@ -849,7 +849,7 @@ def test_chained_del_middle_backup(request, admin_session,
 
 
 @pytest.mark.skip("https://github.com/harvester/harvester/issues/1339")
-@pytest.mark.backup
+@pytest.mark.backups3
 def test_chained_del_first_backup(request, admin_session,
                                   harvester_api_endpoints,
                                   keypair, vm_with_one_vlan,
@@ -864,7 +864,7 @@ def test_chained_del_first_backup(request, admin_session,
 
 
 @pytest.mark.skip("https://github.com/harvester/harvester/issues/1339")
-@pytest.mark.backup
+@pytest.mark.backups3
 def test_chained_del_last_backup(request, admin_session,
                                  harvester_api_endpoints,
                                  keypair, vm_with_one_vlan,
@@ -879,7 +879,7 @@ def test_chained_del_last_backup(request, admin_session,
 
 
 @pytest.mark.skip("https://github.com/harvester/harvester/issues/1339")
-@pytest.mark.backup
+@pytest.mark.backups3
 def test_restore_chained_backups(request, admin_session,
                                  harvester_api_endpoints,
                                  keypair, vm_with_one_vlan,
@@ -891,7 +891,7 @@ def test_restore_chained_backups(request, admin_session,
                                    )
 
 
-@pytest.mark.backup
+@pytest.mark.backupnfs
 def test_backup_restore_new_vm_nfs(request, admin_session,
                                    harvester_api_endpoints,
                                    keypair, vm_with_one_vlan,
@@ -907,7 +907,7 @@ def test_backup_restore_new_vm_nfs(request, admin_session,
                       )
 
 
-@pytest.mark.backup
+@pytest.mark.backupnfs
 def test_backup_restore_existing_vm_nfs(request, admin_session,
                                         harvester_api_endpoints,
                                         keypair, vm_with_one_vlan,
@@ -919,7 +919,7 @@ def test_backup_restore_existing_vm_nfs(request, admin_session,
                       )
 
 
-@pytest.mark.backup
+@pytest.mark.backupnfs
 def test_chained_del_middle_backup_nfs(request, admin_session,
                                        harvester_api_endpoints,
                                        keypair, vm_with_one_vlan,
@@ -933,7 +933,7 @@ def test_chained_del_middle_backup_nfs(request, admin_session,
                                    )
 
 
-@pytest.mark.backup
+@pytest.mark.backupnfs
 def test_chained_del_first_backup_nfs(request, admin_session,
                                       harvester_api_endpoints,
                                       keypair, vm_with_one_vlan,
@@ -947,7 +947,7 @@ def test_chained_del_first_backup_nfs(request, admin_session,
                                    )
 
 
-@pytest.mark.backup
+@pytest.mark.backupnfs
 def test_chained_del_last_backup_nfs(request, admin_session,
                                      harvester_api_endpoints,
                                      keypair, vm_with_one_vlan,
@@ -961,7 +961,7 @@ def test_chained_del_last_backup_nfs(request, admin_session,
                                    )
 
 
-@pytest.mark.backup
+@pytest.mark.backupnfs
 def test_restore_chained_backups_nfs(request, admin_session,
                                      harvester_api_endpoints,
                                      keypair, vm_with_one_vlan,

--- a/harvester_e2e_tests/templates/api_endpoints.json.j2
+++ b/harvester_e2e_tests/templates/api_endpoints.json.j2
@@ -35,6 +35,7 @@
     "migrate_vm": "{{ harvester_endpoint }}/apis/subresources.kubevirt.io/v1/namespaces/{{ api_namespace | default('default') }}/virtualmachines/%s/migrate",
     "create_vm_backup": "{{ harvester_endpoint }}/apis/{{ harvester_api_version }}/namespaces/{{ api_namespace | default('default') }}/virtualmachinebackups",
     "get_vm_backup": "{{ harvester_endpoint }}/apis/{{ harvester_api_version }}/namespaces/{{ api_namespace | default('default') }}/virtualmachinebackups/%s",
+    "update_vm_backup": "{{ harvester_endpoint }}/apis/{{ harvester_api_version }}/namespaces/{{ api_namespace | default('default') }}/virtualmachinebackups/%s",
     "create_vm_restore": "{{ harvester_endpoint }}/apis/{{ harvester_api_version }}/namespaces/{{ api_namespace | default('default') }}/virtualmachinerestores",
     "get_vm_restore": "{{ harvester_endpoint }}/apis/{{ harvester_api_version }}/namespaces/{{ api_namespace | default('default') }}/virtualmachinerestores/%s",
     "delete_vm_backup": "{{ harvester_endpoint }}/apis/{{ harvester_api_version }}/namespaces/{{ api_namespace | default('default') }}/virtualmachinebackups/%s",

--- a/harvester_e2e_tests/utils.py
+++ b/harvester_e2e_tests/utils.py
@@ -1193,8 +1193,6 @@ def delete_vm_backup(request, admin_session,
     else:
         total_objects_after_delete = get_total_objects_nfs_share(request)
 
-    print(total_objects_before_delete)
-    print(total_objects_after_delete)
     assert total_objects_before_delete > total_objects_after_delete, (
             'Failed to delete any objects from %s target. '
             'Before delete object count: %s; after delete object count: %s' % (


### PR DESCRIPTION
Marked backup and restore S3 and NFS testcases separately
Added P2 testcases
- Backup Single VM that has been live migrated before
- Restore Backup for VM that was live migrated
- Edit Backup YAML
- Create Backup Target Negative ( NFS & S3)