### PR TITLE
Add pytest-drop-dup-tests plugin

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-drop-dup-tests
 pytest-ordering
 pytest-html
 pytest-json-report


### PR DESCRIPTION
    In our internal automated pipelines, we
    use run_filters to run subset of tests.
    In a scenario where multiple run filters
    are chosen and if a test is part of
    multiple run_filters, we want
    to drop the duplicates via this plugin.