### PR TITLE
fix terraform tests

### DIFF
--- a/terraform_test_artifacts/terraform.sh
+++ b/terraform_test_artifacts/terraform.sh
@@ -16,29 +16,13 @@ TERDIR="$PWD"/terraform_test_artifacts
 mv "$TERDIR"/resource* "$TMPDIR"
 mv -f "$TERDIR"/provider.tf "$TMPDIR"
 
-#Check whether we need to Import clusternetwork vlan
-if [ $# -ne 1 ]; then
-   IMPYESNO="no"
-   RESEXIST=1
-else 
-   RESEXIST=$(grep 'harvester_clusternetwork' "${TERDIR}/terraformharvester/terraform.tfstate" | wc -l )
-   IMPYESNO="$1"
+pushd "$TMPDIR"
+
+"$TERDIR"/bin/terraform init
+if [ $1 == "import" ]; then
+   "$TERDIR"/bin/terraform import harvester_clusternetwork.vlan harvester-system/vlan
 fi
 
-pushd "$TMPDIR" 
-if [ "$RESEXIST" -eq 0 ]; then
-   IMPYESNO="$1"
-else
-   IMPYESNO="no"
-fi
-
-#terraform import
-if [ "$IMPYESNO" == "import" ]; then
-#terraform import
-   TF_CLI_CONFIG_FILE="$TERDIR"/dev.tfrc "$TERDIR"/bin/terraform import harvester_clusternetwork.vlan harvester-system/vlan
-fi
-
-terraform init
-TF_CLI_CONFIG_FILE="$TERDIR"/dev.tfrc "$TERDIR"/bin/terraform plan -out tfplan -input=false 
-TF_CLI_CONFIG_FILE="$TERDIR"/dev.tfrc "$TERDIR"/bin/terraform apply -input=false tfplan 
+"$TERDIR"/bin/terraform plan -out tfplan -input=false
+"$TERDIR"/bin/terraform apply -input=false tfplan
 popd

--- a/terraform_test_artifacts/terraform_destroy.sh
+++ b/terraform_test_artifacts/terraform_destroy.sh
@@ -4,7 +4,7 @@ set -e
 
 #check to clean only dir_only or all (dir + resource)
 if [ $# -ne 1 ]; then
-    DESTORYTYPE="all"
+    DESTROYTYPE="all"
 else
     DESTROYTYPE="$1"
 fi
@@ -12,7 +12,7 @@ fi
 TMPDIR="$PWD"/terraform_test_artifacts/terraformharvester
 KUBEDIR="$PWD"/terraform_test_artifacts/.kube
 TERDIR="$PWD"/terraform_test_artifacts
-# Check if temp dir exists 
+# Check if temp dir exists
 if [ ! -d $TMPDIR ]; then
     >&2 echo "temp directory doesn't exist"
     exit 1
@@ -22,12 +22,12 @@ fi
 trap "exit 1"           HUP INT PIPE QUIT TERM
 trap 'rm -rf "$TMPDIR" "$KUBEDIR" ' EXIT
 
-pushd "$TMPDIR" 
+pushd "$TMPDIR"
 
 #Remove resource for destroytype all
 if [[ "$DESTROYTYPE" == "all" ]] ; then
-  TF_CLI_CONFIG_FILE="$TERDIR"/dev.tfrc "$TERDIR"/bin/terraform destroy -auto-approve
+  "$TERDIR"/bin/terraform destroy -auto-approve
 else
-  TF_CLI_CONFIG_FILE="$TERDIR"/dev.tfrc "$TERDIR"/bin/terraform destroy -auto-approve --target $DESTROYTYPE
+  "$TERDIR"/bin/terraform destroy -auto-approve --target $DESTROYTYPE
 fi
 popd

--- a/terraform_test_artifacts/terraform_provider_cleanup.sh
+++ b/terraform_test_artifacts/terraform_provider_cleanup.sh
@@ -2,5 +2,4 @@
   
 TERDIR="$PWD/terraform_test_artifacts"
 
-rm -rf ${TERDIR}/dev.tfrc
 rm -rf ${TERDIR}/.terraform.d


### PR DESCRIPTION
Tests that would call import would fail with
no terraform.tfstate file.
So this change moves the terraform init to
be performed earlier so it's applicable for
both the import and apply commands.

Also simplify the script to handle
the "import" argument

Also fixed the variable used for
the destroy all resources.

Also cleanup dev.tfrc which is no longer needed