### PR TITLE
Fix terraform tests for vlan network

### DIFF
--- a/harvester_e2e_tests/fixtures/volume.py
+++ b/harvester_e2e_tests/fixtures/volume.py
@@ -107,7 +107,9 @@ def volume_using_terraform(request, kubevirt_api_version, admin_session,
                                              10)
     yield vol_data
     if not request.config.getoption('--do-not-cleanup'):
-        utils.destroy_resource(request, admin_session, 'all')
+        utils.destroy_resource(
+            request,
+            admin_session, 'harvester_volume.' + vol_data['metadata']['name'])
 
 
 @pytest.fixture(scope='class')

--- a/harvester_e2e_tests/templates/resource_network.tf.j2
+++ b/harvester_e2e_tests/templates/resource_network.tf.j2
@@ -1,6 +1,7 @@
 resource "harvester_network" "{{ name }}" {
   name      = "{{ name }}"
   namespace = "{{ net_namespace | default('default') }}"
+  description = "Network created by terraform tests"
 
   vlan_id = {{ vlan_id }} 
 

--- a/harvester_e2e_tests/templates/resource_vm.tf.j2
+++ b/harvester_e2e_tests/templates/resource_vm.tf.j2
@@ -1,5 +1,5 @@
 resource "harvester_virtualmachine" "{{ name }}" {
-  depends_on = [harvester_image.{{ image_name }}, harvester_volume.{{ vol_name }}, harvester_network.{{ net_name }}]
+  depends_on = [harvester_volume.{{ vol_name }}, harvester_image.{{ image_name }}, harvester_network.{{ net_name }}]
 
   name        = "{{ name }}"
   description = "test raw image"

--- a/harvester_e2e_tests/utils.py
+++ b/harvester_e2e_tests/utils.py
@@ -980,7 +980,7 @@ def create_keypair_terraform(request, admin_session, harvester_api_endpoints,
 
 
 def create_network_terraform(request, admin_session, harvester_api_endpoints,
-                             template_name, vlan_id):
+                             template_name, vlan_id, import_flag):
 
     # NOTE(gyee): will name the network with the following convention as
     # VLAN ID must be unique. vlan_network_<VLAN ID>
@@ -998,8 +998,14 @@ def create_network_terraform(request, admin_session, harvester_api_endpoints,
         token=(admin_session.headers['authorization']).split()[1]
     )
 
-    terraform_script = _get_node_script_path(
-        request, 'terraform.sh', 'terraform')
+    if import_flag:
+        terraform_script = _get_node_script_path(
+            request, 'terraform.sh', 'terraform') + \
+                           ' ' + 'network' + ' ' + name
+    else:
+        terraform_script = _get_node_script_path(
+            request, 'terraform.sh', 'terraform')
+
     result = subprocess.run([terraform_script], shell=True,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     assert result.returncode == 0, (
@@ -1035,7 +1041,7 @@ def create_clusternetworks_terraform(request, admin_session,
     )
 
     terraform_script = _get_node_script_path(
-        request, 'terraform.sh', 'terraform') + ' ' + 'import'
+        request, 'terraform.sh', 'terraform') + ' ' + 'cluster'
     result = subprocess.run([terraform_script], shell=True,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     assert result.returncode == 0, (

--- a/terraform_test_artifacts/terraform.sh
+++ b/terraform_test_artifacts/terraform.sh
@@ -3,6 +3,7 @@
 set -e
 
 # Make a temporary folder
+#DATE_WITH_TIME=`date "+%Y%m%d-%H%M%S"`
 TMPDIR="$PWD"/terraform_test_artifacts/terraformharvester
 mkdir -p "$TMPDIR"
 
@@ -19,8 +20,12 @@ mv -f "$TERDIR"/provider.tf "$TMPDIR"
 pushd "$TMPDIR"
 
 "$TERDIR"/bin/terraform init
-if [ $1 == "import" ]; then
+if [ $1 == "cluster" ]; then
    "$TERDIR"/bin/terraform import harvester_clusternetwork.vlan harvester-system/vlan
+fi
+
+if [ $1 == "network" ]; then
+   "$TERDIR"/bin/terraform import harvester_network.$2 default/$2
 fi
 
 "$TERDIR"/bin/terraform plan -out tfplan -input=false


### PR DESCRIPTION
These tests handle a situation where a nettwork with the vlan ID is already allocated and we need handle this scenario in the test by doing a lookup first and if found, import the resource and not try to create it as creation fails with VLAN ID allocated already message.