### PR TITLE
use --rancher-cluster-wait-timeout instead of --wait-timeout

### DIFF
--- a/harvester_e2e_tests/scenarios/test_rancher_integration.py
+++ b/harvester_e2e_tests/scenarios/test_rancher_integration.py
@@ -72,7 +72,7 @@ def _delete_cluster(request, rancher_admin_session, rancher_api_endpoints,
     success = polling2.poll(
         _check_cluster_deleted,
         step=5,
-        timeout=request.config.getoption('--wait-timeout'))
+        timeout=request.config.getoption('--rancher-cluster-wait-timeout'))
 
     assert success, 'Timed out while waiting for cluster to be deleted.'
 


### PR DESCRIPTION
For cluster creation and deletion as Rancher RKE cluster usually take
longer to create and remove. This will prevent unnecessary timeouts which
can lead to dangling clusters in Rancher.