### PR TITLE
Remove restart VM workaround dual DHCP NICs

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -32,8 +32,6 @@ image-cache-url: ''
 
 terraform-scripts-location: 'terraform_test_artifacts'
 
-workaround-restartvm: False
-
 # Backup Target S3
 region: ''
 accessKeyId: ''

--- a/harvester_e2e_tests/conftest.py
+++ b/harvester_e2e_tests/conftest.py
@@ -106,13 +106,6 @@ def pytest_addoption(parser):
         help=('URL for the local images cache')
     )
     parser.addoption(
-        '--workaround-restartvm',
-        action='store_true',
-        default=config_data['workaround-restartvm'],
-        help=('when enabled reboot the VM as a workaound for '
-              'https://github.com/harvester/harvester/issues/1059')
-    )
-    parser.addoption(
         '--accessKeyId',
         action='store',
         default=config_data['accessKeyId'],

--- a/harvester_e2e_tests/fixtures/vm.py
+++ b/harvester_e2e_tests/fixtures/vm.py
@@ -198,7 +198,7 @@ def vms_with_same_vlan(request, admin_session, image, keypair,
         vms.append(utils.create_vm(request, admin_session, image,
                                    harvester_api_endpoints,
                                    keypair=keypair,
-                                   template='vm_with_one_vlan',
+                                   template='vm_with_vlan_as_default_network',
                                    network=network,
                                    network_data=network_data,
                                    user_data=user_data_with_guest_agent))

--- a/harvester_e2e_tests/utils.py
+++ b/harvester_e2e_tests/utils.py
@@ -492,7 +492,8 @@ def create_vm(request, admin_session, image, harvester_api_endpoints,
     request_json['spec']['running'] = running
     resp = admin_session.post(harvester_api_endpoints.create_vm,
                               json=request_json)
-    assert resp.status_code == 201, 'Failed to create VM'
+    assert resp.status_code == 201, (
+        'Failed to create VM %s: %s' % (resp.status_code, resp.content))
     vm_resp_json = resp.json()
     if running:
         assert_vm_ready(request, admin_session, harvester_api_endpoints,


### PR DESCRIPTION
Dual DHCP NICs tests are de-prioritized as it is not a normal use case.
The expectation is that the default route will be setup for the first DHCP
NIC only. Subsequent DHCP routes must be manually added to the VM. Therefore,
this patch removes the restart VM workaround, as well as tests that are no
longer relevant.