### PR TITLE
Cypress: Fix ComponentPo bug

### DIFF
--- a/cypress/utils/components/component.po.ts
+++ b/cypress/utils/components/component.po.ts
@@ -12,7 +12,7 @@ export default class ComponentPo {
       const [selector, filter, parent] = args as [string, string, CypressChainable];
 
       this.self = () => (parent || cy).get(selector).filter(filter);
-    } else if (typeof args[0] === 'string' && typeof args[0] !== 'string') {
+    } else if (typeof args[0] === 'string' && typeof args[1] !== 'string') {
       const [selector, parent] = args as [string, CypressChainable];
 
       this.self = () => (parent || cy).get(selector);


### PR DESCRIPTION
It will cause `new LabeledInputPo('.labeled-input')` doesn't work as expect.