### PR TITLE
Fix terraform import clusternetwork

### DIFF
--- a/terraform_test_artifacts/terraform.sh
+++ b/terraform_test_artifacts/terraform.sh
@@ -21,7 +21,7 @@ pushd "$TMPDIR"
 
 "$TERDIR"/bin/terraform init
 if [ $1 == "cluster" ]; then
-   "$TERDIR"/bin/terraform import harvester_clusternetwork.vlan harvester-system/vlan
+   "$TERDIR"/bin/terraform import harvester_clusternetwork.vlan vlan
 fi
 
 if [ $1 == "network" ]; then


### PR DESCRIPTION
After terraform-provider-harvester v0.2.0+, we don't need to add namespace during importing clusternetwork