### PR TITLE
Fix terraform state rm clusternetwork

### DIFF
--- a/terraform_test_artifacts/terraform_destroy.sh
+++ b/terraform_test_artifacts/terraform_destroy.sh
@@ -26,7 +26,12 @@ pushd "$TMPDIR"
 
 #Remove resource for destroytype all
 if [[ "$DESTROYTYPE" == "all" ]] ; then
-  "$TERDIR"/bin/terraform state rm harvester_clusternetwork.vlan
+  # remove clusternetwork states before destroy
+  if [[ $("$TERDIR"/bin/terraform state list | grep -c 'harvester_clusternetwork' || true) != "0" ]]; then
+    "$TERDIR"/bin/terraform state list | grep 'harvester_clusternetwork' | while read -r CLUSTERNETWORK; do
+      "$TERDIR"/bin/terraform state rm "${CLUSTERNETWORK}"
+    done
+  fi
   "$TERDIR"/bin/terraform destroy -auto-approve
 else
   "$TERDIR"/bin/terraform destroy -auto-approve --target $DESTROYTYPE


### PR DESCRIPTION
Signed-off-by: futuretea <Hang.Yu@suse.com>

fix Error:
```
request = <SubRequest 'keypair_using_terraform' for <Function test_create_keypairs_using_terraform>>
admin_session = <requests.sessions.Session object at 0x7f43f21d3e80>
destroy_type = 'all'

    def destroy_resource(request, admin_session, destroy_type=None):
        create_kubeconfig_from_template(
            request,
            'kube_config',
            harvester_endpoint=request.config.getoption('--endpoint'),
            token=(admin_session.headers['authorization']).split()[1]
        )
    
        terraform_path = _get_node_script_path(
            request, script_type='terraform')
        if os.path.isdir(os.path.join(terraform_path, 'terraformharvester')):
            terraform_script = _get_node_script_path(
                request, 'terraform_destroy.sh', 'terraform') + ' ' + destroy_type
            result = subprocess.run([terraform_script], shell=True,
                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
            assert result.returncode == 0, (
                'Failed to run terraform : rc: %s, stdout: %s, stderr: %s' % (
>                   result.returncode, result.stderr, result.stdout))
E           AssertionError: Failed to run terraform : rc: 1, stdout: b'\x1b[31m\x1b[31m\xe2\x95\xb7\x1b[0m\x1b[0m\n\x1b[31m\xe2\x94\x82\x1b[0m \x1b[0m\x1b[1m\x1b[31mError: \x1b[0m\x1b[0m\x1b[1mInvalid target address\x1b[0m\n\x1b[31m\xe2\x94\x82\x1b[0m \x1b[0m\n\x1b[31m\xe2\x94\x82\x1b[0m \x1b[0m\x1b[0mNo matching objects found. To view the available instances, use "terraform\n\x1b[31m\xe2\x94\x82\x1b[0m \x1b[0mstate list". Please modify the address to reference a specific instance.\n\x1b[31m\xe2\x95\xb5\x1b[0m\x1b[0m\n\x1b[0m\x1b[0m\n', stderr: b'/var/harvester_test_456_harvester-install-and-test/terraform_test_artifacts/terraformharvester /var/harvester_test_456_harvester-install-and-test\n'

harvester_e2e_tests/utils.py:946: AssertionError
```

in cases:

```
harvester_e2e_tests/apis/test_images.py::test_create_images_using_terraform::teardown
harvester_e2e_tests/apis/test_keypairs.py::test_create_keypairs_using_terraform::teardown
harvester_e2e_tests/scenarios/test_vm_networking.py::test_create_vm_using_terraform
```