### PR TITLE
UI: fix network error

### DIFF
--- a/cypress/constants/types.ts
+++ b/cypress/constants/types.ts
@@ -16,7 +16,7 @@ export const HCI = {
   NODE_NETWORK:       'network.harvesterhci.io.nodenetwork',
   CLUSTER_NETWORK:    'network.harvesterhci.io.clusternetwork',
   SUPPORT_BUNDLE:     'harvesterhci.io.supportbundle',
-  NETWORK_ATTACHMENT: 'k8s.cni.cncf.io.networkattachmentdefinition',
+  NETWORK_ATTACHMENT: 'harvesterhci.io.networkattachmentdefinition',
   CLUSTER:            'harvesterhci.io.management.cluster',
   DASHBOARD:          'harvesterhci.io.dashboard',
   BLOCK_DEVICE:       'harvesterhci.io.blockdevice',
@@ -25,3 +25,5 @@ export const HCI = {
   VERSION:            'harvesterhci.io.version',
   MANAGED_CHART:      'harvesterhci.io.managedchart',
 };
+
+export const NETWORK_ATTACHMENT = 'k8s.cni.cncf.io.networkattachmentdefinition';

--- a/cypress/pageobjects/network.po.ts
+++ b/cypress/pageobjects/network.po.ts
@@ -4,7 +4,7 @@ import LabeledInputPo from '@/utils/components/labeled-input.po';
 import LabeledSelectPo from '@/utils/components/labeled-select.po';
 import LabeledTextAreaPo from '@/utils/components/labeled-textarea.po';
 import RadioButtonPo from '@/utils/components/radio-button.po';
-import { HCI } from '@/constants/types'
+import { HCI, NETWORK_ATTACHMENT } from '@/constants/types'
 import CruResourcePo from '@/utils/components/cru-resource.po';
 
 const constants = new Constants();
@@ -27,6 +27,7 @@ export default class NetworkPage extends CruResourcePo {
     super({
       type: HCI.NETWORK_ATTACHMENT,
       realType: 'k8s.cni.cncf.io.network-attachment-definition',
+      storeType: NETWORK_ATTACHMENT
     });
   }
 

--- a/cypress/testcases/network.spec.ts
+++ b/cypress/testcases/network.spec.ts
@@ -1,19 +1,14 @@
-import YAML from 'js-yaml'
+import NetworkPage from "@/pageobjects/network.po";
+import { generateName } from '@/utils/utils';
 
-import networkPage from "@/pageobjects/network.po";
-import { LoginPage } from "@/pageobjects/login.po";
-import {generateName} from '@/utils/utils';
-
-
-const network = new networkPage();
-const login = new LoginPage();
+const network = new NetworkPage();
 
 /**
  * 1. Login
  * 2. Navigate to the network create page
  * 3. click Create button
  * Expected Results
- * 1. Create network success
+ * 1. create/delete network success
 */
 export function CheckCreateNetwork() {}
 it("Check create/delete network", () => {
@@ -109,4 +104,3 @@ it("Check network with Manual Mode", () => {
 
   network.deleteProgramlly(`${namespace}/${name}`)
 });
-

--- a/cypress/utils/components/cru-resource.po.ts
+++ b/cypress/utils/components/cru-resource.po.ts
@@ -3,21 +3,17 @@ import LabeledInputPo from '@/utils/components/labeled-input.po';
 import LabeledSelectPo from '@/utils/components/labeled-select.po';
 
 export default class CruResourcePo extends PagePo {
-  constructor({
-    type,
-    realType,
-  }: {
-    type: string,
-    realType?: string,
-  }) {
+  constructor({ type, realType, storeType}:  {type: string, realType?: string, storeType?: string}) {
     super(`/c/local/harvester/${type}`);
 
     this.type = type
     this.realType = realType || type
+    this.storeType = storeType || realType
   }
 
   public type = '';
   public realType = '';
+  public storeType: string|undefined = undefined;
   
   private footerButtons = '.cru-resource-footer'
   private confirmRemove = '.card-container.prompt-remove'
@@ -76,7 +72,8 @@ export default class CruResourcePo extends PagePo {
 
   public deleteProgramlly(id:string, retries:number = 3) {
     cy.window().then((win:any) => {
-      const resource = win.byId(this.realType, id, 'harvester')
+      const storeType = this.storeType || this.realType
+      const resource = win.byId(storeType, id, 'harvester')
 
       cy.intercept('DELETE', `/v1/harvester/${this.realType}s/${ id }`).as('delete');
 


### PR DESCRIPTION
1. https://localhost:8005/v1/harvester/k8s.cni.cncf.io.network-attachment-definitions/default/vlan806
2. https://localhost:8005/v1/harvester/schemas/k8s.cni.cncf.io.networkattachmentdefinition

`k8s.cni.cncf.io.networkattachmentdefinition` => `k8s.cni.cncf.io.network-attachment-definitions`

For some resource types, the type name in the url and the name saved in the vue store are not the same