### PR TITLE
Cypress: Run specific in order

### DIFF
--- a/cypress/cypress.json
+++ b/cypress/cypress.json
@@ -4,7 +4,17 @@
     "fixturesFolder": "./fixtures",
     "pluginsFile": "./plugins/index.js",
     "supportFile": "./support/index.js",
-    "testFiles": "**/*.spec.ts",
+    "testFiles": [
+      "login.spec.ts",
+      "settings.spec.ts",
+      "images.spec.ts",
+      "hosts.spec.ts",
+      "virtualmachines/*.ts",
+      "cloud-config-templates.spec.ts",
+      "ssh-keys.spec.ts",
+      "network.spec.ts",
+      "support.spec.ts"
+    ],
     "viewportWidth": 1920,
     "viewportHeight": 1080,
     "numTestsKeptInMemory": 5,

--- a/cypress/testcases/cloud-config-templates.spec.ts
+++ b/cypress/testcases/cloud-config-templates.spec.ts
@@ -18,30 +18,32 @@ const constants = new Constants();
  * 1. Create cloud config template with user data success
 */
 export function CheckUserData() {}
-it("Check create cloud config template", () => {
-  cy.login();
+describe("Check create cloud config template", () => {
+  it("Check create cloud config template", () => {
+    cy.login();
 
-  const namespace = 'default'
-  const name = generateName('test-cloud-config-template-create')
+    const namespace = 'default'
+    const name = generateName('test-cloud-config-template-create')
 
-  cy.intercept('POST', `/v1/harvester/configmaps`).as('create');
+    cy.intercept('POST', `/v1/harvester/configmaps`).as('create');
 
-  cloudConfig.create({
-    name,
-    namespace,
-    data: 'test-data'
-  })
+    cloudConfig.create({
+      name,
+      namespace,
+      data: 'test-data'
+    })
 
-  cy.wait('@create').then(res => {
-    expect(res.response?.statusCode).to.equal(201);
-    const type = res.response?.body?.metadata?.labels['harvesterhci.io/cloud-init-template']
-    const data = res.response?.body?.data
+    cy.wait('@create').then(res => {
+      expect(res.response?.statusCode).to.equal(201);
+      const type = res.response?.body?.metadata?.labels['harvesterhci.io/cloud-init-template']
+      const data = res.response?.body?.data
 
-    expect(type, 'Check selected template type').to.equal('user');
-    expect(data?.cloudInit, 'Check user data').to.equal('test-data');
-  })
+      expect(type, 'Check selected template type').to.equal('user');
+      expect(data?.cloudInit, 'Check user data').to.equal('test-data');
+    })
 
-  cloudConfig.delete(namespace, name)
+    cloudConfig.delete(namespace, name)
+  });
 });
 
 /**
@@ -57,64 +59,66 @@ it("Check create cloud config template", () => {
  * 2. Edit previous cloud config template success
  * 3. Clone previous cloud config template
 */
-it("Check Create network data && Edit && clone", () => {
-  cy.login();
+describe("Check Create network data && Edit && clone", () => {
+  it("Check Create network data && Edit && clone", () => {
+    cy.login();
 
-  const namespace = 'default'
-  const name = generateName('test-template-type')
+    const namespace = 'default'
+    const name = generateName('test-template-type')
 
-  cy.intercept('POST', `/v1/harvester/configmaps`).as('create');
+    cy.intercept('POST', `/v1/harvester/configmaps`).as('create');
 
-  cloudConfig.create({
-    name,
-    namespace,
-    templateType: 'Network Data',
-    data: 'test-network-data',
-  })
-
-  cy.wait('@create').then(res => {
-    expect(res.response?.statusCode).to.equal(201);
-    const type = res.response?.body?.metadata?.labels['harvesterhci.io/cloud-init-template']
-    const data = res.response?.body?.data
-
-    expect(type, 'Check template type').to.equal('network');
-    expect(data?.cloudInit, 'Check network data').to.equal('test-network-data');
-
-    cy.intercept('PUT', `/v1/harvester/configmaps/${namespace}/${name}`).as('update');
-
-    const editedData = 'test-edit-data'
-  
-    cloudConfig.checkEdit(name, namespace, {
-      data: editedData,
+    cloudConfig.create({
+      name,
+      namespace,
+      templateType: 'Network Data',
+      data: 'test-network-data',
     })
-  
-    cy.wait('@update').then(res => {
-      expect(res.response?.statusCode, `Check update ${namespace}/${name}`).to.equal(200);
+
+    cy.wait('@create').then(res => {
+      expect(res.response?.statusCode).to.equal(201);
+      const type = res.response?.body?.metadata?.labels['harvesterhci.io/cloud-init-template']
       const data = res.response?.body?.data
-  
-      expect(data?.cloudInit, 'Check edited data').to.equal(editedData);
 
-      cy.intercept('POST', `/v1/harvester/configmaps`).as('create');
+      expect(type, 'Check template type').to.equal('network');
+      expect(data?.cloudInit, 'Check network data').to.equal('test-network-data');
 
-      const cloneName = generateName('test-clone-clone')
+      cy.intercept('PUT', `/v1/harvester/configmaps/${namespace}/${name}`).as('update');
+
+      const editedData = 'test-edit-data'
     
-      const value = {
-        name: cloneName,
-      }
+      cloudConfig.checkEdit(name, namespace, {
+        data: editedData,
+      })
     
-      cloudConfig.checkClone(name, namespace, value)
-    
-      cy.wait('@create').then(res => {
-        expect(res.response?.statusCode).to.equal(201);
-        const type = res.response?.body?.metadata?.labels['harvesterhci.io/cloud-init-template']
+      cy.wait('@update').then(res => {
+        expect(res.response?.statusCode, `Check update ${namespace}/${name}`).to.equal(200);
         const data = res.response?.body?.data
     
-        expect(type, 'Check template data').to.equal('network');
-        expect(data?.cloudInit, 'Check clouded network data').to.equal(editedData);
-    
-        cloudConfig.deleteProgramlly(`${namespace}/${name}`)
-        cloudConfig.deleteProgramlly(`${namespace}/${cloneName}`)
+        expect(data?.cloudInit, 'Check edited data').to.equal(editedData);
+
+        cy.intercept('POST', `/v1/harvester/configmaps`).as('create');
+
+        const cloneName = generateName('test-clone-clone')
+      
+        const value = {
+          name: cloneName,
+        }
+      
+        cloudConfig.checkClone(name, namespace, value)
+      
+        cy.wait('@create').then(res => {
+          expect(res.response?.statusCode).to.equal(201);
+          const type = res.response?.body?.metadata?.labels['harvesterhci.io/cloud-init-template']
+          const data = res.response?.body?.data
+      
+          expect(type, 'Check template data').to.equal('network');
+          expect(data?.cloudInit, 'Check clouded network data').to.equal(editedData);
+      
+          cloudConfig.deleteProgramlly(`${namespace}/${name}`)
+          cloudConfig.deleteProgramlly(`${namespace}/${cloneName}`)
+        })
       })
     })
-  })
+  });
 });

--- a/cypress/testcases/hosts.spec.ts
+++ b/cypress/testcases/hosts.spec.ts
@@ -11,79 +11,85 @@ const login = new LoginPage();
  * This will insert custom YAML into the hosts page while editing
  */
 export function insertCustomYAML() {}
-it('should insert custom name into YAML', () => {
+describe('should insert custom name into YAML', () => {
+  it('should insert custom name into YAML', () => {
     cy.login();
     hosts.navigateHostsPage();
     hosts.editHostsYaml();
     editYaml.insertCustomName('This is a custom name');
-    });
+  });
+});
 
 export function CheckEdit() {}
-it('Check edit host', () => {
-  cy.login();
-  
-  const host = Cypress.env('host');
-  
-  cy.visit(`/c/local/harvester/${HCI.HOST}/${host.name}?mode=edit`)
+describe('Check edit host', () => {
+  it('Check edit host', () => {
+    cy.login();
+    
+    const host = Cypress.env('host');
+    
+    cy.visit(`/c/local/harvester/${HCI.HOST}/${host.name}?mode=edit`)
 
-  const customName = 'test-custom-name'
-  const consoleUrl = 'test-console-url'
+    const customName = 'test-custom-name'
+    const consoleUrl = 'test-console-url'
 
-  hosts.setValue({
-    customName,
-    consoleUrl,
-  })
+    hosts.setValue({
+      customName,
+      consoleUrl,
+    })
 
-  cy.intercept('PUT', `/v1/harvester/nodes/*`).as('update');
+    cy.intercept('PUT', `/v1/harvester/nodes/*`).as('update');
 
-  hosts.update(host.name)
+    hosts.update(host.name)
 
-  cy.wait('@update').then(res => {
-    const annotations = res.response?.body?.metadata?.annotations || {}
-    expect(annotations['harvesterhci.io/host-custom-name'], 'Check custom name').to.equal(customName);
-    expect(annotations['harvesterhci.io/host-console-url'], 'Check console url').to.equal(consoleUrl);
+    cy.wait('@update').then(res => {
+      const annotations = res.response?.body?.metadata?.annotations || {}
+      expect(annotations['harvesterhci.io/host-custom-name'], 'Check custom name').to.equal(customName);
+      expect(annotations['harvesterhci.io/host-console-url'], 'Check console url').to.equal(consoleUrl);
+    })
   })
 })
 
 export function CheckAddDisk() {}
-it('Check Add disk', () => {
-  cy.login();
-  
-  const host = Cypress.env('host');
-  const disk = host.disks[0]
-  
-  cy.visit(`/c/local/harvester/${HCI.HOST}/${host.name}?mode=edit`)
+describe('Check Add disk', () => {
+  it('Check Add disk', () => {
+    cy.login();
+    
+    const host = Cypress.env('host');
+    const disk = host.disks[0]
+    
+    cy.visit(`/c/local/harvester/${HCI.HOST}/${host.name}?mode=edit`)
 
-  const diskTab = '#disk > a'
-  const addDiskButton = '.button-dropdown'
-  const diskOption = '.vs__dropdown-option'
-  const removeIcon = '.btn > .icon'
+    const diskTab = '#disk > a'
+    const addDiskButton = '.button-dropdown'
+    const diskOption = '.vs__dropdown-option'
+    const removeIcon = '.btn > .icon'
 
-  cy.get(diskTab).click()
+    cy.get(diskTab).click()
 
-  cy.contains(addDiskButton, 'Add Disk').click()
-  cy.contains(diskOption, `${disk.devPath}`).click()
+    cy.contains(addDiskButton, 'Add Disk').click()
+    cy.contains(diskOption, `${disk.devPath}`).click()
 
-  cy.intercept('PUT', `/v1/harvester/${HCI.BLOCK_DEVICE}s/longhorn-system/${disk.name}`).as('updateBD');
+    cy.intercept('PUT', `/v1/harvester/${HCI.BLOCK_DEVICE}s/longhorn-system/${disk.name}`).as('updateBD');
 
-  hosts.update(host.name)
+    hosts.update(host.name)
 
-  cy.wait('@updateBD').then(res => {
-    const spec = res.response?.body?.spec || {}
-    expect(spec?.fileSystem?.provisioned, 'Check provisioned').to.equal(true);
-  })
+    cy.wait('@updateBD').then(res => {
+      const spec = res.response?.body?.spec || {}
+      expect(spec?.fileSystem?.provisioned, 'Check provisioned').to.equal(true);
+    })
 
-  cy.visit(`/c/local/harvester/${HCI.HOST}/${host.name}?mode=edit`)
+    cy.visit(`/c/local/harvester/${HCI.HOST}/${host.name}?mode=edit`)
 
-  cy.get(diskTab).click()
-  cy.get(removeIcon).click()
+    cy.get(diskTab).click()
+    cy.get(removeIcon).click()
 
-  cy.intercept('PUT', `/v1/harvester/${HCI.BLOCK_DEVICE}s/longhorn-system/${disk.name}`).as('updateBD');
+    cy.intercept('PUT', `/v1/harvester/${HCI.BLOCK_DEVICE}s/longhorn-system/${disk.name}`).as('updateBD');
 
-  hosts.update(host.name)
+    hosts.update(host.name)
 
-  cy.wait('@updateBD').then(res => {
-    const spec = res.response?.body?.spec || {}
-    expect(spec?.fileSystem?.provisioned, 'Check provisioned').to.equal(false);
+    cy.wait('@updateBD').then(res => {
+      const spec = res.response?.body?.spec || {}
+      expect(spec?.fileSystem?.provisioned, 'Check provisioned').to.equal(false);
+    })
   })
 })

--- a/cypress/testcases/network.spec.ts
+++ b/cypress/testcases/network.spec.ts
@@ -16,18 +16,20 @@ const login = new LoginPage();
  * 1. Create network success
 */
 export function CheckCreateNetwork() {}
-it("Check create/delete network", () => {
-  cy.login();
+describe('Check create/delete network', () => {
+  it('Check create/delete network', () => {
+    cy.login();
 
-  const name = generateName('test-network-create');
+    const name = generateName('test-network-create');
 
-  network.create({
-    name,
-    namespace: 'default',
-    vlan: '233',
-  })
+    network.create({
+      name,
+      namespace: 'default',
+      vlan: '233',
+    })
 
-  network.delete('default', name)
+    network.delete('default', name)
+  });
 });
 
 /**
@@ -39,33 +41,35 @@ it("Check create/delete network", () => {
  * 1. Create network with DHCP server IP success
 */
 export function CheckDHCP() {}
-it("Check network with DHCP", () => {
-  cy.login();
+describe('Check network with DHCP', () => {
+  it('Check network with DHCP', () => {
+    cy.login();
 
-  cy.intercept('POST', `/v1/harvester/k8s.cni.cncf.io.network-attachment-definitions`).as('create');
+    cy.intercept('POST', `/v1/harvester/k8s.cni.cncf.io.network-attachment-definitions`).as('create');
 
-  const name = generateName('test-network-create');
-  const dhcp = '172.0.0.1'
-  const namespace = 'default'
+    const name = generateName('test-network-create');
+    const dhcp = '172.0.0.1'
+    const namespace = 'default'
 
-  network.create({
-    name,
-    namespace,
-    vlan: '234',
-    mode: 'Auto(DHCP)',
-    dhcp,
-  })
+    network.create({
+      name,
+      namespace,
+      vlan: '234',
+      mode: 'Auto(DHCP)',
+      dhcp,
+    })
 
-  cy.wait('@create').then(res => {
-    expect(res.response?.statusCode).to.equal(201);
-    const route = res.response?.body?.metadata?.annotations['network.harvesterhci.io/route']
-    if (route) {
-      const json = JSON.parse(route)
-      expect(json.serverIPAddr, 'Check Server IP Address').to.equal(dhcp);
-    }
-  })
+    cy.wait('@create').then(res => {
+      expect(res.response?.statusCode).to.equal(201);
+      const route = res.response?.body?.metadata?.annotations['network.harvesterhci.io/route']
+      if (route) {
+        const json = JSON.parse(route)
+        expect(json.serverIPAddr, 'Check Server IP Address').to.equal(dhcp);
+      }
+    })
 
-  network.deleteProgramlly(`${namespace}/${name}`)
+    network.deleteProgramlly(`${namespace}/${name}`)
+  });
 });
 
 /**
@@ -78,35 +82,36 @@ it("Check network with DHCP", () => {
  * 1. Create network with manual mode success
 */
 export function CheckManualMode() {}
-it("Check network with Manual Mode", () => {
-  cy.login();
+describe('Check network with Manual Mode', () => {
+  it('Check network with Manual Mode', () => {
+    cy.login();
 
-  cy.intercept('POST', `/v1/harvester/k8s.cni.cncf.io.network-attachment-definitions`).as('create');
+    cy.intercept('POST', `/v1/harvester/k8s.cni.cncf.io.network-attachment-definitions`).as('create');
 
-  const name = generateName('test-network-create');
-  const cidr = '172.0.0.1/24'
-  const gateway = '172.0.0.1'
-  const namespace = 'default'
+    const name = generateName('test-network-create');
+    const cidr = '172.0.0.1/24'
+    const gateway = '172.0.0.1'
+    const namespace = 'default'
 
-  network.create({
-    name,
-    namespace,
-    vlan: '235',
-    mode: 'Manual',
-    cidr,
-    gateway,
-  })
+    network.create({
+      name,
+      namespace,
+      vlan: '235',
+      mode: 'Manual',
+      cidr,
+      gateway,
+    })
 
-  cy.wait('@create').then(res => {
-    expect(res.response?.statusCode, 'Check create network').to.equal(201);
-    const route = res.response?.body?.metadata?.annotations['network.harvesterhci.io/route']
-    if (route) {
-      const json = JSON.parse(route)
-      expect(json.cidr, 'Check CIDR').to.equal(cidr);
-      expect(json.gateway, 'Check gateway').to.equal(gateway);
-    }
-  })
+    cy.wait('@create').then(res => {
+      expect(res.response?.statusCode, 'Check create network').to.equal(201);
+      const route = res.response?.body?.metadata?.annotations['network.harvesterhci.io/route']
+      if (route) {
+        const json = JSON.parse(route)
+        expect(json.cidr, 'Check CIDR').to.equal(cidr);
+        expect(json.gateway, 'Check gateway').to.equal(gateway);
+      }
+    })
 
-  network.deleteProgramlly(`${namespace}/${name}`)
+    network.deleteProgramlly(`${namespace}/${name}`)
+  });
 });
-

--- a/cypress/testcases/settings.spec.ts
+++ b/cypress/testcases/settings.spec.ts
@@ -10,9 +10,11 @@ const sidebar = new SidebarPage();
  * 2. Navigate to the Advanced Settings Page via the sidebar
  */
 export function navigateAdvanceSettingsPage() {};
-it('should navigate to the Advanced Settings Page', () => {
-    cy.login();
-    sidebar.advancedSettings();
+describe('should navigate to the Advanced Settings Page', () => {
+    it('should navigate to the Advanced Settings Page', () => {
+        cy.login();
+        sidebar.advancedSettings();
+    });
 });
 /**
  * 1. Login
@@ -20,10 +22,12 @@ it('should navigate to the Advanced Settings Page', () => {
  * 3. Edit UI Source via UI
  */
 export function editUiSource() {};
-it('should edit the uisource setting', () => {
-    cy.login();
-    sidebar.advancedSettings();
-    settings.editUiSource();
+describe('should edit the uisource setting', () => {
+    it('should edit the uisource setting', () => {
+        cy.login();
+        sidebar.advancedSettings();
+        settings.editUiSource();
+    });
 });
 /**
  * 1. Login
@@ -33,7 +37,9 @@ it('should edit the uisource setting', () => {
  * 5. Validate that the URL changed
  */
 export function changeUiSourceType() {};
-it('change UI source type to external', () => {
-    cy.login();
-    settings.changeUiSourceType(1);
+describe('change UI source type to external', () => {
+    it('change UI source type to external', () => {
+        cy.login();
+        settings.changeUiSourceType(1);
+    });
 });

--- a/cypress/testcases/ssh-keys.spec.ts
+++ b/cypress/testcases/ssh-keys.spec.ts
@@ -17,24 +17,26 @@ const login = new LoginPage();
  * 1. Create ssh success
 */
 export function CheckCreateSsh() {}
-it("Create a ssh key", () => {
-  cy.login();
+describe('Create a ssh key', () => {
+  it('Create a ssh key', () => {
+    cy.login();
 
-  const name = generateName('test-ssh-create');
-  const namespace = 'default'
+    const name = generateName('test-ssh-create');
+    const namespace = 'default'
 
-  ssh.create({
-    name,
-    namespace,
-    sshKey: sshKeyExample,
-  })
+    ssh.create({
+      name,
+      namespace,
+      sshKey: sshKeyExample,
+    })
 
-  const cloneName = generateName('test-ssh-clone');
-  ssh.clone(`${namespace}/${ name }`, {
-    name: cloneName,
-    namespace,
-  })
-  
-  ssh.delete(namespace, name)
-  ssh.deleteProgramlly(`${namespace}/${cloneName}`)
+    const cloneName = generateName('test-ssh-clone');
+    ssh.clone(`${namespace}/${ name }`, {
+      name: cloneName,
+      namespace,
+    })
+    
+    ssh.delete(namespace, name)
+    ssh.deleteProgramlly(`${namespace}/${cloneName}`)
+  });
 });

--- a/cypress/testcases/support.spec.ts
+++ b/cypress/testcases/support.spec.ts
@@ -27,7 +27,9 @@ describe('Support Page', () => {
  * @notImplementedFully
  */
 export function generateSupportBundle() {}
-it('Generate Support Bundle', () => {
-    cy.login();
-    support.generateSupportBundle('this ia a test description');
+describe('Generate Support Bundle', () => {
+    it('Generate Support Bundle', () => {
+        cy.login();
+        support.generateSupportBundle('this ia a test description');
+    });
 });

--- a/cypress/testcases/virtualmachines/advanced.spec.ts
+++ b/cypress/testcases/virtualmachines/advanced.spec.ts
@@ -95,7 +95,7 @@ describe("Verify Booting in EFI mode checkbox", () => {
     cy.login();
   });
 
-  it.only('Create a new VM with Booting in EFI mode checked', () => {
+  it('Create a new VM with Booting in EFI mode checked', () => {
     const VM_NAME = 'test-efi'
     const NAMESPACE = 'default'
 

--- a/cypress/testcases/virtualmachines/virtual-machine.spec.ts
+++ b/cypress/testcases/virtualmachines/virtual-machine.spec.ts
@@ -141,30 +141,30 @@ describe('Create a VM with Start VM on Creation unchecked', () => {
  * 4. Click create
 */
 export function CheckMemoryRequired() {}
-it('Create VM without memory provided', () => {
-  const VM_NAME = 'test-memory-required'
-  const NAMESPACE = 'default'
-
-  cy.login();
-
-  const imageEnv = Cypress.env('image');
-
-  const value = {
-    name: VM_NAME,
-    cpu: '2',
-    image: imageEnv.name,
-    createRunning: false,
-  }
-
-  vms.goToCreate();
-  vms.setValue(value);
-
-  cy.get('.cru-resource-footer').contains('Create').click()
-
-  cy.contains('"Memory" is required').should('exist')
-});
-
-
+describe('Create VM without memory provided', () => {
+  it('Create VM without memory provided', () => {
+    const VM_NAME = 'test-memory-required'
+    const NAMESPACE = 'default'
+  
+    cy.login();
+  
+    const imageEnv = Cypress.env('image');
+  
+    const value = {
+      name: VM_NAME,
+      cpu: '2',
+      image: imageEnv.name,
+      createRunning: false,
+    }
+  
+    vms.goToCreate();
+    vms.setValue(value);
+  
+    cy.get('.cru-resource-footer').contains('Create').click()
+  
+    cy.contains('"Memory" is required').should('exist')
+  });
+})
 
 /**
  * 1. Login
@@ -175,6 +175,8 @@ it('Create VM without memory provided', () => {
  * @notImplemented
  */
 export function CheckMultiVMScheduler() {}
-it("automatic assignment to different nodes when creating multiple vm's", () => {
+describe("automatic assignment to different nodes when creating multiple vm's", () => {
+  it("automatic assignment to different nodes when creating multiple vm's", () => {
 
-});
+  });
+})


### PR DESCRIPTION
We intend to run specific in order via the `testFiles` of Cypress's configuration, but the specific which is missing `describe`(only has `it`) will run at first.

![截屏2022-05-11 下午5 29 28](https://user-images.githubusercontent.com/15041915/167817811-77ee1cfe-e8f9-4a12-91cf-8bb3a9a6f013.png)


We will Add missing `describe` to cover `it`.

@noahgildersleeve @lanfon72 @TachunLin Please let me know if you have concerns, thanks!