### PR TITLE
Add script for test report and Add command of stopping spec's test on GUI

### DIFF
--- a/cypress/cypress.json
+++ b/cypress/cypress.json
@@ -39,5 +39,12 @@
     "retries": {
         "runMode": 1,
         "openMode": 0
+    },
+    "reporter": "mochawesome",
+    "reporterOptions": {
+      "reportDir": "cypress/results",
+      "overwrite": false,
+      "html": false,
+      "json": true
     }
 }

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "delete:reports": "rm cypress/results/* || true",
-    "prereport": "yarn run delete:reports",
+    "prereport": "npm run delete:reports",
     "report": "node scripts/run.js"
   }
 }

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -5,6 +5,9 @@
     "@types/js-yaml": "^4.0.5",
     "cypress-dotenv": "^2.0.0",
     "dotenv": "^16.0.0",
+    "mochawesome": "^7.1.3",
+    "mochawesome-merge": "^4.2.1",
+    "mochawesome-report-generator": "^6.2.0",
     "typedoc": "^0.22.11",
     "typescript": "^4.5.4"
   },
@@ -20,5 +23,10 @@
   },
   "engines": {
     "node": "^12.22 || ^14.13 || >=16"
+  },
+  "scripts": {
+    "delete:reports": "rm cypress/results/* || true",
+    "prereport": "yarn run delete:reports",
+    "report": "node scripts/run.js"
   }
 }

--- a/cypress/pageobjects/image.po.ts
+++ b/cypress/pageobjects/image.po.ts
@@ -73,8 +73,8 @@ export class ImagePage {
     cy.get('.tab#labels').click();
     keys.forEach((key, index) => {
       cy.contains('Add Label').click();
-      cy.get('.kv-item.key input').eq(index).type(key);
-      cy.get('.kv-item.value textarea').eq(index).type(value.labels[key]);
+      cy.get('.kv-item.key input').eq(index + 2).type(key);
+      cy.get('.kv-item.value input').eq(index + 2).type(value.labels[key]);
     });
   }
 

--- a/cypress/scripts/run.js
+++ b/cypress/scripts/run.js
@@ -1,0 +1,20 @@
+const cypress = require('cypress')
+const marge = require('mochawesome-report-generator')
+const { merge } = require('mochawesome-merge')
+
+cypress.run().then(
+  () => {
+    generateReport()
+  },
+  error => {
+    generateReport()
+    console.error(error)
+    process.exit(1)
+  }
+)
+
+function generateReport(options) {
+  return merge({
+    files: ['./cypress/results/*.json']
+  }).then(report => marge.create(report, options))
+}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -27,6 +27,13 @@ Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cy
     })
 });
 
+Cypress.Commands.add('stopOnFailed', () => {
+  Cypress.on('fail', (e, test) => {
+    Cypress.runner.stop();
+    throw new Error(e.message);
+  })
+})
+
 Cypress.Commands.overwrite('visit', (originalFn, url = '', options) => {
   const isDev = Cypress.env('NODE_ENV') === 'dev';
 


### PR DESCRIPTION
There are two new features:

- Generate report
- Stop failed test on GUI via new command `stopOnFailed`

### Generate report

`yarn run report` can generate report now and the report will be saved as `mochawesome-report/mochawesome.html`

The content of HTML looks like:
![image](https://user-images.githubusercontent.com/15041915/168961154-2ce575e0-5e11-488f-90df-dc3206fabb07.png)

There are records about Test status/Error message/Spent times of test.

### Stop test

Dependent tests should be stopped if it's failed.
Use code below to stop it.

```
before(() => {
    cy.stopOnFailed();
})
```