### PR TITLE
To fix daily e2e testing on pytest

### DIFF
--- a/harvester_e2e_tests/fixtures/network.py
+++ b/harvester_e2e_tests/fixtures/network.py
@@ -70,11 +70,14 @@ def _cleanup_network(admin_session, harvester_api_endpoints, network_id,
 
     # NOTE(gyee): there's no way we know how many VMs the network is currently
     # attached to. Will need to keep trying till all the VMs had been deleted
-    success = polling2.poll(
-        _delete_network,
-        step=5,
-        timeout=wait_timeout)
-    assert success, 'Unable to cleanup network: %s' % (network_id)
+    try:
+        polling2.poll(
+            _delete_network,
+            step=5,
+            timeout=wait_timeout)
+    except polling2.TimeoutException as e:
+        errmsg = 'Unable to cleanup network: %s' % (network_id)
+        raise AssertionError(errmsg) from e
 
 
 def _lookup_network(request, admin_session, harvester_api_endpoints, vlan_id):

--- a/harvester_e2e_tests/scenarios/test_rancher_integration.py
+++ b/harvester_e2e_tests/scenarios/test_rancher_integration.py
@@ -125,11 +125,14 @@ def _wait_for_cluster_ready(request, rancher_admin_session,
                     'ready' in cluster_json['status']):
                 return cluster_json['status']['ready']
 
-    ready = polling2.poll(
-        _wait_for_cluster_ready_status,
-        step=5,
-        timeout=request.config.getoption('--rancher-cluster-wait-timeout'))
-    assert ready, 'Timed out while waiting to import Harvester.'
+    try:
+        polling2.poll(
+            _wait_for_cluster_ready_status,
+            step=5,
+            timeout=request.config.getoption('--rancher-cluster-wait-timeout'))
+    except polling2.TimeoutException as e:
+        errmsg = 'Timed out while waiting to import Harvester.'
+        raise AssertionError(errmsg) from e
 
 
 def _import_harvester_cluster_into_rancher(request, admin_session,

--- a/harvester_e2e_tests/scenarios/test_vm_negatives.py
+++ b/harvester_e2e_tests/scenarios/test_vm_negatives.py
@@ -78,9 +78,12 @@ class TestHostDown:
         Covers:
             Negative virtual-machines-05-Delete VM Negative
         """
-        # make sure the VM instance is successfully created
+        # make sure the VM instance is successfully created and running
         vm_instance_json = utils.lookup_vm_instance(
             admin_session, harvester_api_endpoints, basic_vm)
+        utils.assert_vm_ready(request, admin_session, harvester_api_endpoints,
+                              vm_instance_json["metadata"]["name"], True)
+
         # abruptly shutdown the node where it is running
         node_name = vm_instance_json['status']['nodeName']
         utils.power_off_node(request, admin_session, harvester_api_endpoints,
@@ -95,9 +98,12 @@ class TestHostDown:
     @pytest.mark.host_management
     def test_vm_after_host_reboot(self, request, admin_session,
                                   harvester_api_endpoints, basic_vm):
-        # make sure the VM instance is successfully created
+        # make sure the VM instance is successfully created and running
         vm_instance_json = utils.lookup_vm_instance(
             admin_session, harvester_api_endpoints, basic_vm)
+        utils.assert_vm_ready(request, admin_session, harvester_api_endpoints,
+                              vm_instance_json["metadata"]["name"], True)
+
         node_name = vm_instance_json['status']['nodeName']
         # Reboot VM
         utils.reboot_node(request, admin_session, harvester_api_endpoints,


### PR DESCRIPTION
Changes:
- To handle `polling2` exception correctly
- To check VM is running before get the hosted node name

this is based on **harvester-install-and-test-e2e-daily#253**

---
Cases of `polling2` exception:
- [x] test_create_vm.py::test_create_windows_vm::setup
- [x] test_rancher_integration.py::TestRancherIntegrationWithExternalRancher::test_create_rke1_cluster::setup
- [x] test_rancher_integration.py::TestRancherIntegrationWithExternalRancher::test_create_rke2_cluster::setup
- [x] test_create_vm.py::test_host_maintenance_mode
- [x] test_vm_networking.py::TestVMNetworking::test_add_vlan_network_to_vm

Cases of `KeyError 'nodeName'`:
- [x] test_vm_negatives.py::TestHostDown::test_vm_after_host_reboot
- [x] test_vm_negatives.py::TestHostDown::test_delete_vm_while_host_shutdown

Case of AssertionError:
- [x] test_vm_networking.py::test_create_vm_using_terraform
- [ ] test_rancher_integration.py::TestRancherIntegrationWithExternalRancher::test_add_prj_owner_user