### PR TITLE
To fix daily e2e #260

### DIFF
--- a/harvester_e2e_tests/apis/test_hosts.py
+++ b/harvester_e2e_tests/apis/test_hosts.py
@@ -158,7 +158,7 @@ def test_update_using_yaml(request, admin_session, harvester_api_endpoints):
                 harvester_api_endpoints.get_node % (updated_host_data['id']))
 
 
-@pytest.mark.last
+@pytest.mark.trylast
 @pytest.mark.delete_host
 @pytest.mark.hosts_p1
 @pytest.mark.p1
@@ -171,6 +171,10 @@ def test_delete_host(request, admin_session, harvester_api_endpoints):
     resp = admin_session.get(harvester_api_endpoints.list_nodes)
     assert resp.status_code == 200, 'Failed to list nodes: %s' % (resp.content)
     host_data = resp.json()
+
+    if len(host_data["data"]) == 1:
+        pytest.skip("It will break the cluster as it is single node.")
+
     # FIXME(gyee): for now only delete the last node in the cluster due to
     # https://github.com/harvester/harvester/issues/1398
     # This is assuming that the orders are correct. We'll need to test

--- a/harvester_e2e_tests/conftest.py
+++ b/harvester_e2e_tests/conftest.py
@@ -49,14 +49,14 @@ def pytest_addoption(parser):
     parser.addoption(
         '--harvester_cluster_nodes',
         action='store',
-        type='int',
+        type=int,
         default=config_data['harvester_cluster_nodes'],
         help='Set count of test framework harvester cluster nodes.'
     )
     parser.addoption(
         '--vlan-id',
         action='store',
-        type='int',
+        type=int,
         default=config_data['vlan-id'],
         help=('VLAN ID, if specified, will invoke the tests depended on '
               'external networking.')
@@ -70,7 +70,7 @@ def pytest_addoption(parser):
     parser.addoption(
         '--wait-timeout',
         action='store',
-        type='int',
+        type=int,
         default=config_data['wait-timeout'],
         help='Wait time for polling operations'
     )
@@ -173,7 +173,7 @@ def pytest_addoption(parser):
     parser.addoption(
         '--rancher-cluster-wait-timeout',
         action='store',
-        type='int',
+        type=int,
         default=config_data['rancher-cluster-wait-timeout'],
         help='Wait time for polling Rancher cluster ready status'
     )

--- a/harvester_e2e_tests/fixtures/image.py
+++ b/harvester_e2e_tests/fixtures/image.py
@@ -133,8 +133,8 @@ def image_using_terraform(request, admin_session, harvester_api_endpoints):
     base_url = request.config.getoption(
         '--image-cache-url',
         ('http://download.opensuse.org/repositories/Cloud:/Images:/'
-         'Leap_15.2/images'))
-    url = os.path.join(base_url, 'openSUSE-Leap-15.2.x86_64-NoCloud.qcow2')
+         'Leap_15.3/images'))
+    url = os.path.join(base_url, 'openSUSE-Leap-15.3.x86_64-NoCloud.qcow2')
 
     # when use parameterized fixture, use the URL from the parameter instead
     if getattr(request, 'param', None):

--- a/harvester_e2e_tests/scenarios/test_create_vm.py
+++ b/harvester_e2e_tests/scenarios/test_create_vm.py
@@ -716,7 +716,7 @@ def test_host_maintenance_mode(request, admin_session, image, keypair,
                 timeout=request.config.getoption('--wait-timeout'))
         except polling2.TimeoutException as e:
             errfmt = 'Timed out while waiting for VM to be migrated: %s'
-            raise AssertionError(errfmt % vm_json['metadata']['name']) from e
+            raise AssertionError(errfmt % vm_json['metadata']['name'])
 
         vmi_json_after_migrate = utils.lookup_vm_instance(
             admin_session, harvester_api_endpoints, vm_json)

--- a/harvester_e2e_tests/scenarios/test_create_vm.py
+++ b/harvester_e2e_tests/scenarios/test_create_vm.py
@@ -714,7 +714,7 @@ def test_host_maintenance_mode(request, admin_session, image, keypair,
                 _check_vm_instance_migrated,
                 step=5,
                 timeout=request.config.getoption('--wait-timeout'))
-        except polling2.TimeoutException as e:
+        except polling2.TimeoutException:
             errfmt = 'Timed out while waiting for VM to be migrated: %s'
             raise AssertionError(errfmt % vm_json['metadata']['name'])
 

--- a/harvester_e2e_tests/scenarios/test_rancher_integration.py
+++ b/harvester_e2e_tests/scenarios/test_rancher_integration.py
@@ -116,10 +116,13 @@ def _delete_rke1_cluster(request, rancher_admin_session, rancher_api_endpoints,
 
 def _wait_for_cluster_ready(request, rancher_admin_session,
                             rancher_api_endpoints, cluster_name):
+    cluster_json = dict()
+
     def _wait_for_cluster_ready_status():
         resp = rancher_admin_session.get(
             rancher_api_endpoints.get_provisioning_cluster % (cluster_name))
         if resp.status_code == 200:
+            nonlocal cluster_json
             cluster_json = resp.json()
             if ('status' in cluster_json and
                     'ready' in cluster_json['status']):
@@ -130,9 +133,19 @@ def _wait_for_cluster_ready(request, rancher_admin_session,
             _wait_for_cluster_ready_status,
             step=5,
             timeout=request.config.getoption('--rancher-cluster-wait-timeout'))
-    except polling2.TimeoutException as e:
-        errmsg = 'Timed out while waiting to import Harvester.'
-        raise AssertionError(errmsg) from e
+    except polling2.TimeoutException:
+        from datetime import datetime
+        from json import dumps
+        fmt = "%Y-%m-%dT%H:%M:%SZ"
+
+        def _key(item):
+            t = item['lastUpdateTime']
+            return datetime.strptime(t, fmt) if t else datetime(2000, 1, 1)
+
+        items = sorted(cluster_json['status']['conditions'], key=_key)
+        errmsg = ('Timed out while waiting to import Harvester.\n'
+                  f'Last 5 conditions: {dumps(items[-5:])}')
+        raise AssertionError(errmsg)
 
 
 def _import_harvester_cluster_into_rancher(request, admin_session,

--- a/harvester_e2e_tests/scenarios/test_rancher_integration.py
+++ b/harvester_e2e_tests/scenarios/test_rancher_integration.py
@@ -365,12 +365,16 @@ def rke1_cluster(request, rancher_admin_session, rancher_api_endpoints, image,
 
 
 @pytest.fixture(scope='class')
-def rke2_cluster(request, rancher_admin_session, rancher_api_endpoints, image,
+def rke2_cluster(request, admin_session, harvester_api_endpoints,
+                 rancher_admin_session, rancher_api_endpoints, image,
                  network, cloud_credential,
                  external_rancher_with_imported_harvester):
     test_environment = request.config.getoption('--test-environment')
     cluster_id = external_rancher_with_imported_harvester
     cloud_credential_id = cloud_credential
+
+    utils.assert_image_ready(request, admin_session, harvester_api_endpoints,
+                             image['metadata']['name'])
 
     # Harvester Kubeconfig
     rke2_cluster_name = 'rke2-' + test_environment

--- a/harvester_e2e_tests/scenarios/test_vm_negatives.py
+++ b/harvester_e2e_tests/scenarios/test_vm_negatives.py
@@ -68,6 +68,7 @@ class TestHostDown:
         utils.power_on_node(request, admin_session, harvester_api_endpoints,
                             node_name)
 
+    @pytest.mark.skip("https://github.com/harvester/harvester/issues/2148")
     @pytest.mark.host_management
     @pytest.mark.virtual_machines_p1
     @pytest.mark.p1

--- a/harvester_e2e_tests/utils.py
+++ b/harvester_e2e_tests/utils.py
@@ -362,7 +362,7 @@ def delete_image_by_name(request, admin_session,
             timeout=request.config.getoption('--wait-timeout'))
     except polling2.TimeoutException as e:
         errmsg = 'Timed out while waiting for image to be deleted'
-        raise AssertionError(errmsg) from e
+        raise AssertionError(errmsg)
 
 
 def create_image(request, admin_session, harvester_api_endpoints, url,
@@ -437,11 +437,13 @@ def assert_vm_ready(request, admin_session, harvester_api_endpoints,
                     vm_name, running):
     # give it some time for the VM to boot up
     time.sleep(180)
+    resp_json = dict()
 
     def _check_vm_ready():
         resp = admin_session.get(harvester_api_endpoints.get_vm_instance %
                                  (vm_name))
         if resp.status_code == 200:
+            nonlocal resp_json
             resp_json = resp.json()
             if running:
                 if ('status' in resp_json and
@@ -461,8 +463,9 @@ def assert_vm_ready(request, admin_session, harvester_api_endpoints,
             step=5,
             timeout=request.config.getoption('--wait-timeout'))
     except polling2.TimeoutException as e:
-        errmsg = 'Timed out while waiting for VM to be ready.'
-        raise AssertionError(errmsg) from e
+        errmsg = ('Timed out while waiting for VM to be ready.\n'
+                  f"Stucking in Phase {resp_json['status']['phase']}")
+        raise AssertionError(errmsg)
 
 
 def create_vm(request, admin_session, image, harvester_api_endpoints,
@@ -1452,7 +1455,7 @@ def get_vm_ip_address(admin_session, harvester_api_endpoints, vm, timeout,
     except polling2.TimeoutException as e:
         errmsg = ('Timed out while waiting for IP address for NIC %s to be '
                   ' assigned: %s' % (nic_name, vm_instance_json))
-        raise AssertionError(errmsg) from e
+        raise AssertionError(errmsg)
 
     return (vm_instance_json, ip)
 

--- a/harvester_e2e_tests/utils.py
+++ b/harvester_e2e_tests/utils.py
@@ -360,7 +360,7 @@ def delete_image_by_name(request, admin_session,
             _wait_for_image_to_be_deleted,
             step=5,
             timeout=request.config.getoption('--wait-timeout'))
-    except polling2.TimeoutException as e:
+    except polling2.TimeoutException:
         errmsg = 'Timed out while waiting for image to be deleted'
         raise AssertionError(errmsg)
 
@@ -462,7 +462,7 @@ def assert_vm_ready(request, admin_session, harvester_api_endpoints,
             _check_vm_ready,
             step=5,
             timeout=request.config.getoption('--wait-timeout'))
-    except polling2.TimeoutException as e:
+    except polling2.TimeoutException:
         errmsg = ('Timed out while waiting for VM to be ready.\n'
                   f"Stucking in Phase {resp_json['status']['phase']}")
         raise AssertionError(errmsg)
@@ -1452,7 +1452,7 @@ def get_vm_ip_address(admin_session, harvester_api_endpoints, vm, timeout,
 
     try:
         ip = polling2.poll(_wait_for_ip, step=5, timeout=timeout)
-    except polling2.TimeoutException as e:
+    except polling2.TimeoutException:
         errmsg = ('Timed out while waiting for IP address for NIC %s to be '
                   ' assigned: %s' % (nic_name, vm_instance_json))
         raise AssertionError(errmsg)


### PR DESCRIPTION
Changes:
- skip know issue on `scenarios/test_vm_negatives.py::test_delete_vm_while_host_shutdown`
- remove unnecessary exception chaining
- add more context information when error raised
- fix potential bugs
    1. `test_delete_host` should not test on single node, and the **mark** should be `trylast`, not `last`
    2. parser's **type** should use constructor instead of pure string literal

Case of Errors/Fails on daily\#260:
~~- [ ] `test_create_vm.py::test_create_windows_vm` unable to test on local environment, it use specific image on Jenkins~~
~~- [ ]  `test_rancher_integration.py::TestRancherIntegrationWithExternalRancher::test_create_rke2_cluster` **fail** on local environment, still investigating~~
- [x] `test_vm_networking.py::test_create_vm_using_terraform` **pass** on local environment after update image version, it should be the root cause.
- [x] `test_rancher_integration.py::TestRancherIntegrationWithExternalRancher::test_create_rke1_cluster` **pass** on local environment, add more context information for debug
- [x] `test_create_vm.py::test_host_maintenance_mode` **pass** on local environment
- [x] `test_rancher_integration.py::TestRancherIntegrationWithExternalRancher::test_add_prj_owner_user` **pass** on local environment, should be the environment issue
- [x] `test_vm_negatives.py::TestHostDown::test_delete_vm_while_host_shutdown` **fail** on local environment, known issue
- [x] `test_vm_negatives.py::TestHostDown::test_vm_after_host_reboot` **pass** on local environment, should be the environment issue