### PR TITLE
[WIP] Add CI Support Flow For New Rancher & Harvester (#2096 Sibling PR)

### DIFF
--- a/CI/harvester-installer/roles/jenkins/tasks/install_jenkins.yml
+++ b/CI/harvester-installer/roles/jenkins/tasks/install_jenkins.yml
@@ -59,6 +59,7 @@
     - pam-auth
     - pipeline-github-lib
     - pipeline-stage-view
+    - pipeline-utility-steps
     - ssh-slaves
     - timestamper
     - workflow-aggregator

--- a/CI/harvester-installer/roles/jenkins/templates/harvester_vagrant_installation_test.groovy.j2
+++ b/CI/harvester-installer/roles/jenkins/templates/harvester_vagrant_installation_test.groovy.j2
@@ -6,13 +6,46 @@ pipelineJob('harvester-vagrant-installation-test') {
     }
     parameters {
         booleanParam('keep_environment', false, 'Keep the Vagrant environment around after the test had finish.')
-        booleanParam('slack_notify', true, 'Send notifications to Slack')
+        booleanParam('slack_notify', false, 'Send notifications to Slack')
+        stringParam('WORKSPACE', '/var/lib/jenkins/workspace/harvester-vagrant-installation-test', 'Required: Provide A Workspace')
+        // harvester params
+        stringParam('harvester_cluster_nodes', 'YAML_PROVIDED', 'Override the YAML Provided harvester_cluster_nodes')
+        // single node rancher params
+        stringParam('rancher_config_node_disk_size', 'YAML_PROVIDED', 'Override the YAML Provided rancher_config.node_disk_size - must be in appropriate runtime_configuration')
+        stringParam('rancher_config_cert_manager_version', 'YAML_PROVIDED', 'Override the YAML Provided rancher_config.cert_manager_version - must be in appropriate runtime_configuration')
+        stringParam('rancher_config_k3s_url_escaped_version', 'YAML_PROVIDED', 'Override the YAML Provided rancher_config.k3s_url_escaped_version - must be in appropriate runtime_configuration')
+        stringParam('rancher_config_rancher_version', 'YAML_PROVIDED', 'Override the YAML Provided rancher_config.rancher_version - must be in appropriate runtime_configuration')
+        stringParam('rancher_config_rancher_version_no_prefix', 'YAML_PROVIDED', 'Override the YAML Provided rancher_config.rancher_version_no_prefix - must be in appropriate runtime_configuration')
+        stringParam('rancher_config_cpu', 'YAML_PROVIDED', 'Override the YAML Provded rancher_config.cpu - must be in appropriate runtime_configuration')
+        stringParam('rancher_config_memory', 'YAML_PROVIDED', 'Override the YAML Provded rancher_config.memory - must be in the appropriate runtime_configuration')
+        stringParam('rancher_config_rancher_install_domain', 'YAML_PROVIDED', 'OVerride the YAML Provided rancher_config.rancher_install_domain - must be in appropriate runtime_configuration')
+        stringParam('rancher_config_registry_domain', 'YAML_PROVIDED', 'Override the YAML Provided rancher_config.registry_domain - must be in the appropriate runtime_configuration')
+        // toggle of environments
+        choiceParam('runtime_configuration', ['air_gap_single_rancher_with_harvester', 'harvester_offline', 'normal', 'single_node_rancher_non_airgapped'], 'the runtime for the harvester install')
+        // login params:
+        stringParam('harvester_dashboard_admin_user', 'YAML_PROVIDED', 'Override the YAML provided harvester_dashbaord.admin_user')
+        stringParam('harvester_dashboard_admin_password', 'YAML_PROVIDED', 'Override the default YAML provided harvester_dashboard.admin_password')
+        stringParam('rancher_config_bootstrap_password', 'YAML_PROVIDED', 'OVerride the default YAML Provided rancher password')
+        // settings.yaml override
+        stringParam('settings_yaml_url_override', 'DEFAULT', 'overrides fetching settings.yml raw github url')
+        // tests repo info
+        stringParam('tests_repo_url', 'DEFAULT', 'overrides the default test repo for e2e tests')
+        stringParam('tests_repo_branch', 'DEFAULT', 'overrides the default test repo branch for e2e tests')
     }
     properties {
-        githubProjectUrl('https://github.com/{{ GITHUB_PROJECT }}')
+        githubProjectUrl('https://github.com/irishgordo/harvester-installer')
+        scm {
+            git {
+                remote {
+                    github('https://github.com/irishgordo/harvester-installer')
+                    refspec('+refs/pull/*:refs/remotes/origin/pr/*')
+                }
+                branch('${sha1}')
+            }
+        }
         triggers {
             githubPullRequest {
-                admin('gyee')
+                admin('admin')
                 admins(['guangyee'])
                 userWhitelist('gyee@suse.com')
                 orgWhitelist('harvester')
@@ -43,21 +76,233 @@ pipelineJob('harvester-vagrant-installation-test') {
 pipeline {
     agent any
     stages {
-        stage('Checkout harvester-install pull request') {
+        stage('initalize'){
             steps {
-                dir('harvester-installer') {
-                    checkout([$class: 'GitSCM', branches: [[name: "FETCH_HEAD"]],
-                             extensions: [[$class: 'LocalBranch']],
-                             userRemoteConfigs: [[refspec: "+refs/pull/${ghprbPullId}/head:refs/remotes/origin/PR-${ghprbPullId}", url: "https://github.com/{{ GITHUB_PROJECT }}"]]])
+                sh "echo 'initalizing, cleaning up workspace...'"
+                cleanWs(cleanWhenNotBuilt: true,
+                    deleteDirs: true,
+                    disableDeferredWipeout: false,
+                    notFailBuild: true,
+                    patterns: [[pattern: '.gitignore', type: 'INCLUDE'],
+                            [pattern: '.propsfile', type: 'EXCLUDE']])
+            }
+        }
+        stage('Pull inital Settings.YML Directly'){
+            steps{
+                script{
+                    if (params.settings_yaml_url_override != 'DEFAULT'){
+                        sh "curl ${params['settings_yaml_url_override']} > /tmp/inital_settings.yml"
+                    }else{
+                        sh "curl https://raw.githubusercontent.com/harvester/ipxe-examples/main/vagrant-pxe-harvester/settings.yml > /tmp/inital_settings.yml"
+                    }
+                }
+            }
+        }
+        stage('Read Parameters, Override YAML If Needed'){
+            steps{
+                script{
+                    def baseSettingsYaml = readYaml file: '/tmp/inital_settings.yml'
+                    sh "echo 'initial YAML Settings that will be parsed and overwritten:'"
+                    print baseSettingsYaml
+                    if (params.harvester_cluster_nodes != 'YAML_PROVIDED'){
+                        baseSettingsYaml.harvester_cluster_nodes = params.harvester_cluster_nodes.trim() as Integer
+                    }
+                    if (params.runtime_configuration == 'air_gap_single_rancher_with_harvester'){
+                        baseSettingsYaml.harvester_network_config.offline = true
+                        baseSettingsYaml.rancher_config.run_single_node_air_gapped_rancher = true
+                        baseSettingsYaml.rancher_config.run_signle_node_rancher = true
+                    }
+                    if (params.runtime_configuration == 'harvester_offline'){
+                        baseSettingsYaml.harvester_network_config.offline = true
+                        baseSettingsYaml.rancher_config.run_single_node_air_gapped_rancher = false
+                        baseSettingsYaml.rancher_config.run_single_node_rancher = false
+                    }
+                    if (params.runtime_configuration == 'normal'){
+                        baseSettingsYaml.harvester_network_config.offline = false
+                        baseSettingsYaml.rancher_config.run_single_node_air_gapped_rancher = false
+                        baseSettingsYaml.rancher_config.run_single_node_rancher = false
+                    }
+                    if (params.runtime_configuration == 'single_node_rancher_non_airgapped'){
+                        baseSettingsYaml.rancher_config.run_single_node_rancher = true
+                        baseSettingsYaml.rancher_config.run_single_node_air_gapped_rancher = false
+                        baseSettingsYaml.harvester_network_config.offline = false
+                    }
+                    if (params.runtime_configuration == 'single_node_rancher_non_airgapped_with_offline_harvester'){
+                        baseSettingsYaml.rancher_config.run_single_node_rancher = true
+                        baseSettingsYaml.rancher_config.run_single_node_air_gapped_rancher = false
+                        baseSettingsYaml.harvester_network_config.offline = true
+                    }
+                    if (params.rancher_config_node_disk_size != 'YAML_PROVIDED'){
+                        baseSettingsYaml.rancher_config.node_disk_size = params.rancher_config_node_disk_size.trim() as Integer
+                    }
+                    if (params.rancher_config_run_single_node_air_gapped_rancher != false){
+                        baseSettingsYaml.rancher_config.run_single_node_air_gapped_rancher = params.rancher_config_run_single_node_air_gapped_rancher
+                    }
+                    if (params.rancher_config_cert_manager_version != 'YAML_PROVIDED'){
+                        baseSettingsYaml.rancher_config.cert_manager_version = params.rancher_config_cert_manager_version.trim()  
+                    }
+                    if (params.rancher_config_k3s_url_escaped_version != 'YAML_PROVIDED'){
+                        baseSettingsYaml.rancher_config.k3s_url_escaped_version = params.rancher_config_k3s_url_escaped_version.trim()
+                    }
+                    if (params.rancher_config_rancher_version != 'YAML_PROVIDED'){
+                        baseSettingsYaml.rancher_config.rancher_version = params.rancher_config_rancher_version.trim()
+                        if (params.rancher_config_rancher_version_no_prefix == 'YAML_PROVIDED'){
+                            error "If you specify params.rancher_config_rancher_version you must also specify rancher_config_rancher_version_no_prefix, currently - until future implementations refactor there to be only one rancher_version and prefix is either added or removed via additional business logic."
+                        }
+                    }
+                    if (params.rancher_config_rancher_version_no_prefix != 'YAML_PROVIDED'){
+                        baseSettingsYaml.rancher_config.rancher_version_no_prefix = params.rancher_config_rancher_version_no_prefix.trim()
+                        if (params.rancher_config_rancher_version == 'YAML_PROVIDED'){
+                            error "If you specify params.rancher_config_rancher_version_no_prefix you must also specify rancher_config_rancher_version, currently - until future implementations refactor there to be only one rancher_version and prefix is either added or removed via additional business logic."
+                        }
+                    }
+                    if (params.rancher_config_cpu != 'YAML_PROVIDED'){
+                        baseSettingsYaml.rancher_config.cpu = params.rancher_config_cpu.trim() as Integer
+                    }
+                    if (params.rancher_config_memory != 'YAML_PROVIDED'){
+                        baseSettingsYaml.rancher_config.memory = params.rancher_config_memory.trim() as Integer
+                    }
+                    if (params.rancher_config_rancher_install_domain != 'YAML_PROVIDED'){
+                        baseSettingsYaml.rancher_config.rancher_install_domain = params.rancher_config_rancher_install_domain.trim()
+                    }
+                    if (params.rancher_config_registry_domain != 'YAML_PROVIDED'){
+                        baseSettingsYaml.rancher_config.registry_domain = params.rancher_config_registry_domain.trim()
+                    }
+                    if (params.rancher_config_bootstrap_password != 'YAML_PROVIDED'){
+                        baseSettingsYaml.rancher_config.bootstrap_password = params.rancher_config_bootstrap_password.trim()
+                    }
+                    if (params.harvester_dashboard_admin_user != 'YAML_PROVIDED'){
+                        baseSettingsYaml.harvester_dashboard.admin_user = params.harvester_dashboard_admin_user.trim()
+                    }
+                    if (params.harvester_dashboard_admin_password != 'YAML_PROVIDED'){
+                        baseSettingsYaml.harvester_dashboard.admin_password = params.harvester_dashboard_admin_password.trim()
+                    }
+                    def result = writeYaml file: '/tmp/inital_settings.yml', data: baseSettingsYaml, overwrite: true
+                    sh "echo 'YAML settings for this CI run is as follows, after overwriting if needed:'"
+                    print baseSettingsYaml
+                }
+            }
+        }
+        stage("Grab Tests Repo And Prepare CI E2E Image"){
+            steps{
+                script{
+                    if(params.tests_repo_url != 'DEFAULT'){
+                        dir("${params['WORKSPACE']}"){
+                            sh "git clone ${params['tests_repo_url']}"
+                        }
+                    }else{
+                        dir("${params['WORKSPACE']}"){
+                            sh "git clone https://github.com/harvester/tests.git"
+                        }
+                    }
+                    if(params.tests_repo_branch != 'DEFAULT'){
+                        dir("${params['WORKSPACE']}"){
+                            sh "cd tests && git checkout ${params['tests_repo_branch']} && make build-docker-e2e-ci-image"
+                        }
+                    }else{
+                        dir("${params['WORKSPACE']}"){
+                            sh "cd tests && make build-docker-e2e-ci-image"
+                        }
+                    }
+                }
+            }
+        }
+        stage("Acquire Harvester Installer - TEMPORARY STAGE TESTING ONLY PoC"){
+            steps{
+                script{
+                    dir("${params['WORKSPACE']}"){
+                        sh "git clone https://github.com/irishgordo/harvester-installer.git && cd harvester-installer && git checkout feat/2096-temporary-edits-testing"
+                    }
                 }
             }
         }
         stage('Test harvester-installer pull request') {
             steps {
                 script {
-                    ansiblePlaybook extras: "-e WORKSPACE=${env.WORKSPACE} -e PR_ID=${ghprbPullId} -e harvester_installer_repo_name={{ GITHUB_PROJECT }}", playbook: "${env.WORKSPACE}/harvester-installer/ci/run_vagrant_install_test.yml"
+                    ansiblePlaybook extras: "-e WORKSPACE=${env.WORKSPACE} -e PR_ID=1}", playbook: "${env.WORKSPACE}/harvester-installer/ci/run_vagrant_install_test.yml"
                 }
             }
+        }
+        stage('Test Harvester API'){
+            options {
+                timeout(time: 1, unit: "HOURS")
+            }
+            steps {
+                script{
+                    try { 
+                        docker.image('harvester_installer_e2e_ci_image:latest').inside(){
+                            sh "ls -alh"
+                            def baseSettingsYaml = readYaml file: '/tmp/inital_settings.yml'
+                            print baseSettingsYaml
+                            sh "cd tests && pytest --junitxml=result_harvester_api_latest.xml -m 'not delete_host' harvester_e2e_tests/apis --username ${baseSettingsYaml.harvester_dashboard.admin_user} --password ${baseSettingsYaml.harvester_dashboard.admin_password} --endpoint https://${baseSettingsYaml.harvester_network_config.vip.ip} --harvester_cluster_nodes ${baseSettingsYaml.harvester_cluster_nodes}"
+                        }
+                    } catch (err) {
+                        echo "failed within docker image inside command on harvester testing api stage"
+                        echo err.getMessage()
+                    }
+                }
+            }
+        }
+        stage('Test Rancher Integration'){
+            options {
+                timeout(time: 1, unit: "HOURS")
+            }
+            when{
+                anyOf{
+                    expression{
+                        return params.runtime_configuration == 'air_gap_single_rancher_with_harvester'
+                    }
+                    expression{
+                        return params.runtime_configuration == 'single_node_rancher_non_airgapped_with_offline_harvester'
+                    }
+                    expression{
+                        return params.runtime_configuration == 'single_node_rancher_non_airgapped'
+                    }
+                }
+            }
+            steps{
+                script{
+                    try{
+                        docker.image('harvester_installer_e2e_ci_image:latest').inside(){
+                            sh "ls -alh"
+                            def baseSettingsYaml = readYaml file: '/tmp/inital_settings.yml'
+                            print baseSettingsYaml
+                            sh "cd tests && pytest --junitxml=result_harvester_rancher_integration_latest.xml harvester_e2e_tests/scenarios/test_rancher_integration.py --endpoint https://${baseSettingsYaml.harvester_network_config.vip.ip} --password ${baseSettingsYaml.harvester_dashboard.admin_password} --username ${baseSettingsYaml.harvester_dashboard.admin_user} --rancher-endpoint https://${baseSettingsYaml.rancher_config.rancher_install_domain} --rancher-admin-password ${baseSettingsYaml.rancher_config.bootstrap_password}"
+                        }
+                    } catch(err) {
+                        echo err.getMessage()
+                    }
+                    
+                }
+            }
+        }        
+    }
+    post {
+        // Clean after build
+        always {
+            dir("${env.WORKSPACE}"){
+                script{
+                    try{
+                        junit 'tests/result_harvester_api_latest.xml'
+                    } catch(err) {
+                        echo err.getMessage()
+                    }
+                    try{
+                        junit 'tests/result_harvester_rancher_integration_latest.xml'
+                    } catch(err) {
+                        echo err.getMessage()
+                    }
+                    try{
+                        sh "echo '' > /var/lib/jenkins/.ssh/known_hosts"
+                    } catch(err) {
+                        echo err.getMessage()                    
+                    }
+                }
+                sh "cd ipxe-examples/vagrant-pxe-harvester/ && ls -alh && vagrant destroy -f"
+                sh "cd ${env.WORKSPACE}/tests && make destroy-docker-e2e-ci-image"
+                deleteDir()
+            }
+            cleanWs()
         }
     }
 }


### PR DESCRIPTION

Expand Harvester-Installer Vagrant Pipeline

- Adding support for single node Rancher either air-gapped or
  non-air-gapped
- Allowing for a testing stage to run tests
- Adding additional parameters to control the desired loadout for the
  Rancher instance
- Adding support to set the Harvester Dashboard password via YAML
  settings
- Additional supporting edits allowing for pipeline to be re-run with
  builds in various configurations (versions of K3s, Rancher, etc.)

Resolves: feat/2096-jenkins-pipeline-edits-for-harvester-installer-ci

