### PR TITLE
Created Basic Support Bundle Checks

### DIFF
--- a/harvester_e2e_tests/apis/test_support_bundle.py
+++ b/harvester_e2e_tests/apis/test_support_bundle.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2022 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
+import json
+import os
+import re
+import tempfile
+import zipfile
+
+import polling2
+import pytest
+from harvester_e2e_tests import utils
+
+pytest_plugins = [
+    'harvester_e2e_tests.fixtures.api_endpoints',
+    'harvester_e2e_tests.fixtures.user',
+    'harvester_e2e_tests.fixtures.session',
+    'harvester_e2e_tests.fixtures.support_bundle'
+]
+
+
+def _create_bundle(admin_session, harvester_api_endpoints):
+    """Helper function to create 'happy path' support bundle
+
+    Args:
+        admin_session (dict): fixture that gets exteneded from requests
+        harvester_api_endpoints (dict): constants harvester api endpoints
+    """
+    request_json = utils.get_json_object_from_template('support_bundle')
+    resp = admin_session.post(
+        harvester_api_endpoints.create_support_bundle, json=request_json)
+    assert resp.status_code == 201
+    resp_json = json.loads(resp.text)
+    name = resp_json.get('metadata').get('name')
+    return name, resp_json
+
+
+def test_create_missing_description(
+        admin_session, harvester_api_endpoints):
+    """Tests that description is enforced on support bundle creation
+
+    Args:
+        admin_session (dict): fixture that gets exteneded from requests
+        harvester_api_endpoints (dict): constants harvester api endpoints
+    """
+    request_json = utils.get_json_object_from_template('support_bundle')
+    del request_json['spec']['description']
+    resp = admin_session.post(
+        harvester_api_endpoints.create_support_bundle, json=request_json)
+    assert resp.status_code == 422
+    assert 'is invalid: spec.description: Required value' in resp.text
+
+
+def test_delete(admin_session, harvester_api_endpoints):
+    """Tests creating a support bundle then it's deletion
+
+    Args:
+        admin_session (dict): fixture that gets exteneded from requests
+        harvester_api_endpoints (dict): constants harvester api endpoints
+    """
+    name, _resp_json = _create_bundle(admin_session, harvester_api_endpoints)
+    delete_resp = admin_session.delete(
+        harvester_api_endpoints.delete_support_bundle + name
+    )
+    assert delete_resp.status_code == 200
+
+
+@pytest.mark.p1
+@pytest.mark.slow
+def test_creates_successful_bundle_and_downloads(
+        admin_session, harvester_api_endpoints):
+    """Creates a support bundle, validates it progresses to 100%,
+    downloads in memory as a zip file, audits the zip file to
+    ensure all needed files are present
+
+    Args:
+        admin_session (dict): fixture that gets exteneded from requests
+        harvester_api_endpoints (dict): constants harvester api endpoints
+    """
+    name, _resp_json = _create_bundle(admin_session, harvester_api_endpoints)
+    progress = 0
+
+    def _wait_for_progress_to_be_ready():
+        nonlocal progress
+        resp_progress_check = admin_session.get(
+            harvester_api_endpoints.view_support_bundle +
+            name)
+        json_progress_result = json.loads(resp_progress_check.text)
+        progress = json_progress_result.get('status', {}).get('progress', 0)
+        if progress != 100:
+            return False
+        return True
+
+    try:
+        polling2.poll(
+            _wait_for_progress_to_be_ready,
+            step=5,
+            timeout=300
+        )
+    except Exception as ex:
+        raise f'Timed out waiting for support bundle: {ex}'
+
+    temp_dir = tempfile.mkdtemp()
+    zip_file_location = os.path.join(temp_dir, 'support_bundle.zip')
+    resp_download = admin_session.get(
+        harvester_api_endpoints.download_support_bundle +
+        name +
+        '/download')
+    with open(zip_file_location, 'wb') as zip_file:
+        zip_file.write(resp_download.content)
+    files = None
+    with zipfile.ZipFile(zip_file_location, 'r') as zip_file:
+        files = zip_file.namelist()
+
+    patterns = [r"^.*/logs/cattle-fleet-local-system/fleet-agent-.*/fleet-agent.log",
+                r"^.*/logs/cattle-fleet-system/fleet-controller-.*/fleet-controller.log",
+                r"^.*/logs/cattle-fleet-system/gitjob-.*/gitjob.log"]
+    matches = []
+    for f in files:
+        for pattern in patterns:
+            matches.extend([f] if re.match(pattern, f) else [])
+            print(f)
+            print(pattern)
+
+    err_msg = ("Some file(s) not found,"
+               f"files: {matches}\n"
+               f"patterns: {patterns}")
+    assert len(matches) == len(patterns), err_msg

--- a/harvester_e2e_tests/fixtures/support_bundle.py
+++ b/harvester_e2e_tests/fixtures/support_bundle.py
@@ -1,0 +1,19 @@
+from harvester_e2e_tests import utils
+import pytest
+
+
+@pytest.fixture(scope='class')
+def support_bundle(request, kubevirt_api_version, admin_session,
+                   harvester_api_endpoints):
+    request_json = utils.get_json_object_from_template(
+        'support_bundle',
+        name='testing-e2e-api-support-bundle',
+        description='A testing based support bundle',
+        issue_url=''
+    )
+    resp = admin_session.post(harvester_api_endpoints.create_support_bundle,
+                              json=request_json)
+    assert resp.status_code == 201, ('Unable to create a basic ' +
+                                     'supportbundle: %s' % (resp.content))
+    support_bundle_data = resp.json()
+    yield support_bundle_data

--- a/harvester_e2e_tests/templates/api_endpoints.json.j2
+++ b/harvester_e2e_tests/templates/api_endpoints.json.j2
@@ -58,5 +58,9 @@
     "delete_vm_template": "{{ harvester_endpoint }}/apis/{{ harvester_api_version }}/namespaces/harvester-public/virtualmachinetemplates/%s",
     "create_vm_template_version": "{{ harvester_endpoint }}/apis/{{ harvester_api_version }}/namespaces/harvester-public/virtualmachinetemplateversions",
     "list_vm_template_versions": "{{ harvester_endpoint }}/apis/{{ harvester_api_version }}/namespaces/harvester-public/virtualmachinetemplateversions",
-    "delete_vm_template_version": "{{ harvester_endpoint }}/apis/{{ harvester_api_version }}/namespaces/harvester-public/virtualmachinetemplateversions/%s"
+    "delete_vm_template_version": "{{ harvester_endpoint }}/apis/{{ harvester_api_version }}/namespaces/harvester-public/virtualmachinetemplateversions/%s",
+    "create_support_bundle": "{{ harvester_endpoint }}/apis/harvesterhci.io/v1beta1/namespaces/harvester-system/supportbundles",
+    "view_support_bundle": "{{ harvester_endpoint }}/apis/harvesterhci.io/v1beta1/namespaces/harvester-system/supportbundles/",
+    "download_support_bundle": "{{ harvester_endpoint }}/v1/harvester/supportbundles/",
+    "delete_support_bundle": "{{ harvester_endpoint }}/apis/harvesterhci.io/v1beta1/namespaces/harvester-system/supportbundles/"
 }

--- a/harvester_e2e_tests/templates/basic_support_bundle.json.j2
+++ b/harvester_e2e_tests/templates/basic_support_bundle.json.j2
@@ -1,0 +1,14 @@
+{# Template for basic Harvester support bundle creation request. #}
+{
+    "apiVersion": "harvesterhci.io/v1beta1",
+    "kind": "SupportBundle",
+    "metadata": {
+        "name": "bundle-test",
+        "namespace": "harvester-system"
+    },
+    "spec": {
+        "description": "Testing Support Bundle",
+        "issueURL": ""
+    },
+    "type": "harvesterhci.io.supportbundle"
+}

--- a/harvester_e2e_tests/templates/support_bundle.json.j2
+++ b/harvester_e2e_tests/templates/support_bundle.json.j2
@@ -1,0 +1,24 @@
+{# Template for basic support bundle request #}
+{% if name is not defined or name is none %}
+    {% set name = random_name() %}
+{% endif %}
+{% if description is not defined or name is none %}
+    {% set description = random_name() %}
+{% endif %}
+{% if issue_url is not defined or issue_url is none%}
+    {% set issue_url = "" %}
+{% endif %}
+
+
+{
+    "apiVersion": "harvesterhci.io/v1beta1",
+    "kind": "SupportBundle",
+    "metadata": {
+        "generateName": "{{ name }}-",
+        "namespace": "harvester-system"
+    },
+    "spec": {
+        "description": "{{ description }}",
+        "issueURL": "{{ issue_url }}"
+    }
+}

--- a/tox.ini
+++ b/tox.ini
@@ -25,5 +25,8 @@ deps = flake8
 commands =
   flake8
 
+[flake8]
+max-line-length = 99
+
 [pytest]
 render_collapsed = True


### PR DESCRIPTION
- adding basic support_bundle api test functionality
- per PEP8, it's acceptable to have line length up to 99 characters,
  excluding docstrings, increased flake8 tox.ini configuration of
  increased max line length

Resolves: 350-collect-fleet-logs-in-support-bundle