### PR TITLE
purify ascii color code

### DIFF
--- a/harvester_e2e_tests/utils.py
+++ b/harvester_e2e_tests/utils.py
@@ -35,6 +35,7 @@ import tempfile
 import time
 import uuid
 import yaml
+import re
 
 
 def retry_session():
@@ -61,6 +62,10 @@ def retry_session():
 def random_name():
     """Generate a random alphanumeric name using uuid.uuid4()"""
     return uuid.uuid4().hex
+
+
+def remove_ansicode(string):
+    return re.sub(r"\x1b|\[\d+m", "", string)
 
 
 def random_alphanumeric(length=5, upper_case=False):
@@ -937,6 +942,9 @@ def create_image_terraform(request, admin_session, harvester_api_endpoints,
         request, 'terraform.sh', 'terraform')
     result = subprocess.run([terraform_script], shell=True,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    result.stdout = remove_ansicode(result.stdout.decode())
+    result.stderr = remove_ansicode(result.stderr.decode())
+
     assert result.returncode == 0, (
         'Failed to run terraform : rc: %s, stdout: %s, stderr: %s' % (
             result.returncode, result.stderr, result.stdout))
@@ -985,6 +993,9 @@ def destroy_resource(request, admin_session, destroy_type=None):
             request, 'terraform_destroy.sh', 'terraform') + ' ' + destroy_type
         result = subprocess.run([terraform_script], shell=True,
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        result.stdout = remove_ansicode(result.stdout.decode())
+        result.stderr = remove_ansicode(result.stderr.decode())
+
         assert result.returncode == 0, (
             'Failed to run terraform : rc: %s, stdout: %s, stderr: %s' % (
                 result.returncode, result.stderr, result.stdout))
@@ -1017,6 +1028,9 @@ def create_volume_terraform(request, admin_session, harvester_api_endpoints,
         request, 'terraform.sh', 'terraform')
     result = subprocess.run([terraform_script], shell=True,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    result.stdout = remove_ansicode(result.stdout.decode())
+    result.stderr = remove_ansicode(result.stderr.decode())
+
     assert result.returncode == 0, (
         'Failed to run terraform : rc: %s, stdout: %s, stderr: %s' % (
             result.returncode, result.stderr, result.stdout))
@@ -1050,6 +1064,9 @@ def create_keypair_terraform(request, admin_session, harvester_api_endpoints,
         request, 'terraform.sh', 'terraform')
     result = subprocess.run([terraform_script], shell=True,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    result.stdout = remove_ansicode(result.stdout.decode())
+    result.stderr = remove_ansicode(result.stderr.decode())
+
     assert result.returncode == 0, (
         'Failed to run terraform : rc: %s, stdout: %s, stderr: %s' % (
             result.returncode, result.stderr, result.stdout))
@@ -1092,6 +1109,9 @@ def create_network_terraform(request, admin_session, harvester_api_endpoints,
 
     result = subprocess.run([terraform_script], shell=True,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    result.stdout = remove_ansicode(result.stdout.decode())
+    result.stderr = remove_ansicode(result.stderr.decode())
+
     assert result.returncode == 0, (
         'Failed to run terraform : rc: %s, stdout: %s, stderr: %s' % (
             result.returncode, result.stderr, result.stdout))
@@ -1128,6 +1148,9 @@ def create_clusternetworks_terraform(request, admin_session,
         request, 'terraform.sh', 'terraform') + ' ' + 'cluster'
     result = subprocess.run([terraform_script], shell=True,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    result.stdout = remove_ansicode(result.stdout.decode())
+    result.stderr = remove_ansicode(result.stderr.decode())
+
     assert result.returncode == 0, (
         'Failed to run terraform : rc: %s, stdout: %s, stderr: %s' % (
             result.returncode, result.stderr, result.stdout))
@@ -1172,6 +1195,9 @@ def create_vm_terraform(request, admin_session, harvester_api_endpoints,
         request, 'terraform.sh', 'terraform')
     result = subprocess.run([terraform_script], shell=True,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    result.stdout = remove_ansicode(result.stdout.decode())
+    result.stderr = remove_ansicode(result.stderr.decode())
+
     assert result.returncode == 0, (
         'Failed to run terraform : rc: %s, stdout: %s, stderr: %s' % (
             result.returncode, result.stderr, result.stdout))


### PR DESCRIPTION
This will remove ascii color code from the terraform command, to increase the error message readability.

error message will be changed from:
```
AssertionError: Failed to run terraform : rc: 1, stdout: b'\x1b[31m\x1b[31m\xe2\x95\xb7\x1b[0m\x1b[0m\n\x1b[31m\xe2\x94\x82\x1b[0m \x1b[0m\x1b[1m\x1b[31mError: \x1b[0m\x1b[0m\x1b[1mFailed to install provider\x1b[0m\n\x1b[31m\xe2\x94\x82\x1b[0m \x1b[0m\n\x1b[31m\xe2\x94\x82\x1b[0m \x1b[0m\x1b[0mError while installing harvester/harvester v0.3.2: could not query provider\n\x1b[31m\xe2\x94\x82\x1b[0m \x1b[0mregistry for registry.terraform.io/harvester/harvester: failed to retrieve\n\x1b[31m\xe2\x94\x82\x1b[0m \x1b[0mcryptographic signature for provider: 403 Server failed to authenticate the\n\x1b[31m\xe2\x94\x82\x1b[0m \x1b[0mrequest. Make sure the value of Authorization header is formed correctly\n\x1b[31m\xe2\x94\x82\x1b[0m \x1b[0mincluding the signature.\n\x1b[31m\xe2\x95\xb5\x1b[0m\x1b[0m\n\x1b[0m\x1b[0m\n', stderr: b'/var/harvester_test_310_harvester-install-and-test-e2e-daily/terraform_test_artifacts/terraformharvester /var/harvester_test_310_harvester-install-and-test-e2e-daily\n\n\x1b[0m\x1b[1mInitializing the backend...\x1b[0m\n\n\x1b[0m\x1b[1mInitializing provider plugins...\x1b[0m\n- Finding harvester/harvester versions matching "~> 0.3.2"...\n'
```
to
```
AssertionError: Failed to run terraform : rc: 1, stdout: ╷
│ Error: Failed to install provider
│ 
│ Error while installing harvester/harvester v0.3.2: could not query provider
│ registry for registry.terraform.io/harvester/harvester: failed to retrieve
│ cryptographic signature for provider: 403 Server failed to authenticate the
│ request. Make sure the value of Authorization header is formed correctly
│ including the signature.
╵

, stderr: /var/harvester_test_310_harvester-install-and-test-e2e-daily/terraform_test_artifacts/terraformharvester /var/harvester_test_310_harvester-install-and-test-e2e-daily

Initializing the backend...

Initializing provider plugins...
- Finding harvester/harvester versions matching "~> 0.3.2"...

```