### PR TITLE
Fix daily testing errors

### DIFF
--- a/harvester_e2e_tests/fixtures/network.py
+++ b/harvester_e2e_tests/fixtures/network.py
@@ -127,9 +127,13 @@ def network(request, admin_session, harvester_api_endpoints, enable_vlan):
     yield network_data
 
     if not request.config.getoption('--do-not-cleanup'):
-        _cleanup_network(admin_session, harvester_api_endpoints,
-                         network_data['id'],
-                         request.config.getoption('--wait-timeout'))
+        # XXX: we would need to check the network not be deleted terraform yet
+        if not utils.is_marker_enabled(request, 'terraform') and \
+            _lookup_network(request, admin_session, harvester_api_endpoints,
+                            vlan_id) is not None:
+            _cleanup_network(admin_session, harvester_api_endpoints,
+                             network_data['id'],
+                             request.config.getoption('--wait-timeout'))
 
 
 @pytest.fixture(scope='class')

--- a/harvester_e2e_tests/scenarios/test_vm_negatives.py
+++ b/harvester_e2e_tests/scenarios/test_vm_negatives.py
@@ -100,10 +100,10 @@ class TestHostDown:
     def test_vm_after_host_reboot(self, request, admin_session,
                                   harvester_api_endpoints, basic_vm):
         # make sure the VM instance is successfully created and running
-        vm_instance_json = utils.lookup_vm_instance(
-            admin_session, harvester_api_endpoints, basic_vm)
         utils.assert_vm_ready(request, admin_session, harvester_api_endpoints,
                               basic_vm["metadata"]["name"], True)
+        vm_instance_json = utils.lookup_vm_instance(
+            admin_session, harvester_api_endpoints, basic_vm)
 
         node_name = vm_instance_json['status']['nodeName']
         # Reboot VM

--- a/harvester_e2e_tests/scenarios/test_vm_networking.py
+++ b/harvester_e2e_tests/scenarios/test_vm_networking.py
@@ -740,9 +740,6 @@ def test_create_vm_using_terraform(request, admin_session,
         timeout = request.config.getoption('--wait-timeout')
         (vm_instance_json, public_ip) = get_vm_public_ip(
             admin_session, harvester_api_endpoints, vm_json, timeout)
-
-#       assert_ssh_into_vm(public_ip, timeout, keypair=keypair_using_terraform)
-
     finally:
         if created:
             if not request.config.getoption('--do-not-cleanup'):


### PR DESCRIPTION
Changes:
- For `test_vm_after_host_reboot` case, change to wait VM before get the vm instance information, it should resolve the `nodeName` missing sometimes
- for `test_create_vm_using_terraform` case, change to skip network deletion when it is deleted via terraform


### the case of `test_create_vm_using_terraform`
![image](https://user-images.githubusercontent.com/5169694/180200348-ae7bccae-fff6-4a81-91a9-5ef9a614fa9d.png)

According the error message above, it is not caused by the test case itself, but the teardown execution order.
When you look into to the [test_vm_networking.py](https://github.com/harvester/tests/blob/main/harvester_e2e_tests/scenarios/test_vm_networking.py), the first test case is `TestVMNetworking`, and its `test_ssh_to_vm` will trigger VLAN creation (via the argument `vms_with_vlan_as_default_network`).
The fixture of [network](https://github.com/harvester/tests/blob/f35236f80f18efcfb0f3c542440e29d468bba462/harvester_e2e_tests/fixtures/network.py#L118) be marked as `session` scope, it will be teardown after all test cases executed.
so Test case execution order will be:
```
# test_vm_networking.py
-> TestVMnetworking
=> Setup fixtures including network
-> execute test cases
=> Teardown fixutures which scope is not *session*
...
-> execute test_create_vm_using_terraform
=> destroy all resources including vlan network
=< Teardown fixtures which scope is *session*
```

It is the reason why I add the checker to skip `_cleanup_network` execution.
(I think we should fix it in a graceful way, but consider other solutions might affect more test cases, this fix should be the minimal affection.)