### PR TITLE
fix cases: templates, host shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ terraform_test_artifacts/bin
 *config
 .idea
 node_modules
+scripts/**/*.sh

--- a/harvester_e2e_tests/apis/test_vm_templates.py
+++ b/harvester_e2e_tests/apis/test_vm_templates.py
@@ -23,10 +23,12 @@ pytest_plugins = [
   ]
 
 DEFAULT_TEMPLATES = 4
+DEFAULT_TEMPLATES_NAMESPACE = 'namespaces/harvester-public'
 
 
 def test_verify_default_vm_templates(admin_session, harvester_api_endpoints):
-    resp = admin_session.get(harvester_api_endpoints.list_vm_templates)
+    resp = admin_session.get(harvester_api_endpoints.list_vm_templates.replace(
+                             "namespaces/default", DEFAULT_TEMPLATES_NAMESPACE))
     assert resp.status_code == 200, (
         'Failed to list virtual machine templates: %s' % (resp.content))
     vm_templates = resp.json()
@@ -35,7 +37,8 @@ def test_verify_default_vm_templates(admin_session, harvester_api_endpoints):
 
 def test_verify_default_vm_template_versions(admin_session,
                                              harvester_api_endpoints):
-    resp = admin_session.get(harvester_api_endpoints.list_vm_template_versions)
+    resp = admin_session.get(harvester_api_endpoints.list_vm_template_versions.replace(
+                             "namespaces/default", DEFAULT_TEMPLATES_NAMESPACE))
     assert resp.status_code == 200, (
         'Failed to list virtual machine template versions: %s' % (
             resp.content))


### PR DESCRIPTION
Targeting on daily testing build `#348`, Changes:
- `test_vm_templates.py`: add the constant of _default_ namespace for default templates.
   - `harvester-public` is fixed in https://github.com/harvester/harvester/blob/master/pkg/data/public.go#L10 [^1][^2]
   - Consider we have the namespace `default`, so this should be the way to fix those errors. (and the constant value should follow the source code mentioned above)
- `test_vm_negatives.py`: add checker to make sure host already down before checking the VM.
    - The VM will temporarily unavailable (few mins) when host is down, to hit the criteria, we need to make sure the host already down.
    - To test this case on **Vagrant** environment, you most create `power_off.sh` and `power_on.sh` in `scripts/vagrant`
- Update `.gitignore` to ignore any `.sh` files under `scripts/` folder to avoid expose your customized script.
- Update `utils.py`
    - Fix the bug introduced in https://github.com/harvester/tests/commit/56220aa2835f4cf957f2713c98b362276f03b3cc#diff-464193ef53ea9143d7e439fb4e196095366312371f50630a137624ad1cfb6780L535 , test case `scenarios/test_create_vm.py::test_create_vm_do_not_start` is affected
    - Improve error message when `assert_vm_restarted` is failed, test case `scenarios/test_vm_negatives.py::TestHostDown::test_vm_after_host_reboot` is affected

[^1]: https://github.com/harvester/harvester/blob/master/pkg/data/template.go#L63-L64
[^2]: https://github.com/harvester/harvester/blob/master/pkg/data/add.go#L26
