### PR TITLE
Fix: Adjust Harvester Permissions

### DIFF
--- a/CI/harvester-installer/roles/jenkins/templates/config_jenkins_as_code.yaml.j2
+++ b/CI/harvester-installer/roles/jenkins/templates/config_jenkins_as_code.yaml.j2
@@ -12,14 +12,10 @@ jenkins:
   authorizationStrategy:
     globalMatrix:
       permissions:
-        - "Job/Build:{{ JENKINS_DEV_USERNAME }}"
-        - "Job/Cancel:{{ JENKINS_DEV_USERNAME }}"
         - "Job/Read:{{ JENKINS_DEV_USERNAME }}"
-        - "Job/Workspace:{{ JENKINS_DEV_USERNAME }}"
         - "Overall/Administer:{{ JENKINS_ADMIN_USERNAME }}"
         - "Overall/Read:authenticated"
         - "Run/Replay:{{ JENKINS_DEV_USERNAME }}"
-        - "Run/Update:{{ JENKINS_DEV_USERNAME }}"
   remotingSecurity:
     enabled: true
 


### PR DESCRIPTION
This is the implementation of:
https://github.com/harvester/tests/issues/505

We currently do not have an automated way of provisioning this on our bare-metal Equinix nodes, due to the fact the scripts are broken for provisioning, at least within this branch.  We can for a small footprint change make edits still, yet accepting that the repository is still broken even with the edits merged in.

If we just isolate this change as a file change - we can test leveraging a separate branch that has the same permission edits.

## Test Plan

### Main Objective:
- validate that the Matrix-Role Based Authorization is properly set up leveraging Jenkins Configuration as Code

### Testing Pre-Reqs:
- having Ansible installed
- having the ability to create an Ubuntu 20.04 virtual-machine ( ideally 4C & 8GiB of Memory - disk size around 60GiB if possible )

### How to test:
1. `git clone https://github.com/irishgordo/tests.git` 
1. `git checkout feat/2096-infrastructure-provisioning-edits` - since that branch provides a working, implementation of these scripts
1. visually compare `CI/harvester-installer/roles/jenkins/templates/config_jenkins_as_code.yaml.j2` to the one here in this PR: https://github.com/harvester/tests/pull/507/files
1. create a VM that is running 20.04 Ubuntu, ( https://cloud-images.ubuntu.com/releases/focal/release/  ) ( ubuntu-20.04-server-cloudimg-amd64.img ) with a user 
1. log in to the VM that has 20.04 Ubuntu running on it, add your laptop's/workstation's SSH key to the `~/.ssh/authorized_keys`, or if you were using Harvester to provision the VM you could use some cloud-config:
```
#cloud-config
package_update: true
packages:
  - qemu-guest-agent
runcmd:
  - - systemctl
    - enable
    - --now
    - qemu-guest-agent.service
ssh_authorized_keys:
  - your-key
``` 
1. update the `tests/CI/harvester-installer/inventory.harvester-ci` for the section of:
```
[harvester-ci]
master ansible_host=to_be_your_ip ansible_user=to_be_your_user
```
1. from `tests/CI/harvester-installer/settings.yml.sample` copy that to `tests/CI/harvester-installer/settings.yml`:
```
# update the values of:
JENKINS_USE_PROXY: False
JENKINS_PROXY_ENABLE_SSL: False
JENKINS_PUBLIC_ENDPOINT: https://the_ip_address_of_the_20.04_ubuntu_vm_that_is_running
```
1. use the Ansible script to provision Jenkins on your VM with:
```
ANSIBLE_ENABLE_TASK_DEBUGGER=True ansible-playbook -i inventory.harvester-ci install_jenkins.yml -vvvv
```
(this way there is extra verbosity if the test strategy fails)
1. check that provisioning succeeds
1. validate you can navigate to jenkins via your https://your_virtual_machine_of_ubuntu_2004_ip_addr:8080
1. validate that in a `private` window in your browser that you can log in as the `admin`, navigate to Manage Jenkins -> Configure Global Security - then look at the Authorization section to validate user `harvester`'s authorization is the same as what exists in the: https://github.com/harvester/tests/pull/507/files
1.  validate you can log in as the `harvester` user and see the single job
1.  validate that you can not run/replay/build that job

#### Test Helper Screenshots For Demonstration:
#### NOTE: These are older screenshots and may not represent the entire story, but more of used as a general guide

![admin_can_see_harvester_user_matrix_security](https://user-images.githubusercontent.com/5370752/189784488-61d7c9fb-84f0-4438-a1c5-5338254eaa39.png)
![validate_harvester_user_dashboard_is_view_based](https://user-images.githubusercontent.com/5370752/189784492-6bf0bb16-0119-4116-9993-3bca57d767ad.png)
![validate_harvester_user_can_only_view](https://user-images.githubusercontent.com/5370752/189784495-a5bdaf33-0d1f-4ce1-a38f-ec76dc48a4eb.png)


#### NOTE: This will not create any automated change, as there is no rollout scripts and also the repository is broken, this doesn't fix #488 - which has had work done on it in `feat/2096-infrastructure-provisioning-edits` to fix these broken scripts