### PR TITLE
Create the new upgrade category manual test plan and add initial test plan

### DIFF
--- a/docs/content/manual/upgrade/_index.md
+++ b/docs/content/manual/upgrade/_index.md
@@ -1,0 +1,4 @@
+---
+title: Upgrade Harvester
+---
+These are some basic tests for upgrading Harvester

--- a/docs/content/manual/upgrade/bonded-nics-traditional-network-upgrade.md
+++ b/docs/content/manual/upgrade/bonded-nics-traditional-network-upgrade.md
@@ -1,0 +1,96 @@
+---
+title: Upgrade Harvester with bonded NICs on network
+---
+
+* Related issues: [#3047](https://github.com/harvester/harvester/issues/3047) [BUG] migrate_harv_mgmt_to_mgmt_br.sh should remove ClusterNetwork resource
+
+
+## Category: 
+* Upgrade Harvester
+
+## Environment setup from v1.0.3 upgrade to v1.1.1
+1. Clone ipxe-example and switch to `v1.0` branch 
+1. Add three additional Network interface in `Vagrantfile`
+    ```
+      harvester_node.vm.network 'private_network',
+        libvirt__network_name: 'harvester',
+        mac: @settings['harvester_network_config']['cluster'][node_number]['mac']
+      harvester_node.vm.network 'private_network',
+        libvirt__network_name: 'harvester'
+      harvester_node.vm.network 'private_network',
+        libvirt__network_name: 'harvester'
+      harvester_node.vm.network 'private_network',
+        libvirt__network_name: 'harvester'
+    ```
+1. Edit the config-create.yaml.j2 and config-join.yaml.j2 in /ansible/role/harvester/template/
+1. Add the cluster_network and defaultPysicalNIC to `harvester-mgmt` 
+    ```
+    cluster_networks:
+      vlan:
+        enable: true
+        description: "some description about this cluster network"
+        config:
+          defaultPhysicalNIC: harvester-mgmt
+    
+    ```
+1. Bond multiple NICs on `harvester-mgmt` and `harvester-vlan` networks
+    ```
+    networks:
+        harvester-mgmt:
+          interfaces:
+          - name: {{ settings['harvester_network_config']['cluster'][0]['mgmt_interface'] }}  # The management interface name
+          - name: ens9
+          method: dhcp
+        bond0:
+          interfaces:
+          - name: {{ settings['harvester_network_config']['cluster'][0]['vagrant_interface'] }}
+          method: dhcp
+        harvester-vlan:
+          interfaces:
+          - name: ens7
+          - name: ens8
+          method: none
+    
+    ```
+
+## Verification Steps
+1. Provision previous version of Harvester cluster
+1. For `VLAN 1` testing, enable network on settings, select `harvester-mgmt`
+1. Create a `vlan1` network with id `1` on Networks page 
+    ![image](https://user-images.githubusercontent.com/29251855/201606104-a1e23fd0-f04b-409e-818e-d1c514fea4e5.png)
+1. For other VLAN id testing, enable network on settings, select correct network interface e.g `enps0f1`
+    ![image](https://user-images.githubusercontent.com/29251855/201609582-d9e129f2-1c1e-416f-b878-9df4903ad2e2.png)
+1. Create a `vlan91` network with available id `91` on Networks page (id number depends on your available network setting)
+    ![image](https://user-images.githubusercontent.com/29251855/201609880-22bf619c-d215-403a-8299-63c62934cfe2.png)
+
+1. Create images with different OS distribution
+1. Create several virtual machines, set network to `management-network` or available `vlan` 
+1. Create virtual machine on different target node
+1. Setup NFS or S3 backup target in settings
+1. Backup each virtual machines
+1. Shutdown all virtual machines
+1. Offline upgrade to target version, refer to https://docs.harvesterhci.io/v1.1/upgrade/automatic
+
+
+## Expected Results
+1. Can completely upgrade Harvester to specific version
+1. Cluster Network exists
+  ![image](https://user-images.githubusercontent.com/29251855/201101725-a028bc80-da8d-4708-8ecf-d3b5c7c66d0d.png)
+1. Can create Vlan 1 on mgmt and route correctly
+1. Can create other valid VLAN on specific NIC and route correctly
+1. Check the network connectivity of vlan and management network
+1. All pods are running correctly
+1. Check can display Monitoring Chart 
+   - Prometheus dashboard
+   - VM metrics
+1. Can access dashboard by VIP
+1. Can use original password to login
+1. Can start VM in running status
+1. Image exists without corrupted
+1. Volume exists
+1. Virtual network exists
+1. Backup exists
+1. Setting value exists
+1. Can restore VM from backup
+1. Can create new VMs
+

--- a/docs/content/manual/upgrade/bonded-nics-traditional-network-upgrade.md
+++ b/docs/content/manual/upgrade/bonded-nics-traditional-network-upgrade.md
@@ -92,5 +92,4 @@ title: Upgrade Harvester with bonded NICs on network
 1. Backup exists
 1. Setting value exists
 1. Can restore VM from backup
-1. Can create new VMs
-
+1. Can create new VMs (test)

--- a/docs/content/manual/upgrade/fully-airgapped-upgrade.md
+++ b/docs/content/manual/upgrade/fully-airgapped-upgrade.md
@@ -7,8 +7,10 @@ title: Upgrade Harvester in Fully Airgapped Environment
 
 ## Environment requirement
 1. Airgapped Network without internet connectivity
-1. Network environment have available VLAN id setup on DHCP server can be assigned to Harvester
-1. Network have at least two NICs
+1. Network environment has available VLAN id setup on DHCP server
+1. DHCP server has setup the IP range can allocate to above VLAN id
+1. Harvester node can route to DHCP server through VLAN id to retrieve IP address
+1. Network has at least two NICs
 1. Suggest not to use SMR type HDD disk
 
 #### We can select VM or Bare machine network setup according to your available resource

--- a/docs/content/manual/upgrade/fully-airgapped-upgrade.md
+++ b/docs/content/manual/upgrade/fully-airgapped-upgrade.md
@@ -1,0 +1,70 @@
+---
+title: Upgrade Harvester in Fully Airgapped Environment
+---
+
+## Category: 
+* Upgrade Harvester
+
+## Environment requirement
+1. Airgapped Network without internet connectivity
+1. Network environment have available VLAN id setup on DHCP server can be assigned to Harvester
+1. Network have at least two NICs
+1. Suggest each Harvester node have at lease 6 core CPU, 16GB memory and 200GB disk
+1. Suggest not to use SMR type HDD disk
+
+#### We can select VM or Bare machine network setup according to your available resource
+
+## Virtual Machine environment setup
+1. Clone ipxe-example https://github.com/harvester/ipxe-examples
+1. Switch to v1.0 or main branch
+1. Edit Vagrantfile, add a new network interface of `pxe_server.vm.network` 
+1. Set the `pxe_server.vm.network` bond to correct `libvirt` network
+1. Add two additional new network interface of `harvester_node.vm.network`
+1. Edit the settings.yml, set `harvester_network_config.offline: true`
+1. Use ipxe-example to provision a multi nodes Harvester cluster
+1. Run `varant ssh pxe_server` to access pxe server 
+1. Edit the `dhcpd.conf`, let pxe server can create a vlan and assign IP to it 
+
+## Bare machine environment setup
+1. Ensure your switch router have setup VLAN network
+1. Setup the VLAN connectivity to your Router/Gateway device
+1. Disable internet connectivity on Router 
+1. Provision a multi nodes Harvester cluster
+
+
+## Verification Steps
+1. For `VLAN 1` testing, enable network on settings, select `harvester-mgmt`
+1. Create a `vlan1` network with id `1` on Networks page 
+    ![image](https://user-images.githubusercontent.com/29251855/201606104-a1e23fd0-f04b-409e-818e-d1c514fea4e5.png)
+1. For other VLAN id testing, enable network on settings, select correct network interface e.g `enps0f1`
+    ![image](https://user-images.githubusercontent.com/29251855/201609582-d9e129f2-1c1e-416f-b878-9df4903ad2e2.png)
+1. Create a `vlan91` network with available id `91` on Networks page (id number depends on your available network setting)
+    ![image](https://user-images.githubusercontent.com/29251855/201609880-22bf619c-d215-403a-8299-63c62934cfe2.png)
+
+1. Create images with different OS distribution
+1. Create several virtual machines, set network to `management-network` or available `vlan` 
+1. Create virtual machine on different target node
+1. Setup NFS or S3 backup target in settings
+1. Back each virtual machines
+1. Shutdow all virtual machines
+1. Offline upgrade to traget version, refer to https://docs.harvesterhci.io/v1.1/upgrade/automatic
+
+
+## Expected Results
+1. Can completely upgrade Harvester to specific version
+1. All pods is running correctly
+1. Check can display Monitoring Chart 
+   - Prometheus dashboard
+   - VM metrics
+1. Can access dashboard by VIP
+1. Can use original password to login
+1. Can start VM in running status
+1. Image exists without corrupted
+1. Volume exists
+1. Virtual network exists
+1. Backup exists
+1. Setting value exists
+1. Can restore VM from backup
+
+
+

--- a/docs/content/manual/upgrade/fully-airgapped-upgrade.md
+++ b/docs/content/manual/upgrade/fully-airgapped-upgrade.md
@@ -9,7 +9,6 @@ title: Upgrade Harvester in Fully Airgapped Environment
 1. Airgapped Network without internet connectivity
 1. Network environment have available VLAN id setup on DHCP server can be assigned to Harvester
 1. Network have at least two NICs
-1. Suggest each Harvester node have at lease 6 core CPU, 16GB memory and 200GB disk
 1. Suggest not to use SMR type HDD disk
 
 #### We can select VM or Bare machine network setup according to your available resource
@@ -45,14 +44,14 @@ title: Upgrade Harvester in Fully Airgapped Environment
 1. Create several virtual machines, set network to `management-network` or available `vlan` 
 1. Create virtual machine on different target node
 1. Setup NFS or S3 backup target in settings
-1. Back each virtual machines
-1. Shutdow all virtual machines
-1. Offline upgrade to traget version, refer to https://docs.harvesterhci.io/v1.1/upgrade/automatic
+1. Backup each virtual machines
+1. Shutdown all virtual machines
+1. Offline upgrade to target version, refer to https://docs.harvesterhci.io/v1.1/upgrade/automatic
 
 
 ## Expected Results
 1. Can completely upgrade Harvester to specific version
-1. All pods is running correctly
+1. All pods are running correctly
 1. Check can display Monitoring Chart 
    - Prometheus dashboard
    - VM metrics
@@ -65,6 +64,7 @@ title: Upgrade Harvester in Fully Airgapped Environment
 1. Backup exists
 1. Setting value exists
 1. Can restore VM from backup
+1. Can create new VMs
 
 
 

--- a/docs/content/manual/upgrade/ipv6-dhcp-upgrade.md
+++ b/docs/content/manual/upgrade/ipv6-dhcp-upgrade.md
@@ -44,11 +44,11 @@ title: Upgrade Harvester with IPv6 DHCP
 
 
 ## Verification Steps
-1. Create a VM and use the ipv6 network. (workload)
-1. ISO install v1.0.3 in create mode
+1. Create a VM and use the customized ipv6 virtual network. (workload)
+1. Doing an Harvester v1.0.3 ISO install with `create` new mode
 1. Select DHCP node ip and DHCP vip during the installation 
-1. Create another VMs and use the ipv6 network. (workload)
-1. ISO install v1.0.3 in join mode
+1. Create another VMs use the customized ipv6 virtual network
+1. Doing an Harvester v1.0.3 ISO install with `join` mode
 1. Select DHCP node ip and DHCP vip during the installation
 1. Offline upgrade to master release, refer to https://docs.harvesterhci.io/v1.1/upgrade/automatic
 1. Check host IP on Host page 
@@ -61,20 +61,20 @@ title: Upgrade Harvester with IPv6 DHCP
   ![image](https://user-images.githubusercontent.com/29251855/201028253-5dee39dd-67d4-41c0-a38d-09ac397f3983.png)
   
 1. Access node machine, check the IP information
-  ```
-  harv103-master:~ # kubectl get nodes -o json | jq '.items[].status.addresses'
-  [
-    {
-      "address": "192.168.101.162",
-      "type": "InternalIP"
-    },
-    {
-      "address": "harv103-master",
-      "type": "Hostname"
-    }
-  ]
-  
-  ```
+    ```
+    harv103-master:~ # kubectl get nodes -o json | jq '.items[].status.addresses'
+    [
+      {
+        "address": "192.168.101.162",
+        "type": "InternalIP"
+      },
+      {
+        "address": "harv103-master",
+        "type": "Hostname"
+      }
+    ]
+    
+    ```
 1. Check the network connectivity of vlan and management network
 1. Can completely upgrade Harvester to specific version
 1. All pods are running correctly

--- a/docs/content/manual/upgrade/ipv6-dhcp-upgrade.md
+++ b/docs/content/manual/upgrade/ipv6-dhcp-upgrade.md
@@ -39,6 +39,7 @@ title: Upgrade Harvester with IPv6 DHCP
     ```
     
 1. Change the bridge name to a new one 
+
     ![image](https://user-images.githubusercontent.com/29251855/201565649-ba54d6f7-3540-4a4b-ad66-ee4a77cfbff1.png)
 
 
@@ -75,5 +76,19 @@ title: Upgrade Harvester with IPv6 DHCP
   
   ```
 1. Check the network connectivity of vlan and management network
-
+1. Can completely upgrade Harvester to specific version
+1. All pods are running correctly
+1. Check can display Monitoring Chart 
+   - Prometheus dashboard
+   - VM metrics
+1. Can access dashboard by VIP
+1. Can use original password to login
+1. Can start VM in running status
+1. Image exists without corrupted
+1. Volume exists
+1. Virtual network exists
+1. Backup exists
+1. Setting value exists
+1. Can restore VM from backup
+1. Can create new VMs
 

--- a/docs/content/manual/upgrade/ipv6-dhcp-upgrade.md
+++ b/docs/content/manual/upgrade/ipv6-dhcp-upgrade.md
@@ -1,0 +1,79 @@
+---
+title: Upgrade Harvester with IPv6 DHCP 
+---
+
+* Related issues: [#2962](https://github.com/harvester/harvester/issues/2962) [BUG] Host IP is inconsistent
+
+
+## Category: 
+* Upgrade Harvester
+
+## Environment setup
+1. Open the virtual machine manager 
+1. Open the Connection Details -> Virtual Networks
+1. Create a new virtual network `workload`
+1. Add the following XML content 
+    ```
+    <network>
+    <name>workload</name>
+    <uuid>ac62e6bf-6869-41a9-a2b7-25c06c7601c9</uuid>
+    <forward mode="nat">
+        <nat>
+        <port start="1024" end="65535"/>
+        </nat>
+    </forward>
+    <bridge name="virbr5" stp="on" delay="0"/>
+    <mac address="52:54:00:7b:ed:99"/>
+    <domain name="workload"/>
+    <ip address="192.168.101.1" netmask="255.255.255.0">
+        <dhcp>
+        <range start="192.168.101.128" end="192.168.101.254"/>
+        </dhcp>
+    </ip>
+    <ip family="ipv6" address="fd7d:844d:3e17:f3ae::1" prefix="64">
+        <dhcp>
+        <range start="fd7d:844d:3e17:f3ae::100" end="fd7d:844d:3e17:f3ae::1ff"/>
+        </dhcp>
+    </ip>
+    </network>
+    ```
+    
+1. Change the bridge name to a new one 
+    ![image](https://user-images.githubusercontent.com/29251855/201565649-ba54d6f7-3540-4a4b-ad66-ee4a77cfbff1.png)
+
+
+## Verification Steps
+1. Create a VM and use the ipv6 network. (workload)
+1. ISO install v1.0.3 in create mode
+1. Select DHCP node ip and DHCP vip during the installation 
+1. Create another VMs and use the ipv6 network. (workload)
+1. ISO install v1.0.3 in join mode
+1. Select DHCP node ip and DHCP vip during the installation
+1. Offline upgrade to master release, refer to https://docs.harvesterhci.io/v1.1/upgrade/automatic
+1. Check host IP on Host page 
+1. Check the ip allocated to node `kubectl get nodes -o json | jq '.items[].status.addresses'` 
+
+
+## Expected Results
+1. Can completely upgrade from v1.0.3 to v1.1.0
+1. The Host IP should not display IPv6 information and no `Host IP is inconsistent` error
+  ![image](https://user-images.githubusercontent.com/29251855/201028253-5dee39dd-67d4-41c0-a38d-09ac397f3983.png)
+  
+1. Access node machine, check the IP information
+  ```
+  harv103-master:~ # kubectl get nodes -o json | jq '.items[].status.addresses'
+  [
+    {
+      "address": "192.168.101.162",
+      "type": "InternalIP"
+    },
+    {
+      "address": "harv103-master",
+      "type": "Hostname"
+    }
+  ]
+  
+  ```
+1. Check the network connectivity of vlan and management network
+
+

--- a/docs/content/manual/upgrade/rejoin-node-after-upgrade.md
+++ b/docs/content/manual/upgrade/rejoin-node-after-upgrade.md
@@ -13,7 +13,6 @@ title: Rejoin node machine after Harveter upgrade
 ## Environment requirement
 1. Network environment have available VLAN id setup on DHCP server can be assigned to Harvester
 1. Network have at least two NICs
-1. Suggest each Harvester node have at lease 6 core CPU, 16GB memory and 200GB disk
 1. Suggest not to use SMR type HDD disk
 
 
@@ -21,14 +20,14 @@ title: Rejoin node machine after Harveter upgrade
 1. Create a 3 nodes v1.0.3 Harvester cluster.
 1. Upgrade the master branch:
 1. Remove the agent node and 1 management node.
-   - Remove agent node (node 4)
-  ![image](https://user-images.githubusercontent.com/29251855/196138324-83b64d50-0236-4110-86c2-551ae046a406.png)
-  ![image](https://user-images.githubusercontent.com/29251855/196138906-e77de8f0-d61d-4a91-82b2-e36cbbb6462a.png)
-  
-  - Remove management node (node 3)
-  ![image](https://user-images.githubusercontent.com/29251855/196139707-ce8cc444-21fb-4bba-a040-9b09e0ae7fa9.png)
-  ![image](https://user-images.githubusercontent.com/29251855/196139906-ff92320f-f5f7-4fb5-af20-5cf0f3fe36b9.png)
-  ![image](https://user-images.githubusercontent.com/29251855/196147230-7c0b1835-c219-41b2-b0b8-32bae9962f27.png)
+      - Remove agent node (node 4)
+     ![image](https://user-images.githubusercontent.com/29251855/196138324-83b64d50-0236-4110-86c2-551ae046a406.png)
+     ![image](https://user-images.githubusercontent.com/29251855/196138906-e77de8f0-d61d-4a91-82b2-e36cbbb6462a.png)
+     
+     - Remove management node (node 3)
+     ![image](https://user-images.githubusercontent.com/29251855/196139707-ce8cc444-21fb-4bba-a040-9b09e0ae7fa9.png)
+     ![image](https://user-images.githubusercontent.com/29251855/196139906-ff92320f-f5f7-4fb5-af20-5cf0f3fe36b9.png)
+     ![image](https://user-images.githubusercontent.com/29251855/196147230-7c0b1835-c219-41b2-b0b8-32bae9962f27.png)
 
 1. After the node is removed, provision a new node.
 1. Check the node can join the cluster and can be promoted as a management node.
@@ -40,7 +39,8 @@ title: Rejoin node machine after Harveter upgrade
 1. Can re-join the management node after upgrade 
   ![image](https://user-images.githubusercontent.com/29251855/196159969-9c8acb11-b9fe-4501-94d5-74545579ef4d.png)
 
-1. re-join the agent node after upgrade 
+1. Can re-join the agent node after upgrade 
   ![image](https://user-images.githubusercontent.com/29251855/196164183-20c4498a-c4c6-4033-a527-d3c8ff84f8aa.png)
-
+1. Can create new vms on the newly joined node.
+1. Can restore vms/migrate on the newly joined node.
 

--- a/docs/content/manual/upgrade/rejoin-node-after-upgrade.md
+++ b/docs/content/manual/upgrade/rejoin-node-after-upgrade.md
@@ -1,9 +1,8 @@
 ---
-title: Rejoin node machine after Harveter upgrade
+title: Rejoin node machine after Harvester upgrade
 ---
 
-* Related issues: [#2655](https://github.com/harvester/harvester/issues/2655) 
-[BUG] reinstall 1st node
+* Related issues: [#2655](https://github.com/harvester/harvester/issues/2655) [BUG] reinstall 1st node
 
 
 ## Category: 
@@ -11,8 +10,10 @@ title: Rejoin node machine after Harveter upgrade
 
 
 ## Environment requirement
-1. Network environment have available VLAN id setup on DHCP server can be assigned to Harvester
-1. Network have at least two NICs
+1. Network environment has available VLAN id setup on DHCP server
+1. DHCP server has setup the IP range can allocate to above VLAN id
+1. Harvester node can route to DHCP server through VLAN id to retrieve IP address
+1. Network has at least two NICs
 1. Suggest not to use SMR type HDD disk
 
 

--- a/docs/content/manual/upgrade/rejoin-node-after-upgrade.md
+++ b/docs/content/manual/upgrade/rejoin-node-after-upgrade.md
@@ -1,0 +1,46 @@
+---
+title: Rejoin node machine after Harveter upgrade
+---
+
+* Related issues: [#2655](https://github.com/harvester/harvester/issues/2655) 
+[BUG] reinstall 1st node
+
+
+## Category: 
+* Upgrade Harvester
+
+
+## Environment requirement
+1. Network environment have available VLAN id setup on DHCP server can be assigned to Harvester
+1. Network have at least two NICs
+1. Suggest each Harvester node have at lease 6 core CPU, 16GB memory and 200GB disk
+1. Suggest not to use SMR type HDD disk
+
+
+## Verification Steps
+1. Create a 3 nodes v1.0.3 Harvester cluster.
+1. Upgrade the master branch:
+1. Remove the agent node and 1 management node.
+   - Remove agent node (node 4)
+  ![image](https://user-images.githubusercontent.com/29251855/196138324-83b64d50-0236-4110-86c2-551ae046a406.png)
+  ![image](https://user-images.githubusercontent.com/29251855/196138906-e77de8f0-d61d-4a91-82b2-e36cbbb6462a.png)
+  
+  - Remove management node (node 3)
+  ![image](https://user-images.githubusercontent.com/29251855/196139707-ce8cc444-21fb-4bba-a040-9b09e0ae7fa9.png)
+  ![image](https://user-images.githubusercontent.com/29251855/196139906-ff92320f-f5f7-4fb5-af20-5cf0f3fe36b9.png)
+  ![image](https://user-images.githubusercontent.com/29251855/196147230-7c0b1835-c219-41b2-b0b8-32bae9962f27.png)
+
+1. After the node is removed, provision a new node.
+1. Check the node can join the cluster and can be promoted as a management node.
+1. After we have 3 management nodes, provision a new node and check if it can join the cluster.
+
+## Expected Results
+1. Verify after Harvester upgrade complete, we **can rejoin** the management node and agent node back correctly. 
+
+1. Can re-join the management node after upgrade 
+  ![image](https://user-images.githubusercontent.com/29251855/196159969-9c8acb11-b9fe-4501-94d5-74545579ef4d.png)
+
+1. re-join the agent node after upgrade 
+  ![image](https://user-images.githubusercontent.com/29251855/196164183-20c4498a-c4c6-4033-a527-d3c8ff84f8aa.png)
+
+

--- a/docs/content/manual/upgrade/upgrade-from-new-network-design.md
+++ b/docs/content/manual/upgrade/upgrade-from-new-network-design.md
@@ -45,7 +45,7 @@ We can select VM or Bare machine network setup according to available resource
 1. Create several virtual machines, set network to `management-network` or available `vlan` 
 1. Create virtual machine on different target node
 1. Setup NFS or S3 backup target in settings
-1. Back each virtual machines
+1. Backup each virtual machines
 1. Shutdown all virtual machines
 1. Offline upgrade to target version, refer to https://docs.harvesterhci.io/v1.1/upgrade/automatic
 1. Import Harvester into the Rancher cluster

--- a/docs/content/manual/upgrade/upgrade-from-new-network-design.md
+++ b/docs/content/manual/upgrade/upgrade-from-new-network-design.md
@@ -7,8 +7,10 @@ title: Upgrade Harvester from new cluster network design (after v1.1.0)
 * Upgrade Harvester
 
 ## Environment requirement
-1. Network environment have available VLAN id setup on DHCP server can be assigned to Harvester
-1. Network have at least two NICs
+1. Network environment has available VLAN id setup on DHCP server
+1. DHCP server has setup the IP range can allocate to above VLAN id
+1. Harvester node can route to DHCP server through VLAN id to retrieve IP address
+1. Network has at least two NICs
 1. Suggest not to use SMR type HDD disk
 
 We can select VM or Bare machine network setup according to available resource
@@ -44,16 +46,16 @@ We can select VM or Bare machine network setup according to available resource
 1. Create virtual machine on different target node
 1. Setup NFS or S3 backup target in settings
 1. Back each virtual machines
-1. Shutdow all virtual machines
-1. Offline upgrade to traget version, refer to https://docs.harvesterhci.io/v1.1/upgrade/automatic
+1. Shutdown all virtual machines
+1. Offline upgrade to target version, refer to https://docs.harvesterhci.io/v1.1/upgrade/automatic
 1. Import Harvester into the Rancher cluster
-1. Adding node after the upgrade
+1. Add node after the upgrade
 
 
 ## Expected Results
 1. Can completely upgrade Harvester to specific version
-1. All pods is running correctly
-1. Check can display Monitoring Chart 
+1. All pods are running correctly
+1. Check that can display the Monitoring Chart 
    - Prometheus dashboard
    - VM metrics
 1. Can access dashboard by VIP

--- a/docs/content/manual/upgrade/upgrade-from-new-network-design.md
+++ b/docs/content/manual/upgrade/upgrade-from-new-network-design.md
@@ -1,0 +1,73 @@
+---
+title: Upgrade Harvester from new cluster network design (after v1.1.0)
+---
+
+
+## Category: 
+* Upgrade Harvester
+
+## Environment requirement
+1. Network environment have available VLAN id setup on DHCP server can be assigned to Harvester
+1. Network have at least two NICs
+1. Suggest each Harvester node have at lease 6 core CPU, 16GB memory and 200GB disk
+1. Suggest not to use SMR type HDD disk
+
+We can select VM or Bare machine network setup according to available resource
+
+## Virtual Machine environment setup
+1. Clone ipxe-example https://github.com/harvester/ipxe-examples
+1. Switch to main branch 
+1. Edit Vagrantfile, add a new network interface of `pxe_server.vm.network` 
+1. Set the `pxe_server.vm.network` bond to correct `libvirt` network
+1. Add two additional new network interface of `harvester_node.vm.network`
+1. Use ipxe-example to provision a multi nodes Harvester cluster
+1. Run `varant ssh pxe_server` to access pxe server 
+1. Edit the `dhcpd.conf`, let pxe server can create a vlan and assign IP to it 
+
+## Bare machine environment setup
+1. Ensure your switch router have setup available VLAN network
+1. Setup the VLAN connectivity to your Router/Gateway device
+1. Provision a multi nodes Harvester cluster
+
+
+## Verification Steps
+1. Open Cluster Networks/Configs
+1. Create a new cluster network `vlan`
+1. Create a network config under cluster network `vlan`
+1. Select which node to use this config
+1. Select NICs on the uplink page 
+1. Open Networks page
+1. Create vlan `1` network on `mgmt` cluster network
+1. Create another vlan network on `vlan` cluster network in step 3
+    ![image](https://user-images.githubusercontent.com/29251855/201615070-969e6c34-1a8e-4540-a750-32f7f38b585c.png)
+1. Create images with different OS distribution
+1. Create several virtual machines, set network to `management-network` or available `vlan` 
+1. Create virtual machine on different target node
+1. Setup NFS or S3 backup target in settings
+1. Back each virtual machines
+1. Shutdow all virtual machines
+1. Offline upgrade to traget version, refer to https://docs.harvesterhci.io/v1.1/upgrade/automatic
+1. Import Harvester into the Rancher cluster
+1. Adding node after the upgrade
+
+
+## Expected Results
+1. Can completely upgrade Harvester to specific version
+1. All pods is running correctly
+1. Check can display Monitoring Chart 
+   - Prometheus dashboard
+   - VM metrics
+1. Can access dashboard by VIP
+1. Can use original password to login
+1. Can start VM in running status
+1. Image exists without corrupted
+1. Volume exists
+1. Virtual network exists
+1. Backup exists
+1. Setting value exists
+1. Check the network connectivity of VLAN
+1. Can restore VM from backup 
+1. Can import Harvester in Rancher
+1. Can add additional nodes to existing Harvester cluster
+
+

--- a/docs/content/manual/upgrade/upgrade-from-new-network-design.md
+++ b/docs/content/manual/upgrade/upgrade-from-new-network-design.md
@@ -9,7 +9,6 @@ title: Upgrade Harvester from new cluster network design (after v1.1.0)
 ## Environment requirement
 1. Network environment have available VLAN id setup on DHCP server can be assigned to Harvester
 1. Network have at least two NICs
-1. Suggest each Harvester node have at lease 6 core CPU, 16GB memory and 200GB disk
 1. Suggest not to use SMR type HDD disk
 
 We can select VM or Bare machine network setup according to available resource
@@ -69,5 +68,6 @@ We can select VM or Bare machine network setup according to available resource
 1. Can restore VM from backup 
 1. Can import Harvester in Rancher
 1. Can add additional nodes to existing Harvester cluster
+1. Can create new vms
 
 

--- a/docs/content/manual/upgrade/upgrade-from-traditional-network-design.md
+++ b/docs/content/manual/upgrade/upgrade-from-traditional-network-design.md
@@ -7,8 +7,11 @@ title: Upgrade Harvester from traditonal cluster network design (before v1.1.0)
 * Upgrade Harvester
 
 ## Environment requirement
-1. Network environment have available VLAN id setup on DHCP server can be assigned to Harvester
-1. Network have at least two NICs
+1. Network environment has available VLAN id setup on DHCP server
+1. DHCP server has setup the IP range can allocate to above VLAN id
+1. Harvester node can route to DHCP server through VLAN id to retrieve IP address
+1. Network has at least two NICs
+1. Network has at least two NICs
 1. Suggest not to use SMR type HDD disk
 
 We can select VM or Bare machine network setup according to available resource
@@ -46,7 +49,7 @@ We can select VM or Bare machine network setup according to available resource
 1. Shutdown all virtual machines
 1. Offline upgrade to target version, refer to https://docs.harvesterhci.io/v1.1/upgrade/automatic
 1. Import Harvester into the Rancher cluster
-1. Adding node after the upgrade
+1. Add node after the upgrade
 
 
 ## Expected Results

--- a/docs/content/manual/upgrade/upgrade-from-traditional-network-design.md
+++ b/docs/content/manual/upgrade/upgrade-from-traditional-network-design.md
@@ -1,0 +1,72 @@
+---
+title: Upgrade Harvester from traditonal cluster network design (before v1.1.0)
+---
+
+
+## Category: 
+* Upgrade Harvester
+
+## Environment requirement
+1. Network environment have available VLAN id setup on DHCP server can be assigned to Harvester
+1. Network have at least two NICs
+1. Suggest each Harvester node have at lease 6 core CPU, 16GB memory and 200GB disk
+1. Suggest not to use SMR type HDD disk
+
+We can select VM or Bare machine network setup according to available resource
+
+## Virtual Machine environment setup
+1. Clone ipxe-example https://github.com/harvester/ipxe-examples
+1. Switch to v1.0 branch 
+1. Edit Vagrantfile, add a new network interface of `pxe_server.vm.network` 
+1. Set the `pxe_server.vm.network` bond to correct `libvirt` network
+1. Add two additional new network interface of `harvester_node.vm.network`
+1. Use ipxe-example to provision a multi nodes Harvester cluster
+1. Run `varant ssh pxe_server` to access pxe server 
+1. Edit the `dhcpd.conf`, let pxe server can create a vlan and assign IP to it 
+
+## Bare machine environment setup
+1. Ensure your switch router have setup available VLAN network
+1. Setup the VLAN connectivity to your Router/Gateway device
+1. Provision a multi nodes Harvester cluster
+
+
+## Verification Steps
+1. For `VLAN 1` testing, enable network on settings, select `harvester-mgmt`
+1. Create a `vlan1` network with id `1` on Networks page 
+    ![image](https://user-images.githubusercontent.com/29251855/201606104-a1e23fd0-f04b-409e-818e-d1c514fea4e5.png)
+1. For other VLAN id testing, enable network on settings, select correct network interface e.g `enps0f1`
+    ![image](https://user-images.githubusercontent.com/29251855/201609582-d9e129f2-1c1e-416f-b878-9df4903ad2e2.png)
+1. Create a `vlan91` network with available id `91` on Networks page (id number depends on your available network setting)
+    ![image](https://user-images.githubusercontent.com/29251855/201609880-22bf619c-d215-403a-8299-63c62934cfe2.png)
+
+1. Create images with different OS distribution
+1. Create several virtual machines, set network to `management-network` or available `vlan` 
+1. Create virtual machine on different target node
+1. Setup NFS or S3 backup target in settings
+1. Back each virtual machines
+1. Shutdow all virtual machines
+1. Offline upgrade to traget version, refer to https://docs.harvesterhci.io/v1.1/upgrade/automatic
+1. Import Harvester into the Rancher cluster
+1. Adding node after the upgrade
+
+
+## Expected Results
+1. Can completely upgrade Harvester to specific version
+1. All pods is running correctly
+1. Check can display Monitoring Chart 
+- Prometheus dashboard
+- VM metrics
+1. Can access dashboard by VIP
+1. Can use original password to login
+1. Can start VM in running status
+1. Image exists without corrupted
+1. Volume exists
+1. Virtual network exists
+1. Backup exists
+1. Setting value exists
+1. Check the network connectivity of VLAN
+1. Can restore VM from backup 
+1. Can import Harvester in Rancher
+1. Can add additional nodes to existing Harvester cluster
+
+

--- a/docs/content/manual/upgrade/upgrade-from-traditional-network-design.md
+++ b/docs/content/manual/upgrade/upgrade-from-traditional-network-design.md
@@ -9,7 +9,6 @@ title: Upgrade Harvester from traditonal cluster network design (before v1.1.0)
 ## Environment requirement
 1. Network environment have available VLAN id setup on DHCP server can be assigned to Harvester
 1. Network have at least two NICs
-1. Suggest each Harvester node have at lease 6 core CPU, 16GB memory and 200GB disk
 1. Suggest not to use SMR type HDD disk
 
 We can select VM or Bare machine network setup according to available resource
@@ -43,9 +42,9 @@ We can select VM or Bare machine network setup according to available resource
 1. Create several virtual machines, set network to `management-network` or available `vlan` 
 1. Create virtual machine on different target node
 1. Setup NFS or S3 backup target in settings
-1. Back each virtual machines
-1. Shutdow all virtual machines
-1. Offline upgrade to traget version, refer to https://docs.harvesterhci.io/v1.1/upgrade/automatic
+1. Backup each virtual machines
+1. Shutdown all virtual machines
+1. Offline upgrade to target version, refer to https://docs.harvesterhci.io/v1.1/upgrade/automatic
 1. Import Harvester into the Rancher cluster
 1. Adding node after the upgrade
 
@@ -54,8 +53,8 @@ We can select VM or Bare machine network setup according to available resource
 1. Can completely upgrade Harvester to specific version
 1. All pods is running correctly
 1. Check can display Monitoring Chart 
-- Prometheus dashboard
-- VM metrics
+   - Prometheus dashboard
+   - VM metrics
 1. Can access dashboard by VIP
 1. Can use original password to login
 1. Can start VM in running status
@@ -68,5 +67,6 @@ We can select VM or Bare machine network setup according to available resource
 1. Can restore VM from backup 
 1. Can import Harvester in Rancher
 1. Can add additional nodes to existing Harvester cluster
+1. Can create new vms
 
 

--- a/docs/content/manual/upgrade/upgrade-with-HDD-disk.md
+++ b/docs/content/manual/upgrade/upgrade-with-HDD-disk.md
@@ -1,0 +1,61 @@
+---
+title: Upgrade Harvester with HDD Disks
+---
+
+
+## Category: 
+* Upgrade Harvester
+
+## Environment requirement
+1. Network environment have available VLAN id setup on DHCP server can be assigned to Harvester
+1. Network have at least two NICs
+1. Use HDD disk with SMR type or slow I/O speed
+    ```
+    n1-103:~ # smartctl -a /dev/sda
+    smartctl 7.2 2021-09-14 r5237...
+    === START OF INFORMATION SECTION ===
+    Model Family:     Seagate BarraCuda 3.5 (SMR)
+    ```
+
+## Verification Steps
+1. Create images with different OS distribution
+1. Create several virtual machines, set network to `management-network` or available `vlan` 
+1. Create virtual machine on different target node
+1. Setup NFS or S3 backup target in settings
+1. Backup each virtual machines
+1. Shutdown all virtual machines
+1. Offline upgrade to target version, refer to https://docs.harvesterhci.io/v1.1/upgrade/automatic
+1. Apply the increase the job deadline workaround before clicking the upgrade button on dashboard
+    ```
+    $ cat > /tmp/fix.yaml <<EOF
+    spec:
+    values:
+        systemUpgradeJobActiveDeadlineSeconds: "3600"
+    EOF
+
+    $ kubectl patch managedcharts.management.cattle.io local-managed-system-upgrade-controller --namespace fleet-local --patch-file=/tmp/fix.yaml --type merge
+    $ kubectl -n cattle-system rollout restart deploy/system-upgrade-controller
+    ```
+
+
+## Expected Results
+1. Can completely upgrade Harvester to specific version
+1. All pods is running correctly
+1. Check can display Monitoring Chart 
+   - Prometheus dashboard
+   - VM metrics
+1. Can access dashboard by VIP
+1. Can use original password to login
+1. Can start VM in running status
+1. Image exists without corrupted
+1. Volume exists
+1. Virtual network exists
+1. Backup exists
+1. Setting value exists
+1. Check the network connectivity of VLAN
+1. Can restore VM from backup 
+1. Can import Harvester in Rancher
+1. Can add additional nodes to existing Harvester cluster
+1. Can create new vms
+
+

--- a/docs/content/manual/upgrade/upgrade-with-HDD-disk.md
+++ b/docs/content/manual/upgrade/upgrade-with-HDD-disk.md
@@ -7,8 +7,10 @@ title: Upgrade Harvester with HDD Disks
 * Upgrade Harvester
 
 ## Environment requirement
-1. Network environment have available VLAN id setup on DHCP server can be assigned to Harvester
-1. Network have at least two NICs
+1. Network environment has available VLAN id setup on DHCP server
+1. DHCP server has setup the IP range can allocate to above VLAN id
+1. Harvester node can route to DHCP server through VLAN id to retrieve IP address
+1. Network has at least two NICs
 1. Use HDD disk with SMR type or slow I/O speed
     ```
     n1-103:~ # smartctl -a /dev/sda


### PR DESCRIPTION
Create the new upgrade category manual test plan and add major test
cases including:

1. Upgrade from new network design (1.1.0 and after)
2. Upgrade from traditional network design (before v1.1.0)
3. Upgrade in fully airpagged network
4. Upgrade with ipv6 DHCP network
5. Rejoin node machine after upgrade