### PR TITLE
update e2e testing scenarios

### DIFF
--- a/apiclient/harvester_api/api.py
+++ b/apiclient/harvester_api/api.py
@@ -5,7 +5,8 @@ from pkg_resources import parse_version
 from requests.packages.urllib3.util.retry import Retry
 
 from .managers import (HostManager, KeypairManager, ImageManager, SettingManager,
-                       NetworkManager, VolumeManager, TemplateManager, SupportBundlemanager)
+                       NetworkManager, VolumeManager, TemplateManager, SupportBundlemanager,
+                       ClusterNetworkManager)
 
 
 class HarvesterAPI:
@@ -42,6 +43,7 @@ class HarvesterAPI:
         self.templates = TemplateManager(self)
         self.supportbundle = SupportBundlemanager(self)
         self.settings = SettingManager(self)
+        self.clusternetworks = ClusterNetworkManager(self)
 
     @property
     def cluster_version(self):

--- a/apiclient/harvester_api/managers.py
+++ b/apiclient/harvester_api/managers.py
@@ -422,8 +422,13 @@ class NetworkManager(BaseManager):
             "apiVersion": self.API_VERSION,
             "kind": self._KIND,
             "metadata": {
-                "labels": {
-                    "network.harvesterhci.io/type": "L2VlanNetwork"
+                "annotations": {
+                    "network.harvesterhci.io/route": json.dumps({
+                        "mode": "auto",
+                        "serverIPAddr": "",
+                        "cidr": "",
+                        "gateway": ""
+                    })
                 },
                 "name": name,
                 "namespace": namespace
@@ -448,7 +453,7 @@ class NetworkManager(BaseManager):
 
     def create(self, name, vlan_id, namespace=DEFAULT_NAMESPACE, *,
                cluster_network=None, raw=False):
-        cluster_network = cluster_network or self._default_cluster_network()
+        cluster_network = f"{cluster_network}-br" if cluster_network else self._default_cluster_network()
         data = self.create_data(name, namespace, vlan_id, cluster_network)
         path = self.PATH_fmt.format(uid="", ns=namespace, NETWORK_API=self.API_VERSION)
         return self._create(path, json=data, raw=raw)
@@ -514,4 +519,103 @@ class SupportBundlemanager(BaseManager):
 
     def delete(self, uid, *, raw=False):
         path = self.PATH_fmt.format(uid=uid)
+        return self._delete(path, raw=raw)
+
+
+class ClusterNetworkManager(BaseManager):
+    PATH_fmt = "apis/network.{{API_VERSION}}/clusternetworks/{uid}"
+    CONFIG_fmt = "apis/network.{{API_VERSION}}/vlanconfigs/{uid}"
+    _default_bond_mode = "active-backup"
+
+    def create_data(self, name, description="", labels=None, annotations=None):
+        data = {
+            "apiVersion": "network.{API_VERSION}",
+            "kind": "ClusterNetwork",
+            "metadata": {
+                "annotations": {
+                    "field.cattle.io/description": description
+                },
+                "labels": labels or dict(),
+                "name": name
+            }
+
+        }
+
+        if annotations is not None:
+            data['metadata']['annotations'].update(annotations)
+
+        return self._inject_data(data)
+
+    def create_config_data(self, name, clusternetwork, *nics,
+                           bond_mode=None, hostname=None, miimon=None, mtu=None):
+        data = {
+            "apiVersion": "network.{API_VERSION}",
+            "kind": "VlanConfig",
+            "metadata": {
+                "name": name
+            },
+            "spec": {
+                "clusterNetwork": clusternetwork,
+                "uplink": {
+                    "bondOptions": {
+                        "mode": bond_mode or self._default_bond_mode,
+                    },
+                    "nics": nics
+                }
+            }
+        }
+
+        if hostname is not None:
+            data['spec']['nodeSelector']["kubernetes.io/hostname"] = hostname
+
+        if miimon is not None:
+            data['spec']['uplink']['bondOptions']['miimon'] = miimon
+
+        if mtu is not None:
+            data['spec']['uplink']["linkAttributes"] = {
+                "mtu": mtu
+            }
+
+        return self._inject_data(data)
+
+    def get(self, name="", raw=False):
+        path = self.PATH_fmt.format(uid=name)
+        return self._get(path, raw=raw)
+
+    def create(self, name, description="", labels=None, annotations=None, *, raw=False):
+        data = self.create_data(name, description, labels, annotations)
+        path = self.PATH_fmt.format(uid="")
+        return self._create(path, json=data, raw=raw)
+
+    def update(self, name, data, *, raw=False, as_json=True, **kwargs):
+        path = self.PATH_fmt.format(uid=name)
+        if isinstance(data, Mapping) and as_json:
+            _, node = self.get(name)
+            data = merge_dict(data, node)
+        return self._update(path, data, raw=raw, as_json=as_json, **kwargs)
+
+    def delete(self, name, *, raw=False):
+        path = self.PATH_fmt.format(uid=name)
+        return self._delete(path, raw=raw)
+
+    def get_config(self, name="", raw=False):
+        path = self.CONFIG_fmt.format(uid=name)
+        return self._get(path, raw=raw)
+
+    def create_config(self, name, clusternetwork, *nics,
+                      bond_mode=None, hostname=None, miimon=None, mtu=None, raw=False):
+        data = self.create_config_data(name, clusternetwork, *nics, bond_mode=bond_mode,
+                                       hostname=hostname, miimon=miimon, mtu=mtu)
+        path = self.CONFIG_fmt.format(uid=name)
+        return self._create(path, json=data, raw=raw)
+
+    def update_config(self, name, data, *, raw=False, as_json=True, **kwargs):
+        path = self.CONFIG_fmt.format(uid=name)
+        if isinstance(data, Mapping) and as_json:
+            _, node = self.get_config(name)
+            data = merge_dict(data, node)
+        return self._update(path, data, raw=raw, as_json=as_json, **kwargs)
+
+    def delete_config(self, name, *, raw=False):
+        path = self.CONFIG_fmt.format(uid=name)
         return self._delete(path, raw=raw)

--- a/apiclient/harvester_api/managers.py
+++ b/apiclient/harvester_api/managers.py
@@ -411,7 +411,9 @@ class NetworkManager(BaseManager):
     API_VERSION = "k8s.cni.cncf.io/v1"
     _KIND = "NetworkAttachmentDefinition"
 
-    def _default_cluster_network(self):
+    def _bridge_name(self, cluster_network=None):
+        if cluster_network is not None:
+            return f"{cluster_network}-br"
         if self.api.cluster_version >= parse_version("v1.1.0"):
             return "mgmt-br"
         else:
@@ -453,8 +455,7 @@ class NetworkManager(BaseManager):
 
     def create(self, name, vlan_id, namespace=DEFAULT_NAMESPACE, *,
                cluster_network=None, raw=False):
-        cluster_network = f"{cluster_network}-br" if cluster_network else self._default_cluster_network()
-        data = self.create_data(name, namespace, vlan_id, cluster_network)
+        data = self.create_data(name, namespace, vlan_id, self._bridge_name(cluster_network))
         path = self.PATH_fmt.format(uid="", ns=namespace, NETWORK_API=self.API_VERSION)
         return self._create(path, json=data, raw=raw)
 


### PR DESCRIPTION
## Changes
- Implement `ClusterNetworkManager` in apiclient for relevant API calls
- Update fixture `enable_vlan` to create cluster network when the Harvester version over `v1.0.3`

## Will not fix
### need to update terraform test cases and resources
- [ ] harvester_e2e_tests/integration/test_terraform.py::test_create_network_using_terraform::setup  
- [ ] harvester_e2e_tests/integration/test_terraform.py::test_create_volume_using_terraform::setup   
- [ ] harvester_e2e_tests/scenarios/test_vm_networking.py::test_create_vm_using_terraform::setup   
### randomly failed, need to figure a better way to test
- [ ] harvester_e2e_tests/scenarios/test_create_vm.py::test_create_vm_on_available_cpu_node  
- [ ] harvester_e2e_tests/scenarios/test_create_vm.py::test_update_vm_on_available_cpu_node  
### `affinity` will be added, but while update VM, affinity will be removed automatically, need to check whether it is API issue or not
- [ ] harvester_e2e_tests/scenarios/test_vm_networking.py::TestVMNetworking::test_remove_vlan_network_from_vm 
- [ ] harvester_e2e_tests/scenarios/test_vm_networking.py::test_update_vm_vlan_network_to_management