### PR TITLE
[CY] delete deleteProgramlly function

### DIFF
--- a/cypress/pageobjects/virtualmachine.po.ts
+++ b/cypress/pageobjects/virtualmachine.po.ts
@@ -1,5 +1,3 @@
-import cookie from 'cookie';
-
 import { Constants } from "@/constants/constants";
 import { HCI } from '@/constants/types';
 import LabeledSelectPo from '@/utils/components/labeled-select.po';
@@ -315,20 +313,5 @@ export class VmsPage extends CruResourcePo {
 
   efiEnabled() {
     return new CheckboxPo('.checkbox-container', `:contains("Booting in EFI mode")`)
-  }
-
-  deleteProgramlly(id:string) {
-    const { CSRF } = cookie.parse(document.cookie);
-
-    cy.request({
-      url: `/v1/harvester/${HCI.VM}s/${ id }`,
-      headers: {
-        accept: 'application/json',
-        'x-api-csrf': CSRF,
-      },
-      method: 'DELETE',
-    }).then(res => {
-      expect(res.status).to.equal(200);
-    })
   }
 }

--- a/cypress/testcases/VM settings/cloud-config-templates.spec.ts
+++ b/cypress/testcases/VM settings/cloud-config-templates.spec.ts
@@ -1,7 +1,4 @@
-import YAML from 'js-yaml'
-
 import cloudConfigTemplatePage from "@/pageobjects/cloudConfigTemplate.po";
-import { LoginPage } from "@/pageobjects/login.po";
 import { Constants } from "@/constants/constants";
 import {generateName} from '@/utils/utils';
 
@@ -115,8 +112,8 @@ describe("Check Create network data && Edit && clone", () => {
           expect(type, 'Check template data').to.equal('network');
           expect(data?.cloudInit, 'Check clouded network data').to.equal(editedData);
       
-          cloudConfig.deleteProgramlly(`${namespace}/${name}`)
-          cloudConfig.deleteProgramlly(`${namespace}/${cloneName}`)
+          cloudConfig.deleteFromStore(`${namespace}/${name}`)
+          cloudConfig.deleteFromStore(`${namespace}/${cloneName}`)
         })
       })
     })

--- a/cypress/testcases/networks/network.spec.ts
+++ b/cypress/testcases/networks/network.spec.ts
@@ -75,7 +75,7 @@ describe('Check network with DHCP', () => {
       }
     })
 
-    network.deleteProgramlly(`${namespace}/${name}`)
+    network.deleteFromStore(`${namespace}/${name}`)
   });
 });
 
@@ -120,7 +120,7 @@ describe('Check network with Manual Mode', () => {
       }
     })
 
-    network.deleteProgramlly(`${namespace}/${name}`)
+    network.deleteFromStore(`${namespace}/${name}`)
   });
 });
 

--- a/cypress/testcases/virtualmachines/advanced.spec.ts
+++ b/cypress/testcases/virtualmachines/advanced.spec.ts
@@ -1,12 +1,8 @@
 import YAML from 'js-yaml'
-
 import { VmsPage } from "@/pageobjects/virtualmachine.po";
-import { LoginPage } from "@/pageobjects/login.po";
 import { generateName } from '@/utils/utils';
 
-
 const vms = new VmsPage();
-const login = new LoginPage();
 
 describe('Create a new VM and add Enable USB tablet option', () => { 
   beforeEach(() => {
@@ -53,7 +49,7 @@ describe('Create a new VM and add Enable USB tablet option', () => {
       expect(foundTablet).to.equal(true);
     })
 
-    vms.deleteProgramlly(`${NAMESPACE}/${VM_NAME}`)
+    vms.deleteFromStore(`${NAMESPACE}/${VM_NAME}`)
   })
 })
 
@@ -87,7 +83,7 @@ describe("Create a new VM and add Install guest agent option", () => {
     cy.get('.tab#advanced').click()
     vms.usbTablet().expectChecked()
 
-    vms.deleteProgramlly(`${NAMESPACE}/${VM_NAME}`)
+    vms.deleteFromStore(`${NAMESPACE}/${VM_NAME}`)
   })
 })
 
@@ -126,6 +122,6 @@ describe("Verify Booting in EFI mode checkbox", () => {
     cy.get('.tab#advanced').click()
     vms.efiEnabled().expectChecked()
 
-    vms.deleteProgramlly(`${NAMESPACE}/${VM_NAME}`)
+    vms.deleteFromStore(`${NAMESPACE}/${VM_NAME}`)
   })
 }) 

--- a/cypress/utils/components/cru-resource.po.ts
+++ b/cypress/utils/components/cru-resource.po.ts
@@ -151,23 +151,6 @@ export default class CruResourcePo extends PagePo {
     })
   }
 
-  public deleteProgramlly(id:string, retries:number = 3) {
-    cy.wrap(document.cookie).then(() => {
-      const { CSRF } = cookie.parse(document.cookie);
-
-      cy.request({
-        url: `/v1/harvester/${this.realType}s/${ id }`,
-        headers: {
-          accept: 'application/json',
-          'x-api-csrf': CSRF,
-        },
-        method: 'DELETE',
-      }).then(res => {
-        expect(res.status, `Delete ${this.type}`).to.be.oneOf([200, 204]);
-      })
-    })
-  }
-
   setNameNsDescription(name: string, ns: string, description?: string) {
     this.namespace().select({ option: ns })
     this.name().input(name)


### PR DESCRIPTION
1. When we want to test the UI deletion function, we should call the `delete` method in the `Cru-Resource Class`.
2. We can call the deleteFromStore method when we simply want to delete a previously created object.

So the `deleteProgramlly` method is no longer needed