### PR TITLE
Implement VM's API calls for apiclient

### DIFF
--- a/apiclient/harvester_api/api.py
+++ b/apiclient/harvester_api/api.py
@@ -6,7 +6,7 @@ from requests.packages.urllib3.util.retry import Retry
 
 from .managers import (HostManager, KeypairManager, ImageManager, SettingManager,
                        NetworkManager, VolumeManager, TemplateManager, SupportBundlemanager,
-                       ClusterNetworkManager)
+                       ClusterNetworkManager, VirtualMachineManager)
 
 
 class HarvesterAPI:
@@ -44,6 +44,7 @@ class HarvesterAPI:
         self.supportbundle = SupportBundlemanager(self)
         self.settings = SettingManager(self)
         self.clusternetworks = ClusterNetworkManager(self)
+        self.vms = VirtualMachineManager(self)
 
     @property
     def cluster_version(self):

--- a/apiclient/harvester_api/managers.py
+++ b/apiclient/harvester_api/managers.py
@@ -604,9 +604,7 @@ class VirtualMachineManager(BaseManager):
     API_VERSION = "kubevirt.io/v1"
 
     # operators: start, restart, stop, migrate, pause, unpause, softreboot
-    OP_fmt = "v1/harvester/kubevirt.io.virtualmachines/{ns}/{uid}?action={op}"
-
-    PATH_fmt = "apis/{VM_API}/namespaces/{ns}/virtualmachines/{uid}"
+    PATH_fmt = "v1/harvester/kubevirt.io.virtualmachines/{ns}{uid}"
     # guestinfo, network
     VMI_fmt = "apis/{VM_API}/namespaces/{ns}/virtualmachineinstances/{uid}"
     # operators: guestosinfo, console(ws), vnc(ws)
@@ -614,55 +612,68 @@ class VirtualMachineManager(BaseManager):
 
     Spec = VMSpec
 
-    def create_data(self):
-        pass
+    def get(self, name="", namespace=DEFAULT_NAMESPACE, *, raw=False, **kwargs):
+        path = self.PATH_fmt.format(uid=f"/{name}", ns=namespace, VM_API=self.API_VERSION)
+        return self._get(path, raw=raw, **kwargs)
 
-    def get(self, name="", namespace=DEFAULT_NAMESPACE, *, raw=False):
-        path = self.PATH_fmt.format(uid=name, ns=namespace, VM_API=self.API_VERSION)
-        return self._get(path, raw=raw)
+    def create(self, name, vm_spec, namespace=DEFAULT_NAMESPACE, *, raw=False):
+        if isinstance(vm_spec, self.Spec):
+            vm_spec = vm_spec.to_dict(name, namespace)
+        path = self.PATH_fmt.format(uid="", ns=namespace)
+        return self._create(path, json=vm_spec, raw=raw)
 
-    def create(self, name):
-        pass
-
-    def update(self, name):
-        pass
+    def update(self, name, vm_spec, namespace=DEFAULT_NAMESPACE, *,
+               raw=False, as_json=True, **kwargs):
+        if isinstance(vm_spec, self.Spec):
+            vm_spec = vm_spec.to_dict(name, namespace)
+        path = self.PATH_fmt.format(uid=f"/{name}", ns=namespace)
+        return self._update(path, vm_spec, raw=raw, as_json=as_json, **kwargs)
 
     def delete(self, name, namespace=DEFAULT_NAMESPACE, *, raw=False):
-        path = self.PATH_fmt.format(uid=name, ns=namespace, VM_API=self.API_VERSION)
+        path = self.PATH_fmt.format(uid=f"/{name}", ns=namespace, VM_API=self.API_VERSION)
         return self._delete(path, raw=raw)
 
     def clone(self, name, new_vm_name, namespace=DEFAULT_NAMESPACE, *, raw=False):
-        path = self.OP_fmt.format(op="clone", uid=name, ns=namespace)
-        return self._create(path, raw=raw, json=dict(targetVm=new_vm_name))
+        path = self.PATH_fmt.format(uid=f"/{name}", ns=namespace)
+        params = dict(action="clone")
+        return self._create(path, raw=raw, params=params, json=dict(targetVm=new_vm_name))
 
     def start(self, name, namespace=DEFAULT_NAMESPACE, *, raw=False):
-        path = self.OP_fmt.format(op="start", uid=name, ns=namespace)
-        return self._create(path, raw=raw)
+        path = self.PATH_fmt.format(uid=f"/{name}", ns=namespace)
+        params = dict(action="start")
+        return self._create(path, raw=raw, params=params)
 
     def restart(self, name, namespace=DEFAULT_NAMESPACE, *, raw=False):
-        path = self.OP_fmt.format(op="restart", uid=name, ns=namespace)
-        return self._create(path, raw=raw)
+        path = self.PATH_fmt.format(uid=f"/{name}", ns=namespace)
+        params = dict(action="restart")
+        return self._create(path, raw=raw, params=params)
 
     def stop(self, name, namespace=DEFAULT_NAMESPACE, *, raw=False):
-        path = self.OP_fmt.format(op="stop", uid=name, ns=namespace)
-        return self._create(path, raw=raw)
+        path = self.PATH_fmt.format(uid=f"/{name}", ns=namespace)
+        params = dict(action="stop")
+        return self._create(path, raw=raw, params=params)
 
     def migrate(self, name, target_node, namespace=DEFAULT_NAMESPACE, *, raw=False):
-        path = self.OP_fmt.format(op="migrate", uid=name, ns=namespace)
-        return self._create(path, raw=raw, json=dict(nodeName=target_node))
+        path = self.PATH_fmt.format(uid=f"/{name}", ns=namespace)
+        params = dict(action="migrate")
+        return self._create(path, raw=raw, params=params, json=dict(nodeName=target_node))
 
     def abort_migrate(self, name, namespace=DEFAULT_NAMESPACE, *, raw=False):
-        path = self.OP_fmt.format(op="abortMigration", uid=name, ns=namespace)
-        return self._create(path, raw=raw)
+        path = self.PATH_fmt.format(uid=f"/{name}", ns=namespace)
+        params = dict(action="abortMigration")
+        return self._create(path, raw=raw, params=params)
 
     def pause(self, name, namespace=DEFAULT_NAMESPACE, *, raw=False):
-        path = self.OP_fmt.format(op="pause", uid=name, ns=namespace)
-        return self._create(path, raw=raw)
+        path = self.PATH_fmt.format(uid=f"/{name}", ns=namespace)
+        params = dict(action="pause")
+        return self._create(path, raw=raw, params=params)
 
     def unpause(self, name, namespace=DEFAULT_NAMESPACE, *, raw=False):
-        path = self.OP_fmt.format(op="unpause", uid=name, ns=namespace)
-        return self._create(path, raw=raw)
+        path = self.PATH_fmt.format(uid=f"/{name}", ns=namespace)
+        params = dict(action="unpause")
+        return self._create(path, raw=raw, params=params)
 
     def softreboot(self, name, namespace=DEFAULT_NAMESPACE, *, raw=False):
-        path = self.OP_fmt.format(op="softreboot", uid=name, ns=namespace)
-        return self._create(path, raw=raw)
+        path = self.PATH_fmt.format(uid=f"/{name}", ns=namespace)
+        params = dict(action="softreboot")
+        return self._create(path, raw=raw, params=params)

--- a/apiclient/harvester_api/managers.py
+++ b/apiclient/harvester_api/managers.py
@@ -175,6 +175,7 @@ class ImageManager(BaseManager):
 
 
 class VolumeManager(BaseManager):
+    # XXX: https://github.com/harvester/harvester/issues/3250
     PATH_fmt = "v1/harvester/persistentvolumeclaims/{ns}{uid}"
 
     Spec = VolumeSpec

--- a/apiclient/harvester_api/models.py
+++ b/apiclient/harvester_api/models.py
@@ -12,6 +12,18 @@ class VMSpec:
     def __init__(self, cpu=1, mem=1):
         pass
 
+    def add_image(self, name, size, bus="virtio", type="disk"):
+        pass
+
+    def add_container(self, name, image_name, bus="virtio", type="disk"):
+        pass
+
+    def add_volume(self):
+        pass
+
+    def add_network(self):
+        pass
+
     def to_dict(self, name, hostname=None):
         acpi = dict(enabled=self.acpi)
         machine = dict()
@@ -44,3 +56,62 @@ class VMSpec:
                 }
             }
         }
+
+
+class VolumeSpec:
+    volume_mode = "Block"
+    _data = None
+
+    def __init__(self, size, storage_cls=None, description=None, annotations=None):
+        self.access_modes = ["ReadWriteMany"]
+
+        self.size = size
+        self.storage_cls = storage_cls
+        self.description = description
+        self.annotations = annotations
+
+    def to_dict(self, name, namespace, image_id=None):
+        annotations = self.annotations or dict()
+        size = f"{self.size}Gi" if isinstance(self.size, (int, float)) else self.size
+        data = {
+            "type": "persistentvolumeclaim",
+            "metadata": {
+                "namespace": namespace,
+                "name": name,
+                "annotations": annotations
+            },
+            "spec": {
+                "accessModes": self.access_modes,
+                "resources": {
+                    "requests": dict(storage=size)
+                },
+                "volumeMode": self.volume_mode
+            }
+        }
+
+        if image_id is not None:
+            annotations.update({"harvesterhci.io/imageId": self.image_id})
+        if self.description is not None:
+            annotations.update({"field.cattle.io/description": self.description})
+        if self.storage_cls is not None:
+            data['spec']['storageClassName'] = self.storage_cls
+
+        if self._data:
+            self._data['metadata'].update(data['metadata'])
+            self._data['spec'].update(data['spec'])
+            return self._data
+
+        return data
+
+    @classmethod
+    def from_dict(cls, data):
+        spec, metadata = data.get('spec', {}), data.get('metadata', {})
+        annotations = metadata.get('annotations')
+        size = spec['resources']['requests']['storage']
+        storage_cls = spec.get('storageClassName')
+
+        obj = cls(size, storage_cls, annotations.get("field.cattle.io/description"))
+        obj.annotations = annotations
+        obj._data = data
+
+        return obj

--- a/apiclient/harvester_api/models.py
+++ b/apiclient/harvester_api/models.py
@@ -1,61 +1,292 @@
+from json import dumps
+
+import yaml
+
+MGMT_NETID = object()
+
+
 class VMSpec:
     # ref: https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstancespec
     # defaults
-    sockets = threads = 1
+    cpu_sockets = cpu_threads = 1
     run_strategy = "RerunOnFailure",
     eviction_strategy = "LiveMigrate"
-    acpi = True
-    # cpu, mem, volumes, networks
-    # VolumeClaimTemplates
-    # affinity
+    hostname = None
+    machine_type = ""
+    usbtablet = True
 
-    def __init__(self, cpu=1, mem=1):
-        pass
+    # TODOs:
+    # node selector(affinity)
+    # userdata/networkdata enhancement
 
-    def add_image(self, name, size, bus="virtio", type="disk"):
-        pass
+    def __init__(self, cpu_cores, memory, mgmt_network=True):
+        self.cpu_cores = cpu_cores
+        self.memory = memory
+        self.volumes, self.networks = [], []
+        self._firmwares, self._features = dict(), dict()
+        if mgmt_network:
+            self.add_network("default", MGMT_NETID)
 
-    def add_container(self, name, image_name, bus="virtio", type="disk"):
-        pass
+        # default
+        self.acpi = True
+        self._cloudinit_vol = {
+            "disk": {
+                "name": "cloudinitdisk",
+                "disk": dict(bus="virtio")
+            },
+            "volume": {
+                "name": "cloudinitdisk",
+                "cloudInitNoCloud": {
+                    "networkData": "",
+                    "userData": "#cloud-config\npackage_update: true"
+                }
+            }
+        }
 
-    def add_volume(self):
-        pass
+    @property
+    def acpi(self):
+        return self._features['acpi'].get('enabled')
 
-    def add_network(self):
-        pass
+    @acpi.setter
+    def acpi(self, enable):
+        self._features['acpi'] = enable
 
-    def to_dict(self, name, hostname=None):
-        acpi = dict(enabled=self.acpi)
-        machine = dict()
-        cpu = dict(sockets=self.sockets, thread=self.threads)
-        devices = dict()
-        resources = dict()
-        networks = []
-        volumes = []
+    @property
+    def efi_boot(self):
+        return 'efi' in self._firmwares.get('bootloader', dict())
 
-        return {
-            "runStrategy": self.run_strategy,
-            "template": {
-                "metadata": {
-                    "labels": {
-                        "harvesterhci.io/vmName": name
-                    }
-                },
-                "spec": {
-                    "evictionStrategy": self.eviction_strategy,
-                    "hostname": hostname or name,
-                    "networks": networks,
-                    "volumes": volumes,
-                    "domain": {
-                        "machine": machine,
-                        "cpu": cpu,
-                        "devices": devices,
-                        "resources": resources,
-                        "features": dict(acpi=acpi)
+    @efi_boot.setter
+    def efi_boot(self, enable):
+        if enable:
+            self._features['smm'] = dict(enabled=True)
+            self._firmwares['bootloader'] = dict(efi=dict(secureBoot=True))
+        else:
+            self._features.pop('smm', None)
+            self._firmwares.pop('bootloader', None)
+
+    @property
+    def secure_boot(self):
+        return self.efi_boot and self._firmwares['bootloader']['efi']['secureBoot']
+
+    @secure_boot.setter
+    def secure_boot(self, enable):
+        if enable:
+            self.efi_boot = True
+            self._firmwares['bootloader']['efi']['secureBoot'] = True
+        else:
+            self.efi_boot = False
+
+    @property
+    def guest_agent(self):
+        return 'qemu-guest-agent.service' in self.user_data
+
+    @guest_agent.setter
+    def guest_agent(self, enable):
+        cmd = 'systemctl enable --now qemu-guest-agent.service'
+        userdata = yaml.safe_load(self.user_data) or dict()
+        pkgs = userdata.get('packages', [])
+        runcmds = [' '.join(c) for c in userdata.get('runcmd', [])]
+        if enable:
+            if 'qemu-guest-agent' not in pkgs:
+                userdata.setdefault('packages', []).append('qemu-guest-agent')
+
+            if cmd not in runcmds:
+                userdata.setdefault('runcmd', []).append(cmd.split())
+        else:
+            userdata['packages'] = [p for p in pkgs if p != 'qemu-guest-agent']
+            userdata['runcmd'] = [c.split() for c in runcmds if c != cmd]
+
+        self.user_data = "#cloud-config\n" + yaml.dump(userdata)
+
+    @property
+    def user_data(self):
+        return self._cloudinit_vol['volume']['cloudInitNoCloud']['userData']
+
+    @user_data.setter
+    def user_data(self, val):
+        self._cloudinit_vol['volume']['cloudInitNoCloud']['userData'] = val
+
+    @property
+    def network_data(self):
+        return self._cloudinit_vol['volume']['cloudInitNoCloud']['networkData']
+
+    @network_data.setter
+    def network_data(self, val):
+        self._cloudinit_vol['volume']['cloudInitNoCloud']['networkData'] = val
+
+    def add_cd_rom(self, name, image_id, size=10, bus="SATA"):
+        vol_spec = VolumeSpec(size, annotations={"harvesterhci.io/imageId": image_id})
+
+        vol = {
+            "claim": vol_spec,
+            "disk": {
+                "name": name,
+                "cdrom": dict(bus=bus),
+                "bootOrder": 1
+            },
+            "volume": {
+                "name": name,
+                "persistentVolumeClaim": dict(claimName="")
+            }
+        }
+
+        self.volumes.append(vol)
+        return vol
+
+    def add_image(self, name, image_id, size=10, bus="virtio", type="disk"):
+        vol_spec = VolumeSpec(size, annotations={"harvesterhci.io/imageId": image_id})
+
+        vol = {
+            "claim": vol_spec,
+            "disk": {
+                type: dict(bus=bus),
+                "name": name,
+                "bootOrder": 1
+            },
+            "volume": {
+                "name": name,
+                "persistentVolumeClaim": dict(claimName="")
+            }
+        }
+        self.volumes.append(vol)
+        return vol
+
+    def add_container(self, name, docker_image, bus="virtio", type="disk"):
+        vol = {
+            "disk": {
+                type: dict(bus=bus),
+                "name": name,
+                "bootOrder": 1
+            },
+            "volume": {
+                "name": name,
+                "containerDisk": dict(image=docker_image)
+            }
+        }
+
+        self.volumes.append(vol)
+        return vol
+
+    def add_volume(self, name, size, type="disk", bus="virtio", storage_cls=None):
+        vol_spec = VolumeSpec(size, storage_cls)
+        vol = {
+            "claim": vol_spec,
+            "disk": {
+                type: dict(bus=bus),
+                "name": name,
+                "bootOrder": 1
+            },
+            "volume": {
+                "name": name,
+                "persistentVolumeClaim": dict(claimName="")
+            }
+        }
+
+        self.volumes.append(vol)
+        return vol
+
+    def add_existing_volume(self, name, volume_name, type="disk"):
+        vol = {
+            "disk": {
+                type: dict(bus="virtio"),
+                "name": name,
+                "bootOrder": 1
+            },
+            "volume": {
+                "name": name,
+                "persistentVolumeClaim": dict(claimName=volume_name)
+            }
+        }
+
+        self.volumes.append(vol)
+        return vol
+
+    def add_network(self, name, net_uid, model="virtio", mac_addr=None):
+        net = {
+            "iface": dict(model=model, name=name),
+            "network": dict(name=name)
+        }
+
+        if net_uid is MGMT_NETID:
+            net['iface']["masquerade"] = dict()
+            net['network']['pod'] = dict()
+        else:
+            net['iface']["bridge"] = dict()
+            net['network']['multus'] = dict(networkName=net_uid)
+
+        if mac_addr is not None:
+            net['iface']['macAddress'] = mac_addr
+
+        self.networks.append(net)
+        return net
+
+    def _update_bootorder(self):
+        its = enumerate([v['disk'] for v in self.volumes if 'disk' in v], 1)
+        for idx, disk in its:
+            disk['bootOrder'] = idx
+
+    def _update_volume_spec(self, name, namespace):
+        for v in self.volumes:
+            if 'claim' in v:
+                v['claim'] = v['claim'].to_dict(name, namespace)
+                disk_name = v['volume']['name']
+                v['volume']['persistentvolumeclaim']['claimName'] = f"{name}-{disk_name}"
+
+    def to_dict(self, name, namespace, hostname=None):
+        self._update_bootorder()
+        self._update_volume_spec(name, namespace)
+        volumes = self.volumes + [self._cloudinit_vol]
+        mem = f"{self.memory}Gi" if isinstance(self.memory, int) else self.memory
+
+        machine = dict(type=self.machine_type)
+        cpu = dict(sockets=self.cpu_sockets, thread=self.cpu_threads)
+        resources = dict(cpu=self.cpu_cores, memory=mem)
+
+        volume_claims = dumps([v['claim'] for v in volumes if 'claim' in v])
+
+        data = {
+            "type": "kubevirt.io.virtualmachine",
+            "metadata": {
+                "namespace": namespace,
+                "name": name,
+                "annotations": {
+                    "harvesterhci.io/volumeClaimTemplates": volume_claims
+                }
+            },
+            "spec": {
+                "runStrategy": self.run_strategy,
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "harvesterhci.io/vmName": name
+                        }
+                    },
+                    "spec": {
+                        "evictionStrategy": self.eviction_strategy,
+                        "hostname": hostname or self.hostname or name,
+                        "networks": [n['network'] for n in self.networks],
+                        "volumes": [v['volume'] for v in volumes if 'volume' in v],
+                        "domain": {
+                            "machine": machine,
+                            "cpu": cpu,
+                            "resources": dict(limits=resources),
+                            "features": self._features,
+                            "firmware": self._firmwares,
+                            "devices": {
+                                "intrefaces": [n['iface'] for n in self.networks],
+                                "disks": [v['disk'] for v in volumes if 'disk' in v]
+                            },
+                        }
                     }
                 }
             }
         }
+
+        if self.usbtablet:
+            inputs = [dict(bus="usb", name="tablet", type="tablet")]
+            data['spec']['template']['spec']['domain']['devices']['inputs'] = inputs
+
+        return data
 
 
 class VolumeSpec:
@@ -90,7 +321,7 @@ class VolumeSpec:
         }
 
         if image_id is not None:
-            annotations.update({"harvesterhci.io/imageId": self.image_id})
+            annotations.update({"harvesterhci.io/imageId": image_id})
         if self.description is not None:
             annotations.update({"field.cattle.io/description": self.description})
         if self.storage_cls is not None:

--- a/apiclient/harvester_api/models.py
+++ b/apiclient/harvester_api/models.py
@@ -1,0 +1,46 @@
+class VMSpec:
+    # ref: https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstancespec
+    # defaults
+    sockets = threads = 1
+    run_strategy = "RerunOnFailure",
+    eviction_strategy = "LiveMigrate"
+    acpi = True
+    # cpu, mem, volumes, networks
+    # VolumeClaimTemplates
+    # affinity
+
+    def __init__(self, cpu=1, mem=1):
+        pass
+
+    def to_dict(self, name, hostname=None):
+        acpi = dict(enabled=self.acpi)
+        machine = dict()
+        cpu = dict(sockets=self.sockets, thread=self.threads)
+        devices = dict()
+        resources = dict()
+        networks = []
+        volumes = []
+
+        return {
+            "runStrategy": self.run_strategy,
+            "template": {
+                "metadata": {
+                    "labels": {
+                        "harvesterhci.io/vmName": name
+                    }
+                },
+                "spec": {
+                    "evictionStrategy": self.eviction_strategy,
+                    "hostname": hostname or name,
+                    "networks": networks,
+                    "volumes": volumes,
+                    "domain": {
+                        "machine": machine,
+                        "cpu": cpu,
+                        "devices": devices,
+                        "resources": resources,
+                        "features": dict(acpi=acpi)
+                    }
+                }
+            }
+        }

--- a/harvester_e2e_tests/apis/test_volumes.py
+++ b/harvester_e2e_tests/apis/test_volumes.py
@@ -38,32 +38,35 @@ class TestVolumesNegative:
         code, data = api_client.volumes.get(unique_name)
 
         assert 404 == code, (code, data)
-        assert "NotFound" == data.get('reason'), (code, data)
+        assert "NotFound" == data.get('code'), (code, data)
 
     def test_delete_not_exist(self, api_client, unique_name):
         code, data = api_client.volumes.delete(unique_name)
 
         assert 404 == code, (code, data)
-        assert "NotFound" == data.get("reason"), (code, data)
+        assert "NotFound" == data.get("code"), (code, data)
 
     def test_create_without_size(self, api_client, unique_name):
-        code, data = api_client.volumes.create(unique_name, 0)
+        spec = api_client.volumes.Spec(0)
+        code, data = api_client.volumes.create(unique_name, spec)
 
         assert 422 == code, (code, data)
-        assert "Invalid" == data.get("reason"), (code, data)
+        assert "Invalid" == data.get("code"), (code, data)
 
     def test_create_without_name(self, api_client):
-        code, data = api_client.volumes.create("", 1)
+        spec = api_client.volumes.Spec(1)
+        code, data = api_client.volumes.create("", spec)
 
         assert 422 == code, (code, data)
-        assert "Invalid" == data.get("reason"), (code, data)
+        assert "Invalid" == data.get("code"), (code, data)
 
 
 @pytest.mark.p0
 @pytest.mark.volumes
 class TestVolumes:
     def test_create(self, api_client, unique_name):
-        code, data = api_client.volumes.create(unique_name, 1)
+        spec = api_client.volumes.Spec(1)
+        code, data = api_client.volumes.create(unique_name, spec)
 
         assert 201 == code, (code, data)
 
@@ -72,7 +75,7 @@ class TestVolumes:
         code, data = api_client.volumes.get()
 
         assert 200 == code, (code, data)
-        assert len(data['items']) > 0, (code, data)
+        assert len(data['data']) > 0, (code, data)
 
         # Case 2: get specific volume
         code, data = api_client.volumes.get(unique_name)
@@ -94,16 +97,9 @@ class TestVolumes:
                 f"Got error: {code}, {data}"
             )
 
-        updates = {
-            "spec": {
-                "resources": {
-                    "requests": {
-                        "storage": "10Gi"
-                    }
-                }
-            }
-        }
-        code, data = api_client.volumes.update(unique_name, updates)
+        spec = api_client.volumes.Spec.from_dict(data)
+        spec.size = "10Gi"
+        code, data = api_client.volumes.update(unique_name, spec)
 
         assert 200 == code, (f"Failed to update volume with error: {code}, {data}")
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands =
 whitelist_externals =
   bash
   find
-passenv = http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY PBR_VERSION
+passenv = http_proxy,HTTP_PROXY,https_proxy,HTTPS_PROXY,no_proxy,NO_PROXY,PBR_VERSION
 
 [testenv:pep8]
 deps = flake8


### PR DESCRIPTION
## Implements
- [x] Add VM's Manager to API client as `api.vms`
- [x] Add `get` method
- [x] Add `start` method
- [x] Add `restart` method
- [x] Add `stop` method
- [x] Add `pause` method
- [x] Add `unpause` method
- [x] Add `softreboot` method
- [x] Add `migrate` method
- [x] Add `abort_migrate` method
- [x] Add `clone` method
- [x] Add `create` method
    - add `VMSpec` for VM creation to fit complex parameters
- [x] Add `update` method
    - use `VMSepc` for update

## TODOs (next PR)
- [ ] Add `add_volume` method
- [ ] Add `remove_volume` method
- [ ] Add `generate_template` method
- [ ] Add method to reach VM's console
- [ ] Add method to reach VM's vnc
- [ ] Improve `VMSpec.from_dict` to handle *volumeClaimTemplates*
- [ ] Implement **NodeSelector** in `VMSpec`
- [ ] Improve `VMSpec.user_data`, `VMSpec.network_data` to interact with _secrets_
- [ ] Implement **SSHKey** reference in `VMSpec`