### PR TITLE
bugfix: Fixing Broken Jenkins Provisioning On Debian (non-proxy & non-ssl)

### DIFF
--- a/CI/harvester-installer/roles/jenkins/tasks/install_jenkins.yml
+++ b/CI/harvester-installer/roles/jenkins/tasks/install_jenkins.yml
@@ -7,6 +7,11 @@
 - name: jenkins | install_jenkins | Install Jenkins
   include_tasks: install_jenkins_on_{{ ansible_os_family }}.yml
 
+- name: jenkins | install_jenkins | Check for jenkins-cli
+  ansible.builtin.stat:
+    path: /usr/bin/jenkins-cli
+  register: jenkins_cli_bin
+
 - name: jenkins | install_jenkins | Wait for Jenkins to be ready
   uri:
     url: "http://localhost:8080/cli/"
@@ -15,6 +20,7 @@
   until: get_jenkins_cli_result.status == 200
   retries: 10
   delay: 20
+  when: jenkins_cli_bin.stat.isreg is not defined and jenkins_cli_bin.stat.executable is not defined
 
 - name: jenkins | install_jenkins | Install Jenkins CLI
   get_url:
@@ -24,20 +30,24 @@
   until: "'OK' in jarfile_get.msg or '304' in jarfile_get.msg or 'file already exists' in jarfile_get.msg"
   retries: 5
   delay: 10
+  when: jenkins_cli_bin.stat.isreg is not defined and jenkins_cli_bin.stat.executable is not defined
 
 - name: jenkins | install_jenkins | Create jenkins CLI to install plugins
   template:
     src: jenkins.j2
-    dest: /usr/bin/jenkins
+    dest: /usr/bin/jenkins-cli
     mode: 0755
     force: yes
   vars:
     JENKINS_AUTH_USERNAME: "{{ JENKINS_BOOTSTRAP_USERNAME }}"
     JENKINS_AUTH_PASSWORD: "{{ JENKINS_BOOTSTRAP_PASSWORD }}"
+  when: jenkins_cli_bin.stat.isreg is not defined and jenkins_cli_bin.stat.executable is not defined
 
+# TODO: fix to allow for new plugins to be added to ansible and script to pretty much just be re-run
+# to install new plugins as desired or possibly update pre-existing ones  
 - name: jenkins | install_jenkins | Install Jenkins plugins
   shell: >
-    /usr/bin/jenkins install-plugin {{ item }}
+    /usr/bin/jenkins-cli install-plugin {{ item }}
   with_items:
     - ansible
     - authorize-project
@@ -65,6 +75,11 @@
     - workflow-cps
     - workflow-job
     - ws-cleanup
+  register: result
+  retries: 5
+  delay: 30
+  until: result is success
+  when: jenkins_cli_bin.stat.isreg is not defined and jenkins_cli_bin.stat.executable is not defined
 
 - name: jenkins | install_jenkins | Remove Jenkins security bootstrap scripts
   file:
@@ -106,17 +121,20 @@
   with_items:
     - harvester_vagrant_installation_test.groovy
 
+- name: Just force systemd to reread configs
+  ansible.builtin.systemd:
+    daemon_reload: yes
+
+- name: Brief pause after systemd rereading configs
+  ansible.builtin.pause:
+    prompt: "pausing briefly after systemd rereading configs"
+    seconds: 30
+
 - name: jenkins | install_jenkins | Restart jenkins
-  service:
+  ansible.builtin.systemd:
     name: jenkins
     state: restarted
-
-- name: jenkins | install_jenkins | Create jenkins CLI
-  template:
-    src: jenkins.j2
-    dest: /usr/bin/jenkins
-    mode: 0755
-    force: yes
-  vars:
-    JENKINS_AUTH_USERNAME: "{{ JENKINS_ADMIN_USERNAME }}"
-    JENKINS_AUTH_PASSWORD: "{{ JENKINS_ADMIN_PASSWORD }}"
+  register: result
+  retries: 5
+  delay: 30
+  until: result is success

--- a/CI/harvester-installer/roles/jenkins/tasks/install_jenkins_on_Debian.yml
+++ b/CI/harvester-installer/roles/jenkins/tasks/install_jenkins_on_Debian.yml
@@ -57,6 +57,19 @@
     mode: 0644
   when: JENKINS_USE_PROXY
 
+- name: jenkins | build drop in system-d config dir
+  ansible.builtin.shell: >
+    mkdir -p /etc/systemd/system/jenkins.service.d
+
+- name: jenkins | load in the override.conf
+  template:
+    src: override.conf.j2
+    dest: /etc/systemd/system/jenkins.service.d/override.conf
+    mode: 0600
+    force: yes
+  vars:
+    JENKINS_USING_PROXY: "{{ JENKINS_USE_PROXY }}"
+
 - name: jenkins | install_jenkins_on_Debian |
         Create init.groovy.d to bootstrap Jenkins
   file:
@@ -75,10 +88,18 @@
     group: jenkins
     mode: 0755
 
-- name: jenkins | install_jenkins_on_Debian | Restart Jenkins
-  systemd:
+- name: jenkins | install_jenkins | Restart jenkins
+  ansible.builtin.systemd:
     name: jenkins
     state: restarted
+    daemon_reload: yes
+    force: yes
+    enabled: yes
+    masked: no
+  register: result
+  retries: 5
+  delay: 30
+  until: result is success
 
 - name: jenkins | install_jenkins_on_Debian | Enable Jenkins port 8080
   shell: ufw allow 8080

--- a/CI/harvester-installer/roles/jenkins/tasks/install_vagrant_on_Debian.yml
+++ b/CI/harvester-installer/roles/jenkins/tasks/install_vagrant_on_Debian.yml
@@ -1,7 +1,10 @@
 ---
+# NOTE: this is strange...I have no idea why the `-1` on the package has to be present now...but it seems they changed
+# the way they are serving the packages... idk... here's to being "optimistic" that they won't change their file
+# serving pattern again in the future...
 - name: jenkins | install_vagrant_on_Debian | Install vagrant package
   apt:
-    deb: https://releases.hashicorp.com/vagrant/{{ LATEST_VAGRANT_VERSION }}/vagrant_{{ LATEST_VAGRANT_VERSION }}_x86_64.deb
+    deb: https://releases.hashicorp.com/vagrant/{{ LATEST_VAGRANT_VERSION }}/vagrant_{{ LATEST_VAGRANT_VERSION }}-1_amd64.deb
 
 - name: jenkins | install_vagrant_on_Debian | Install build essentials
   apt:
@@ -10,7 +13,7 @@
 
 - name: jenkins | install_vagrant_on_Debian | Install KVM
   apt:
-    name: [qemu-kvm, libvirt-daemon-system, libvirt-clients, bridge-utils, virtinst, virt-manager, libvirt-dev]
+    name: [qemu-system-x86, libvirt-daemon-system, libvirt-clients, bridge-utils, virtinst, virt-manager, libvirt-dev]
     state: latest
 
 - name: jenkins | install_vagrant_on_Debian | Add jenkins user to libvirt group

--- a/CI/harvester-installer/roles/jenkins/templates/override.conf.j2
+++ b/CI/harvester-installer/roles/jenkins/templates/override.conf.j2
@@ -1,0 +1,8 @@
+# https://www.jenkins.io/doc/book/system-administration/systemd-services/
+[Service]
+Environment="JAVA_OPTS=-Djenkins.install.runSetupWizard=false -Dcasc.jenkins.config=/var/lib/jenkins/casc_configs -Djava.awt.headless=true"
+Environment="CASC_JENKINS_CONFIG=/var/lib/jenkins/casc_configs/"
+{% if JENKINS_USING_PROXY %}
+Environment="JENKINS_OPTS=--httpListenAddress=127.0.0.1"
+{% endif %}
+


### PR DESCRIPTION
* fixing jenkins provisioning, new versions are all systemd based services needing additional edits

Resolves: bug/fix-infrastructure-provisioning
Co-Authored-By: ttpcodes <alice.nguyen@suse.com>

Fixes:
- https://github.com/harvester/tests/issues/657
- https://github.com/harvester/tests/issues/659
- https://github.com/harvester/tests/issues/661
- https://github.com/harvester/tests/issues/662