### PR TITLE
* [e2e] Fix daily testing errors and fails

### DIFF
--- a/harvester_e2e_tests/fixtures/images.py
+++ b/harvester_e2e_tests/fixtures/images.py
@@ -12,7 +12,7 @@ DEFAULT_OPENSUSE_IMAGE_URL = ("https://download.opensuse.org/repositories/Cloud:
 
 
 @pytest.fixture(scope="session")
-def opensuse_image(request, api_client):
+def image_opensuse(request, api_client):
     image_server = request.config.getoption('--image-cache-url')
     url = urlparse(request.config.getoption('--opensuse-image-url') or DEFAULT_OPENSUSE_IMAGE_URL)
 

--- a/harvester_e2e_tests/integration/test_images.py
+++ b/harvester_e2e_tests/integration/test_images.py
@@ -15,7 +15,7 @@ pytest_plugins = [
 @pytest.mark.images
 @pytest.mark.p0
 @pytest.mark.dependency(name="create_image_url")
-def test_create_with_url(api_client, opensuse_image, unique_name, wait_timeout, sleep_timeout):
+def test_create_with_url(api_client, image_opensuse, unique_name, wait_timeout, sleep_timeout):
     """
     Test if you can create an image from a URL.
 
@@ -29,7 +29,7 @@ def test_create_with_url(api_client, opensuse_image, unique_name, wait_timeout, 
     4. Check if the image is intialzied and the status is true
     5. Remove image
     """
-    code, data = api_client.images.create_by_url(unique_name, opensuse_image.url)
+    code, data = api_client.images.create_by_url(unique_name, image_opensuse.url)
     assert 201 == code, (
                 f"Failed to create image {unique_name} from URL got\n"
                 f"Creation got {code} with {data}"

--- a/harvester_e2e_tests/integration/test_terraform.py
+++ b/harvester_e2e_tests/integration/test_terraform.py
@@ -34,6 +34,7 @@ def test_create_images_using_terraform(admin_session, image_using_terraform):
     pass
 
 
+@pytest.mark.skip("get_vlan API removed")
 @pytest.mark.terraform_provider_p1
 @pytest.mark.p1
 @pytest.mark.terraform

--- a/harvester_e2e_tests/integration/test_vm_functions.py
+++ b/harvester_e2e_tests/integration/test_vm_functions.py
@@ -35,10 +35,10 @@ def kubeconfig_file(api_client):
 
 
 @pytest.fixture(scope="module")
-def image(api_client, opensuse_image, unique_name, wait_timeout):
+def image(api_client, image_opensuse, unique_name, wait_timeout):
     unique_image_id = f'image-{unique_name}'
     code, data = api_client.images.create_by_url(
-        unique_image_id, opensuse_image.url, display_name=f"{unique_name}-{opensuse_image.name}"
+        unique_image_id, image_opensuse.url, display_name=f"{unique_name}-{image_opensuse.name}"
     )
 
     assert 201 == code, (code, data)
@@ -56,7 +56,7 @@ def image(api_client, opensuse_image, unique_name, wait_timeout):
         )
 
     yield dict(id=f"{data['metadata']['namespace']}/{unique_image_id}",
-               user=opensuse_image.ssh_user)
+               user=image_opensuse.ssh_user)
 
     code, data = api_client.images.delete(unique_image_id)
 

--- a/harvester_e2e_tests/scenarios/test_vm_networking.py
+++ b/harvester_e2e_tests/scenarios/test_vm_networking.py
@@ -299,6 +299,7 @@ def backup_restore_chained_backups(request, admin_session,
                                            backuptarget, backup_json)
 
 
+@pytest.mark.skip("get_vlan API removed")
 @pytest.mark.network_p1
 @pytest.mark.p1
 @pytest.mark.public_network
@@ -470,6 +471,7 @@ class TestVMNetworking:
             'still accessible.' % (vm_name, public_ip))
 
 
+@pytest.mark.skip("get_vlan API removed")
 @pytest.mark.public_network
 def test_two_vms_on_same_vlan(request, admin_session,
                               harvester_api_endpoints, keypair,
@@ -493,6 +495,7 @@ def test_two_vms_on_same_vlan(request, admin_session,
         assert_ssh_into_vm(public_ip, timeout, keypair=keypair)
 
 
+@pytest.mark.skip("get_vlan API removed")
 @pytest.mark.public_network
 def test_update_vm_management_network_to_vlan(request, admin_session,
                                               harvester_api_endpoints, keypair,
@@ -543,6 +546,7 @@ def test_update_vm_management_network_to_vlan(request, admin_session,
     assert_ssh_into_vm(public_ip, timeout, keypair=keypair)
 
 
+@pytest.mark.skip("get_vlan API removed")
 @pytest.mark.public_network
 def test_update_vm_vlan_network_to_management(request, admin_session,
                                               harvester_api_endpoints, keypair,
@@ -604,6 +608,7 @@ def test_update_vm_vlan_network_to_management(request, admin_session,
             ip))
 
 
+@pytest.mark.skip("get_vlan API removed")
 @pytest.mark.network_p2
 @pytest.mark.p2
 @pytest.mark.public_network
@@ -628,6 +633,7 @@ def test_vm_network_with_bogus_vlan(request, admin_session,
         'VM should not have gotten an IPv4 address. Got %s' % (public_ip))
 
 
+@pytest.mark.skip("get_vlan API removed")
 @pytest.mark.public_network
 def test_create_update_vm_user_data(request, admin_session, image,
                                     keypair, harvester_api_endpoints, network,
@@ -702,6 +708,7 @@ def test_create_update_vm_user_data(request, admin_session, image,
                                 harvester_api_endpoints, single_vm)
 
 
+@pytest.mark.skip("get_vlan API removed")
 @pytest.mark.terraform
 @pytest.mark.terraform_provider_p1
 @pytest.mark.p1


### PR DESCRIPTION
# Changes
Based on `harvester-install-and-test-e2e-daily` build `#510` and `#511`

## Skipped: old `get_vlan` API has been removed.
- [x] **Error** scenarios/test_vm_networking.py::TestVMNetworking::test_ssh_to_vm::setup
- [x] **Error** scenarios/test_vm_networking.py::TestVMNetworking::test_vlan_ip_pingable_after_reboot::setup
- [x] **Error** scenarios/test_vm_networking.py::TestVMNetworking::test_add_vlan_network_to_vm::setup
- [x] **Error** scenarios/test_vm_networking.py::TestVMNetworking::test_remove_vlan_network_from_vm::setup
- [x] **Error** scenarios/test_vm_networking.py::test_two_vms_on_same_vlan::setup
- [x] **Error** scenarios/test_vm_networking.py::test_update_vm_management_network_to_vlan::setup
- [x] **Error** scenarios/test_vm_networking.py::test_update_vm_vlan_network_to_management::setup
- [x] **Error** scenarios/test_vm_networking.py::test_vm_network_with_bogus_vlan::setup
- [x] **Error** scenarios/test_vm_networking.py::test_create_update_vm_user_data::setup
- [x] **Error** scenarios/test_vm_networking.py::test_create_vm_using_terraform::setup
- [x] **Error** integration/test_terraform.py::test_create_network_using_terraform::setup

## Fixture naming conflict
- [x] **Error**  integration/test_vm_functions.py::test_minimal_vm::setup
- [x] **Error**  integration/test_vm_functions.py::test_create_stopped_vm::setup
- [x] **Error**  integration/test_vm_functions.py::TestVMClone::test_clone_running_vm::setup
- [x] **Error**  integration/test_vm_functions.py::TestVMClone::test_clone_stopped_vm::setup
- [x] **Error**  integration/test_vm_functions.py::TestVMWithVolumes::test_create_with_two_volumes::setup
- [x] **Error**  integration/test_vm_functions.py::TestVMWithVolumes::test_create_with_existing_volume::setup
- [x] **Failed** integration/test_images.py::test_create_with_url
- [x] **Failed** integration/test_volumes.py::test_create_volume_backing_image


## Others: (will not fix in this PR, might need more test or investigate)
- [ ] **Error**   integration/test_upgrade.py::TestThreeNodesUpgrade::test_perform_upgrade::setup
    know issue, it's template code for upgrade
- [ ] **Failed**  integration/test_hosts.py::test_maintenance_mode_trigger_vm_migrate
- [ ] **Failed**  integration/test_rancher_integration.py::TestRKE::test_create_rke1
- [ ] **Failed**  apis/test_hosts.py::test_maintenance_mode
- [ ] **Failed**  apis/test_images.py::test_create_with_invalid_url
- [ ] **Failed**  apis/test_networks.py::TestNetworksNegative::test_create_with_invalid_id[0]
- [ ] **Failed**  apis/test_networks.py::TestNetworksNegative::test_create_with_invalid_id[4095]
- [ ] **Failed**  apis/test_networks.py::TestNetworks::test_create
- [ ] **Failed**  scenarios/test_create_vm.py::test_create_vm_do_not_start
- [ ] **Failed**  scenarios/test_create_vm.py::test_create_vm_on_available_cpu_node
- [ ] **Failed**  scenarios/test_create_vm.py::test_update_vm_on_available_cpu_node
- [ ] **Failed**  scenarios/test_create_vm.py::test_host_maintenance_mode