### PR TITLE
[e2e] fix e2e testing errors for v1.1-head

### DIFF
--- a/apiclient/harvester_api/managers.py
+++ b/apiclient/harvester_api/managers.py
@@ -105,10 +105,10 @@ class HostManager(BaseManager):
     def get_metrics(self, name="", *, raw=False):
         return self._get(self.METRIC_fmt.format(uid=name), raw=raw)
 
-    def maintenance_mode(self, name, enable=True):
+    def maintenance_mode(self, name, enable=True, force=False):
         action = "enable" if enable else "disable"
         params = dict(action=f"{action}MaintenanceMode")
-        self._create(self.PATH_fmt.format(uid=name), params=params)
+        self._create(self.PATH_fmt.format(uid=name), params=params, data=dict(force=force))
         return self.get(name)
 
 

--- a/apiclient/harvester_api/managers.py
+++ b/apiclient/harvester_api/managers.py
@@ -108,8 +108,8 @@ class HostManager(BaseManager):
     def maintenance_mode(self, name, enable=True, force=False):
         action = "enable" if enable else "disable"
         params = dict(action=f"{action}MaintenanceMode")
-        self._create(self.PATH_fmt.format(uid=name), params=params, data=dict(force=force))
-        return self.get(name)
+        payload = dict(force=str(force).lower())
+        return self._create(self.PATH_fmt.format(uid=name), params=params, json=payload)
 
 
 class ImageManager(BaseManager):

--- a/harvester_e2e_tests/apis/test_hosts.py
+++ b/harvester_e2e_tests/apis/test_hosts.py
@@ -85,8 +85,8 @@ def test_maintenance_mode(api_client, wait_timeout):
     endtime = datetime.now() + timedelta(seconds=wait_timeout)
     while endtime > datetime.now():
         _, stats = api_client.hosts.get(node_id)
-        if ("harvesterhci.io/maintain-status" not in node_stats["metadata"]["annotations"]
-           and "unschedulable" not in node_stats["spec"]):
+        if ("harvesterhci.io/maintain-status" not in stats["metadata"]["annotations"]
+           and "unschedulable" not in stats["spec"]):
             break
         sleep(5)
     else:

--- a/harvester_e2e_tests/apis/test_images.py
+++ b/harvester_e2e_tests/apis/test_images.py
@@ -170,9 +170,9 @@ def test_create_with_invalid_url(api_client, unique_name, wait_timeout):
             break
         sleep(3)
 
-    assert len(image_conds) == 1, f"Got unexpected image conditions!\n{data}"
-    assert "Initialized" == image_conds[0].get("type")
-    assert "False" == image_conds[0].get("status")
-    assert "no such host" in image_conds[0].get("message")
+    assert len(image_conds) in (1, 2), f"Got unexpected image conditions!\n{data}"
+    assert "Initialized" == image_conds[-1].get("type")
+    assert "False" == image_conds[-1].get("status")
+    assert "no such host" in image_conds[-1].get("message")
 
     api_client.images.delete(unique_name)

--- a/harvester_e2e_tests/apis/test_networks.py
+++ b/harvester_e2e_tests/apis/test_networks.py
@@ -58,14 +58,28 @@ class TestNetworksNegative:
         assert 422 == code, (code, data)
         assert "Invalid" == data.get("reason"), (code, data)
 
+    @pytest.mark.parametrize("vlan_id", [4095])
+    @pytest.mark.skip_version_before("v1.1.0")  # ref to harvester/issues/3151
+    def test_create_with_invalid_id_110(self, api_client, unique_name, vlan_id):
+        code, data = api_client.networks.create(unique_name, vlan_id)
+
+        assert 422 == code, (vlan_id, code, data)
+        assert "Invalid" == data.get("reason"), (vlan_id, code, data)
+
 
 @pytest.mark.p0
 @pytest.mark.networks
 class TestNetworks:
 
     @pytest.mark.dependency(name="create_network")
+    @pytest.mark.skip_version_after("v1.0.3")
     def test_create(self, api_client, unique_name):
         code, data = api_client.networks.create(unique_name, VLAN_ID)
+        assert 201 == code, (code, data)
+
+    @pytest.mark.skip_version_before("v1.1.0")
+    def test_create_110(self, api_client, unique_name):
+        code, data = api_client.networks.create(unique_name, VLAN_ID, cluster_network='mgmt')
         assert 201 == code, (code, data)
 
     @pytest.mark.dependency(depends=["create_network"])

--- a/harvester_e2e_tests/apis/test_networks.py
+++ b/harvester_e2e_tests/apis/test_networks.py
@@ -46,7 +46,7 @@ class TestNetworksNegative:
 
     @pytest.mark.parametrize("vlan_id", [0, 4095])
     @pytest.mark.skip_version_after("v1.0.3")  # ref to harvester/issues/3151
-    def test_create_with_invalid_id(self, api_client, unique_name, vlan_id):
+    def test_create_with_invalid_id_103(self, api_client, unique_name, vlan_id):
         code, data = api_client.networks.create(unique_name, vlan_id)
 
         assert 422 == code, (vlan_id, code, data)
@@ -60,7 +60,7 @@ class TestNetworksNegative:
 
     @pytest.mark.parametrize("vlan_id", [4095])
     @pytest.mark.skip_version_before("v1.1.0")  # ref to harvester/issues/3151
-    def test_create_with_invalid_id_110(self, api_client, unique_name, vlan_id):
+    def test_create_with_invalid_id(self, api_client, unique_name, vlan_id):
         code, data = api_client.networks.create(unique_name, vlan_id)
 
         assert 500 == code, (vlan_id, code, data)
@@ -73,12 +73,12 @@ class TestNetworks:
 
     @pytest.mark.dependency(name="create_network")
     @pytest.mark.skip_version_after("v1.0.3")
-    def test_create(self, api_client, unique_name):
+    def test_create_103(self, api_client, unique_name):
         code, data = api_client.networks.create(unique_name, VLAN_ID)
         assert 201 == code, (code, data)
 
     @pytest.mark.skip_version_before("v1.1.0")
-    def test_create_110(self, api_client, unique_name):
+    def test_create(self, api_client, unique_name):
         code, data = api_client.networks.create(unique_name, VLAN_ID, cluster_network='mgmt')
         assert 201 == code, (code, data)
 

--- a/harvester_e2e_tests/apis/test_networks.py
+++ b/harvester_e2e_tests/apis/test_networks.py
@@ -63,8 +63,8 @@ class TestNetworksNegative:
     def test_create_with_invalid_id_110(self, api_client, unique_name, vlan_id):
         code, data = api_client.networks.create(unique_name, vlan_id)
 
-        assert 422 == code, (vlan_id, code, data)
-        assert "Invalid" == data.get("reason"), (vlan_id, code, data)
+        assert 500 == code, (vlan_id, code, data)
+        assert "InternalError" == data.get("reason"), (vlan_id, code, data)
 
 
 @pytest.mark.p0

--- a/harvester_e2e_tests/fixtures/api_client.py
+++ b/harvester_e2e_tests/fixtures/api_client.py
@@ -147,11 +147,13 @@ def k8s_version(request):
 @pytest.fixture(autouse=True)
 def skip_version_before(request, api_client):
     mark = request.node.get_closest_marker("skip_version_before")
-    if mark and parse_version(mark.args[0]) > api_client.cluster_version:
-        pytest.skip(
-            f"Cluster Version `{api_client.cluster_version}` is not included"
-            f" in the supported version (most >= `{mark.args[0]}`)"
-        )
+    if mark:
+        cluster_ver = api_client.cluster_version
+        if '-head' not in cluster_ver.public and parse_version(mark.args[0]) > cluster_ver:
+            pytest.skip(
+                f"Cluster Version `{api_client.cluster_version}` is not included"
+                f" in the supported version (most >= `{mark.args[0]}`)"
+            )
 
 
 @pytest.fixture(autouse=True)
@@ -159,7 +161,7 @@ def skip_version_after(request, api_client):
     mark = request.node.get_closest_marker("skip_version_after")
     if mark:
         cluster_ver = api_client.cluster_version
-        if hasattr(cluster_ver, 'major') and parse_version(mark.args[0]) <= cluster_ver:
+        if not hasattr(cluster_ver, 'major') or parse_version(mark.args[0]) <= cluster_ver:
             pytest.skip(
                 f"Cluster Version `{api_client.cluster_version}` is not included"
                 f" in the supported version (most < `{mark.args[0]}`)"

--- a/harvester_e2e_tests/fixtures/api_client.py
+++ b/harvester_e2e_tests/fixtures/api_client.py
@@ -157,11 +157,13 @@ def skip_version_before(request, api_client):
 @pytest.fixture(autouse=True)
 def skip_version_after(request, api_client):
     mark = request.node.get_closest_marker("skip_version_after")
-    if mark and parse_version(mark.args[0]) <= api_client.cluster_version:
-        pytest.skip(
-            f"Cluster Version `{api_client.cluster_version}` is not included"
-            f" in the supported version (most < `{mark.args[0]}`)"
-        )
+    if mark:
+        cluster_ver = api_client.cluster_version
+        if hasattr(cluster_ver, 'major') and parse_version(mark.args[0]) <= cluster_ver:
+            pytest.skip(
+                f"Cluster Version `{api_client.cluster_version}` is not included"
+                f" in the supported version (most < `{mark.args[0]}`)"
+            )
 
 
 @pytest.fixture(scope="session")

--- a/harvester_e2e_tests/integration/test_hosts.py
+++ b/harvester_e2e_tests/integration/test_hosts.py
@@ -226,7 +226,7 @@ def test_maintenance_mode_trigger_vm_migrate(api_client, focal_vm, wait_timeout,
     src_host = data['status']['nodeName']
 
     code, data = api_client.hosts.maintenance_mode(src_host, enable=True)
-    assert 200 == code, (
+    assert 204 == code, (
         f"Failed to enable maintenance mode on node {src_host} with error: {code}, {data}",
     )
 
@@ -260,7 +260,7 @@ def test_maintenance_mode_trigger_vm_migrate(api_client, focal_vm, wait_timeout,
 
     # teardown
     code, data = api_client.hosts.maintenance_mode(src_host, enable=False)
-    assert 200 == code, (
+    assert 204 == code, (
         f"Failed to disable maintenance mode on node {src_host} with error: {code}, {data}",
     )
 

--- a/harvester_e2e_tests/integration/test_hosts.py
+++ b/harvester_e2e_tests/integration/test_hosts.py
@@ -169,7 +169,8 @@ def test_host_poweron_state(api_client, host_state, wait_timeout):
     endtime = datetime.now() + timedelta(seconds=wait_timeout)
     while endtime > datetime.now():
         _, metric = api_client.hosts.get_metrics(node['id'])
-        if not metric.get("metadata", {}).get("state", {}).get("error"):
+        state = metric.get("metadata", {}).get("state", {})
+        if not state.get("error") or state.get('name') != 'unavailable':
             break
         sleep(5)
     else:

--- a/harvester_e2e_tests/integration/test_volumes.py
+++ b/harvester_e2e_tests/integration/test_volumes.py
@@ -78,7 +78,7 @@ def validate_blank_volumes(request, admin_session, get_api_link):
 
 @pytest.mark.volumes
 @pytest.mark.p1
-def test_create_volume_backing_image(api_client, unique_name, opensuse_image,
+def test_create_volume_backing_image(api_client, unique_name, image_opensuse,
                                      wait_timeout, sleep_timeout):
     """
     1. Create a new image from URL
@@ -88,7 +88,7 @@ def test_create_volume_backing_image(api_client, unique_name, opensuse_image,
     5. Delete image and volume
     """
 
-    code, image_data = api_client.images.create_by_url(unique_name, opensuse_image.url)
+    code, image_data = api_client.images.create_by_url(unique_name, image_opensuse.url)
 
     assert 201 == code, (code, image_data)
 


### PR DESCRIPTION
## Changes (Based on `harvester-install-and-test/build#673`)
- [apiclient] add new parameter `force=False` for `hosts.maintenance_mode`
- Update `apis/test_hosts.py` to wait node entering maintenance mode for its enhancement https://github.com/harvester/harvester/issues/3363
- Update `apis/test_images.py` to include condition of retry which introduced in https://github.com/harvester/harvester/pull/3148
- Update `apis/test_networks.py` and fixture `skip_version_after` to skip test case correctly
- Add new test case to fulfill skipped test cases in `apis/test_networks.py`
- Update `integration/test_volumes.py` to fix fixture reference


## To fix
- [x] apis/test_hosts.py::test_maintenance_mode
- [x] apis/test_images.py::test_create_with_invalid_url
- [x] apis/test_networks.py::TestNetworksNegative::test_create_with_invalid_id[0]
- [x] apis/test_networks.py::TestNetworksNegative::test_create_with_invalid_id[4095] 
- [x] apis/test_networks.py::TestNetworks::test_create 
- [x] integration/test_volumes.py::test_create_volume_backing_image

## Need more monitoring
- [ ] integration/test_rancher_integration.py::TestRKE::test_create_rke1
- [ ] integration/test_backup_target.py::test_invalid_backup_target_nfs
- [x] integration/test_hosts.py::test_host_poweron_state


## Won't fix
### Potential bug
- [ ] integration/test_hosts.py::test_maintenance_mode_trigger_vm_migrate
### Legacy code
- [ ] scenarios/test_create_vm.py::test_create_vm_on_available_cpu_node
- [ ] scenarios/test_create_vm.py::test_update_vm_on_available_cpu_node
- [ ] scenarios/test_vm_actions.py::test_restore_backup_vm_on
