### PR TITLE
* [apiclient] update for new kubeconfig endpoint

### DIFF
--- a/apiclient/harvester_api/api.py
+++ b/apiclient/harvester_api/api.py
@@ -116,7 +116,13 @@ class HarvesterAPI:
         self.session.mount("http://", adapter)
 
     def generate_kubeconfig(self):
-        path = "v1/management.cattle.io.clusters/local?action=generateKubeconfig"
+        # `v1.2-xxx-head` will less than v1.2.0, so use `v1.1.99` instead.
+        if self.cluster_version < parse_version('v1.1.99'):
+            path = "v1/management.cattle.io.clusters/local?action=generateKubeconfig"
+        else:
+            # new endpoint since embeded rancher introduced
+            path = "v3/clusters/local?action=generateKubeconfig"
+
         r = self._post(path)
         return r.json()['config']
 


### PR DESCRIPTION
We can also use EAFP (more pythonic) for the change like:
```python
try:
    r = self._post('NEW_PATH')
    return r.json()['config']
except requests.exceptions.JSONDecodeError:
    # new path is not available in old Harvester version
    r = self._post("OLD_PATH")
    return r.json()['config']
```

but consider that we might remove old version support and LBYL in this case is more explicit and readable, so this change will use LBYL for it.