### PR TITLE
Fix protocol in cloud image example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ For example, to overwrite the `endpoint` option, we can use the `--endpoint` par
 - `image-cache-url`
 - `win-image-url`
 
-While running the tests, the image fixtures will attempt to create the test images by providing the download URLs for the various cloud image providers (e.g. `htps://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.3/images/openSUSE-Leap-15.3.x86_64-NoCloud.qcow2`). Sometimes a given cloud image provider URL can be slow or inaccessible, which cause the underlying tests to fail. Therefore, it is recommended to create a local web server to cache the images that the tests depended on. We can then use the `--image-cache-url` parameter to convey the image cache URL to the tests. The absence of the `--image-cache-url` parameter means the tests will attempt to directly download the images directly from the cloud image providers instead.
+While running the tests, the image fixtures will attempt to create the test images by providing the download URLs for the various cloud image providers (e.g. `https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.3/images/openSUSE-Leap-15.3.x86_64-NoCloud.qcow2`). Sometimes a given cloud image provider URL can be slow or inaccessible, which cause the underlying tests to fail. Therefore, it is recommended to create a local web server to cache the images that the tests depended on. We can then use the `--image-cache-url` parameter to convey the image cache URL to the tests. The absence of the `--image-cache-url` parameter means the tests will attempt to directly download the images directly from the cloud image providers instead.
 
 ### Network Config Options <a name="network_config" />
 - `vlan-id`, be used to create **VM Network**, should be integer and in range 1 to 4094


### PR DESCRIPTION
Change "htps" to "https", just in case someone copies and pastes the link when setting up their image cache web server for running the tests.

Before:

	$ curl -Lk --head htps://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.3/images/openSUSE-Leap-15.3.x86_64-NoCloud.qcow2
	curl: (1) Protocol "htps" not supported or disabled in libcurl

After:

	$ curl -Lk --head https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.3/images/openSUSE-Leap-15.3.x86_64-NoCloud.qcow2
	HTTP/2 302
	date: Tue, 09 May 2023 15:07:17 GMT
	location: https://mirrorcache-us.opensuse.org/repositories/Cloud:/Images:/Leap_15.3/images/openSUSE-Leap-15.3.x86_64-NoCloud.qcow2
	server: Apache

	HTTP/2 302
	content-length: 0
	date: Tue, 09 May 2023 15:07:17 GMT
	location: https://downloadcontent-us1.opensuse.org/repositories/Cloud:/Images:/Leap_15.3/images/openSUSE-Leap-15.3.x86_64-NoCloud.qcow2
	vary: Accept, COUNTRY
	x-frame-options: SAMEORIGIN
	x-xss-protection: 1; mode=block
	x-content-type-options: nosniff
	referrer-policy: no-referrer-when-downgrade
	strict-transport-security: max-age=31536000;includeSubDomains;preload

	HTTP/1.1 302 Moved Temporarily
	Server: nginx
	Date: Tue, 09 May 2023 15:07:18 GMT
	Content-Type: text/html
	Content-Length: 138
	Connection: keep-alive
	Location: https://downloadcontent.opensuse.org./repositories/Cloud:/Images:/Leap_15.3/images/openSUSE-Leap-15.3.x86_64-NoCloud.qcow2

	HTTP/2 200
	server: nginx
	date: Tue, 09 May 2023 15:07:18 GMT
	content-type: application/octet-stream
	content-length: 590348288
	last-modified: Tue, 09 May 2023 13:03:48 GMT
	etag: "645a44b4-23300000"
	strict-transport-security: max-age=31536000
	accept-ranges: bytes