### PR TITLE
[e2e] add  keyword for test selection

### DIFF
--- a/harvester_e2e_tests/conftest.py
+++ b/harvester_e2e_tests/conftest.py
@@ -345,7 +345,8 @@ def pytest_configure(config):
         config.addinivalue_line("markers", f"{m}:{msg.format(_r=related)}")
 
 
-def pytest_collection_modifyitems(config, items):
+@pytest.hookimpl(hookwrapper=True)
+def pytest_collection_modifyitems(session, config, items):
     if config.getoption('--vlan-id') == -1:
         skip_public_network = pytest.mark.skip(reason=(
             'VM not accessible because no VLAN setup with public routing'))
@@ -394,3 +395,62 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "delete_host" in item.keywords:
                 item.add_marker(pytest.mark.skip(reason="Not configured to test host deletion."))
+
+    # legacy code above
+    # ''' To enable the test select with `and depends` keyword,
+    #     to select test cases and it depended test cases.
+    # '''
+
+    if "and depends" not in config.option.keyword:
+        # DO nothing
+        yield
+        return
+
+    all_items, old_keyword = items.copy(), config.option.keyword
+    config.option.keyword = old_keyword.replace('and depends', '')
+
+    yield
+
+    scope_cls = {
+        "session": pytest.Session,
+        "package": pytest.Package,
+        "module": pytest.Module,
+        "class": pytest.Class
+    }
+    # ref: https://github.com/RKrahl/pytest-dependency/blob/0.5.1/pytest_dependency.py#L77
+    # named_items : dict['dep-scope', dict['dep-name', list['test-item']]]
+    deselected, named_items = list(), dict()
+    for item in all_items:
+        if item in items:
+            continue
+        try:
+            marker = item.get_closest_marker('dependency')
+            scope = marker.kwargs.get('scope', 'module')
+            node = item.getparent(scope_cls[scope])
+            named_items.setdefault(node, {}).setdefault(marker.kwargs['name'], [])
+            named_items[node][marker.kwargs['name']].append(item)
+        except AttributeError:
+            deselected.append(item)
+            continue
+        except KeyError:
+            nodeid = item.nodeid.replace("::()::", "::")
+            if scope not in ("session", "package"):
+                idx = 2 if scope == "class" else 1
+                nodeid = nodeid.split("::", idx)[idx]
+            named_items[node].setdefault(nodeid, []).append(item)
+
+    depends = []
+    for item in items:
+        try:
+            marker = item.get_closest_marker('dependency')
+            scope = marker.kwargs.get('scope', 'module')
+            node = item.getparent(scope_cls[scope])
+            for name in marker.kwargs['depends']:
+                depends.extend(named_items[node].pop(name, []))
+        except (AttributeError, KeyError):
+            continue
+
+    session.items = depends + items
+    deselected.extend(t for v in named_items.values() for ts in v.values() for t in ts)
+    # update to let the report shows correct counts
+    config.pluginmanager.get_plugin('terminalreporter').stats['deselected'] = deselected


### PR DESCRIPTION
## Changes
- **ADD** `__init__.py` file to make `package` scope for **integration**
- **add** `and depends` keyword for test selection when using `-k` to select test cases

for example, when we want to test `delete_rke2`, it would also need select the test `create_rke2`, otherwise the test will pass with test skipped:
![image](https://github.com/harvester/tests/assets/5169694/6135119e-e469-472f-9c15-8fb827f57f72)
![image](https://github.com/harvester/tests/assets/5169694/a7a7095f-8a5d-4607-828f-0f789349f1e6)

and now we can use `and depends` to select the test and its depended test cases:
![image](https://github.com/harvester/tests/assets/5169694/e766560b-ce30-4601-8f2a-93a26798567f)

To be aware that this PR will not recursively add all depended test cases[^1] (it's the known issue):
![image](https://github.com/harvester/tests/assets/5169694/52a164b2-f7d6-4ec1-bb93-6df2a828b357)

[^1]: for `test_start` in `test_vm_functions.py`, it will depends on `test_stop` which depends on `minimal_vm`, so in this case, we should select `test_minimal_vm`, `test_stop` then `test_start`