### PR TITLE
Update test plan of manually install Harvester csi-driver on RKE2 and K3s cluster

### DIFF
--- a/docs/content/manual/harvester-rancher/66-deploy-harvester-csi-driver-to-k3s-cluster.md
+++ b/docs/content/manual/harvester-rancher/66-deploy-harvester-csi-driver-to-k3s-cluster.md
@@ -2,52 +2,68 @@
 title: 66-Deploy Harvester csi driver to k3s Cluster	
 ---
 
-* Related task: [#1812](https://github.com/harvester/harvester/issues/1812) K3s cloud provider and csi driver support
+* Related task: [#2755](https://github.com/harvester/harvester/issues/2755#issuecomment-1552842389) Steps to manually install Harvester csi-driver on K3s cluster
 
-### Environment Setup
-1. Docker install rancher v2.6.4
-1. Create one node harvester with enough resource
+
+### Reference Document
+[Deploying with Harvester K3s Node Driver](https://deploy-preview-309--harvester-preview.netlify.app/dev/rancher/csi-driver/#deploying-with-harvester-k3s-node-driver)
 
 ### Verify steps
-Follow step **1~13** in tets plan `59-Create K3s Kubernetes Cluster`
-
-1. Download the [Generate addon configuration](https://github.com/harvester/harvester-csi-driver/blob/master/deploy/generate_addon.sh) for csi driver
-1. ssh to harvester node 1
-1. Execute `cat /etc/rancher/rke2/rke2.yaml`  
-1. change the server value from https://127.0.0.1:6443 to your node1 IP
+1. Prepare a Harvester cluster with enough cpu, memory and disks for K3s guest cluster
+1. Create a Rancher instance 
+1. Import Harvester in Rancher and create cloud credential
+1. ssh to Harvester management node 
+1. Extract the kubeconfig of Harvester with `cat /etc/rancher/rke2/rke2.yaml` 
+1. Change the server value from https://127.0.0.1:6443/ to your VIP 
 1. Copy the kubeconfig and add into your local ~/.kube/config file
-1. Generate K3s kubeconfig by running generate addon script
-` ./deploy/generate_addon.sh <k3s cluster name> <namespace>`
-e.g `./generate_addon.sh k3s-csi-cluster default`
-1. Copy the ks3 kubeconfig content start with `cloud-provider-config:` between `addons_include:`
-1. ssh to K3s VM
-  ![image](https://user-images.githubusercontent.com/29251855/158932912-38297b70-7546-4349-801f-6a4b8b973305.png)
+1. Import Harvester in Rancher
+1. Create cloud credential 
+1. Provision a k3s cluster 
+  ![image](https://github.com/harvester/harvester/assets/29251855/98f9d10f-2307-4aa5-bd47-3e68e03c2232)
 
-1. Add kubeconfig content to `/etc/kubernetes/cloud-config`file, remember to align the yaml layout
-1. Install Harvester csi driver
-  ![image](https://user-images.githubusercontent.com/29251855/158550983-61cff655-66a6-4a49-96bd-6e208f4fc9d8.png)
-  ![image](https://user-images.githubusercontent.com/29251855/158551034-090cee3d-9bd6-425c-84d8-16f6a66a5c64.png)
-  ![image](https://user-images.githubusercontent.com/29251855/158933473-a0172a62-5f7c-4e68-860c-c9cb38275791.png)
-  ![image](https://user-images.githubusercontent.com/29251855/158933756-d4198111-ae05-4a7d-8ea8-d21e3f3d2b87.png)
+1. Provide the login credential in user data
+    ```
+    password: 123456
+    chpasswd: { expire: False }
+    ssh_pwauth: True
+    ```
+1. On K3s, by default will not provide cloud-provider
+  ![image](https://github.com/harvester/harvester/assets/29251855/5058509e-f82e-4f98-af39-3d4e7ad54127)
+
+1. Check k3s cluster provisioning in Ready
+  ![image](https://github.com/harvester/harvester/assets/29251855/3acc2867-006b-4fa9-ba37-2e663eaaa8d4)
 
 
+1. Use the new [generate_cloud_provider_config.sh](https://github.com/harvester/harvester-csi-driver/pull/24/files) to generate `cloud-config` content for csi-driver
+    ```
+    ./generate_cloud_provider_config.sh <serviceaccount name> <namespace>
+    
+    e.g ./generate_cloud_provider_config.sh k3s default
+    
+    ```
+1. ssh to the k3s guest cluster vm
+1. Create the config-files directory
+    ```
+    mkdir -p /var/lib/rancher/rke2/etc/config-files
+    ```
+
+1. Add the cloud-provider-config file from the cloud-config part of output generated from script 
+    ```
+    vim /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
+    ```
+
+1. Access k3s guest cluster on Rancher 
+1. Switch to `All Namespace`
+1. Open Apps -> Charts
+1. Install Harvester CSI Driver from the Rancher marketplace. You do not need to change the cloud-config path. 
+    ![image](https://github.com/harvester/harvester/assets/29251855/188af4e3-9735-4c59-868d-2173c1ea3971)
 
 
 ## Expected Results
-1. Can deploy K3s cluster on harvester with kubernetes version `v1.23.4+k3s1`
-  ![image](https://user-images.githubusercontent.com/29251855/158935474-9d6f1c37-ea59-485d-83f5-6f1b19ebfa98.png)
+1. Check can successfully install csi-driver on `Installed Apps`
+  ![image](https://github.com/harvester/harvester/assets/29251855/4493d3d1-230f-4651-a9ce-cc25eae8459e)
 
-1. Can correctly install harvester csi driver on K3s cluster
-  ![image](https://user-images.githubusercontent.com/29251855/158933473-a0172a62-5f7c-4e68-860c-c9cb38275791.png)
-  ![image](https://user-images.githubusercontent.com/29251855/158933756-d4198111-ae05-4a7d-8ea8-d21e3f3d2b87.png)
 
-1. Can deploy nginx service with new PVC created
-  ![image](https://user-images.githubusercontent.com/29251855/158934469-6b050d39-a45c-493d-9e29-89e16c1cf23d.png)
-  ![image](https://user-images.githubusercontent.com/29251855/158934499-6c7d9525-f43a-4426-8786-1e4aec099964.png)
-  ![image](https://user-images.githubusercontent.com/29251855/158934531-9c42b704-67cc-4c91-b24e-fa29f7183f05.png)
-1. Can allocate size in nginx container 
-  ![image](https://user-images.githubusercontent.com/29251855/158934986-c08ddccc-3b33-4508-9861-6d10c5ded3c5.png)
-1. Can resize and delete volume with harvester storage class
-  ![image](https://user-images.githubusercontent.com/29251855/158935263-a8b6fa9e-1f4b-43ae-a687-6df3e34986a1.png)
-  ![image](https://user-images.githubusercontent.com/29251855/158935288-67409de3-d5d5-4c9d-af04-421f4153658b.png)
+1. Check `Harvester` set to the `default` storage class
+  ![image](https://github.com/harvester/harvester/assets/29251855/34489066-ea70-4271-a64f-12e9018aaa95)
 

--- a/docs/content/manual/harvester-rancher/66-deploy-harvester-csi-driver-to-k3s-cluster.md
+++ b/docs/content/manual/harvester-rancher/66-deploy-harvester-csi-driver-to-k3s-cluster.md
@@ -58,6 +58,11 @@ title: 66-Deploy Harvester csi driver to k3s Cluster
 1. Install Harvester CSI Driver from the Rancher marketplace. You do not need to change the cloud-config path. 
     ![image](https://github.com/harvester/harvester/assets/29251855/188af4e3-9735-4c59-868d-2173c1ea3971)
 
+1. Open Storage -> StorageClasses
+1. PersistentVolumeClaims page
+1. Create a PVC named `test-pvc`, select `Harvester` in the Storage Class
+    ![image](https://github.com/harvester/harvester/assets/29251855/cf4e1682-3774-4b57-b897-411f36d1bc44)
+
 
 ## Expected Results
 1. Check can successfully install csi-driver on `Installed Apps`
@@ -67,3 +72,6 @@ title: 66-Deploy Harvester csi driver to k3s Cluster
 1. Check `Harvester` set to the `default` storage class
   ![image](https://github.com/harvester/harvester/assets/29251855/34489066-ea70-4271-a64f-12e9018aaa95)
 
+1. Check the `test-pvc` exists on `PersistentVolumeClaims` page
+1. Check a new pv created on PersistentVolumes  
+1. Check the created pv also exists on Harvester Volumes page

--- a/docs/content/manual/harvester-rancher/67-harvester-persistent-volume-on-k3s-cluster.md
+++ b/docs/content/manual/harvester-rancher/67-harvester-persistent-volume-on-k3s-cluster.md
@@ -2,56 +2,59 @@
 title: 67-Harvester persistent volume on k3s Cluster	
 ---
 
-* Related task: [#1812](https://github.com/harvester/harvester/issues/1812) K3s cloud provider and csi driver support
-
-### Environment Setup
-1. Docker install rancher v2.6.4
-1. Create one node harvester with enough resource
+* Related task: [#2755](https://github.com/harvester/harvester/issues/2755#issuecomment-1552842389) Steps to manually install Harvester csi-driver on K3s cluster
 
 ### Verify steps
-Follow step **1~6** in tets plan `66-Deploy Harvester csi driver to k3s Cluster`
+Follow test case `66-Deploy Harvester csi driver to k3s Cluster` to manually install csi-driver on k3s cluster
 
-#### Create Nginx workload for testing
-1. Create a nginx-csi deployment with image nginx:latest.
-  ![image](https://user-images.githubusercontent.com/29251855/158934043-11d94957-5b85-469e-bdf7-5658edfec5d9.png)
+1. Create a nginx deployment in Workload -> Deployments
+1. Create a Persistent Volume Claims, select storage class to `harvester` 
+1. Select the `Single-Node Read/Write`
 
-
-1. Create a new PVC in storage tab: 
-  ![image](https://user-images.githubusercontent.com/29251855/158934170-8cb212e7-c84c-48d4-a15d-b921a9e6a8fc.png)
-
-1. Complete the nginx deployment, create related PV in Harvester volume
-  ![image](https://user-images.githubusercontent.com/29251855/158934469-6b050d39-a45c-493d-9e29-89e16c1cf23d.png)
-  ![image](https://user-images.githubusercontent.com/29251855/158934499-6c7d9525-f43a-4426-8786-1e4aec099964.png)
-  ![image](https://user-images.githubusercontent.com/29251855/158934531-9c42b704-67cc-4c91-b24e-fa29f7183f05.png)
-
+1. Open Harvester Volumes page, check the corresponding volume exists
+  ![image](https://github.com/harvester/harvester/assets/29251855/8330c45f-ade1-4819-b2f0-5206e32123b6)
 
 1. Click Execute shell to access Nginx container.
-1. Run `dd if=/dev/zero of=/test/tmpfile bs=1M count=512`
 1. Run `dd if=/dev/null of=/test/tmpfile bs=1M count=512`
  ![image](https://user-images.githubusercontent.com/29251855/158934986-c08ddccc-3b33-4508-9861-6d10c5ded3c5.png)
 
 1. Delete the Nginx deployment.
 
-#### Resize and delete volume with harvester storage class
+1. Create a standalone PVC on `PersistentVolumeClaims` page with `harvester` storage class
+
 1. Change to Harvester dashboard.
 1. Click the Edit config for the volume.
 1. Change volume size. We can see the volume is in Resizing status.
-![image](https://user-images.githubusercontent.com/29251855/158935263-a8b6fa9e-1f4b-43ae-a687-6df3e34986a1.png)
-![image](https://user-images.githubusercontent.com/29251855/158935288-67409de3-d5d5-4c9d-af04-421f4153658b.png)
-1. Delete PVC in k3s dashboard.
-1. Related volume should be deleted in Harvester too.
 
+1. Delete PVC in k3s dashboard.
 
 
 
 ## Expected Results
-1. Can deploy nginx service with new PVC created
-  ![image](https://user-images.githubusercontent.com/29251855/158934469-6b050d39-a45c-493d-9e29-89e16c1cf23d.png)
-  ![image](https://user-images.githubusercontent.com/29251855/158934499-6c7d9525-f43a-4426-8786-1e4aec099964.png)
-  ![image](https://user-images.githubusercontent.com/29251855/158934531-9c42b704-67cc-4c91-b24e-fa29f7183f05.png)
-1. Can allocate size in nginx container 
+
+1. Check can deploy nginx service correctly
+  ![image](https://github.com/harvester/harvester/assets/29251855/53b606b9-f429-4806-8c5d-4fa2e06e9cf3)
+
+
+1. Check can correctly create PVC in `PersistenVolumeClaims`
+  ![image](https://github.com/harvester/harvester/assets/29251855/631e0977-51e0-491f-9cca-d01f88c41253)
+
+
+1. Check can correctly create PV in `PersistentVolumes` 
+  ![image](https://github.com/harvester/harvester/assets/29251855/d9fb5bf1-debb-4644-8c9d-424cee6a5f22)
+
+1. Check can allocate size in nginx container 
   ![image](https://user-images.githubusercontent.com/29251855/158934986-c08ddccc-3b33-4508-9861-6d10c5ded3c5.png)
-1. Can resize and delete volume with harvester storage class
+
+1. Check the created stand alone PVC and PV on Rancher and Harvester volumes page
+  ![image](https://github.com/harvester/harvester/assets/29251855/a7029c09-84b6-4f49-bd6e-436162eece43)
+  ![image](https://github.com/harvester/harvester/assets/29251855/81c74645-2608-4fe4-9efa-bd8a7f34f295)
+  ![image](https://github.com/harvester/harvester/assets/29251855/8cf67085-6970-4a6c-a8e1-3f14b52e0b8c)
+
+
+
+1. Check can resize and delete volume with harvester storage class
   ![image](https://user-images.githubusercontent.com/29251855/158935263-a8b6fa9e-1f4b-43ae-a687-6df3e34986a1.png)
   ![image](https://user-images.githubusercontent.com/29251855/158935288-67409de3-d5d5-4c9d-af04-421f4153658b.png)
 
+1. Check the related volume should be deleted in Harvester too.

--- a/docs/content/manual/harvester-rancher/71-manually-deploy-csi-driver-to-rke2-cluster.md
+++ b/docs/content/manual/harvester-rancher/71-manually-deploy-csi-driver-to-rke2-cluster.md
@@ -1,0 +1,84 @@
+---
+title: 71-Manually Deploy Harvester csi driver to RKE2 Cluster	
+---
+
+* Related task: [#2755](https://github.com/harvester/harvester/issues/2755#issuecomment-1552839577) Steps to manually install Harvester csi-driver on RKE2 cluster
+
+### Reference Document
+[Deploying with Harvester RKE2 Node Driver](https://deploy-preview-309--harvester-preview.netlify.app/dev/rancher/csi-driver/#deploying-with-harvester-rke2-node-driver)
+
+### Verify steps
+1. ssh to Harvester management node 
+1. Extract the kubeconfig of Harvester with `cat /etc/rancher/rke2/rke2.yaml` 
+1. Change the server value from https://127.0.0.1:6443/ to your VIP 
+1. Copy the kubeconfig and add into your local ~/.kube/config file
+1. Import Harvester in Rancher
+1. Create cloud credential 
+1. Provision a RKE2 cluster 
+  ![image](https://github.com/harvester/harvester/assets/29251855/b3d0f21a-0f7a-40a9-a6af-5cedbdc0a13e)
+1. Provide the login credential in user data
+    ```
+    password: 123456
+    chpasswd: { expire: False }
+    ssh_pwauth: True
+    ```
+1. Select cloud-provider to `Default - RKE2 Embedded` (on Rancher 2.6 you need to select to NONE)
+  ![image](https://github.com/harvester/harvester/assets/29251855/73009f87-a0c7-4766-90c6-ff1bef8578e5)
+
+1. Check RKE2 cluster provisioning in Ready
+1. Use the new [generate_cloud_provider_config.sh](https://github.com/harvester/harvester-csi-driver/pull/24/files) to generate `cloud-config` content for csi-driver
+    ```
+    ./generate_cloud_provider_config.sh <serviceaccount name> <namespace>
+    
+    e.g ./generate_cloud_provider_config.sh rke2 default
+    
+    ```
+1. ssh to the RKE2 guest cluster vm
+1. Create the config-files directory
+    ```
+    mkdir -p /var/lib/rancher/rke2/etc/config-files
+    ```
+
+1. Add the cloud-provider-config file from the cloud-config part of output generated from script 
+    ```
+    vim /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
+    ```
+
+1. Access RKE2 guest cluster on Rancher 
+1. Switch to `All Namespace`
+1. Open Apps -> Charts
+1. Install Harvester CSI Driver from the Rancher marketplace. You do not need to change the cloud-config path. 
+![image](https://github.com/harvester/harvester/assets/29251855/0a02534b-8526-4616-9332-2aad383bc337)
+![image](https://github.com/harvester/harvester/assets/29251855/ce0606c4-c676-4ddd-a6b9-8c9c146c6555)
+
+1. Check can successfully install csi-driver on `Installed Apps`
+![image](https://github.com/harvester/harvester/assets/29251855/0d2853ed-eadc-47d9-b128-978ebf2cc5ea)
+
+1. Check `Harvester` set to the `default` storage class
+![image](https://github.com/harvester/harvester/assets/29251855/ef684d43-c871-4207-b49e-9732b29fc472)
+
+1. Create a nginx deployment in Workload -> Deployments
+1. Create a Persistent Volume Claims, select storage class to `harvester` 
+1. Select the `Single-Node Read/Write`
+
+1. Create a standalone PVC on `PersistentVolumeClaims` page with `harvester` storage class
+
+## Expected Results
+1. Check can deploy nginx service correctly
+![image](https://github.com/harvester/harvester/assets/29251855/b1beffb0-eee4-447c-95ff-ecf96790cfa1)
+
+1. Check can correctly create PVC in `PersistenVolumeClaims`
+![image](https://github.com/harvester/harvester/assets/29251855/03ad7f37-c016-4d2d-ab27-599b262022ad)
+
+1. Check can correctly create PV in `PersistentVolumes` 
+![image](https://github.com/harvester/harvester/assets/29251855/372ec12c-36b8-4251-b559-a0ae0f647cae)
+
+1. Open Harvester Volumes page, check the corresponding volume exists
+![image](https://github.com/harvester/harvester/assets/29251855/30752025-d062-4ae6-beee-54be3c90a3fb)
+
+1. Check can correctly create PVC and PV 
+  ![image](https://github.com/harvester/harvester/assets/29251855/ac3c12a2-9349-404c-8b2b-b1ca4e4e5a9d)
+  ![image](https://github.com/harvester/harvester/assets/29251855/12bfd2f6-d592-4b93-b48f-9a48cdd6a5bf)
+
+1. Check can create corresponding volume on Harvester 
+  ![image](https://github.com/harvester/harvester/assets/29251855/def1f0a2-bd9b-4c35-9081-eec32c2234c0)


### PR DESCRIPTION

According to the latest test result of:
* RKE2: https://github.com/harvester/harvester/issues/2755#issuecomment-1552839577
* K3s: https://github.com/harvester/harvester/issues/2755#issuecomment-1552842389

Update the current test plan of **manually** install `K3s` cluster and add a new test plan to install `RKE2` cluster 

1. Update test plan: 66-Deploy Harvester csi driver to k3s Cluster
2. Update test plan: 67-Harvester persistent volume on k3s Cluster
3. Add test plan: 71-Manually Deploy Harvester csi driver to RKE2 Cluster