### PR TITLE
Enhance apis test images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ terraform_test_artifacts/bin
 node_modules
 scripts/**/*.sh
 .vscode/
+.tox
+test_result.json
+.report.json

--- a/harvester_e2e_tests/apis/test_hosts.py
+++ b/harvester_e2e_tests/apis/test_hosts.py
@@ -153,6 +153,7 @@ def test_maintenance_mode(api_client, wait_timeout):
     status_code, node_stats = api_client.hosts.maintenance_mode(node_id, enable=True)
     assert 204 == status_code, (status_code, node_stats)
 
+    maintain_stat = ""
     endtime = datetime.now() + timedelta(seconds=wait_timeout)
     while endtime > datetime.now():
         _, stats = api_client.hosts.get(node_id)

--- a/harvester_e2e_tests/apis/test_images.py
+++ b/harvester_e2e_tests/apis/test_images.py
@@ -63,7 +63,7 @@ class TestImagesNegative:
 @pytest.mark.p0
 @pytest.mark.images
 class TestImages:
-    # TODO: This is a temporary enhancement for harvester#4027, consider just check return code after fix.
+    # TODO: This is a temporary fix for harvester#4027, consider just check return code after.
     def verify_image_created(self, api_client, unique_name, wait_timeout):
         endtime = datetime.now() + timedelta(seconds=wait_timeout)
         while endtime > datetime.now():

--- a/harvester_e2e_tests/apis/test_images.py
+++ b/harvester_e2e_tests/apis/test_images.py
@@ -63,7 +63,8 @@ class TestImagesNegative:
 @pytest.mark.p0
 @pytest.mark.images
 class TestImages:
-    def image_do_created(self, api_client, unique_name, wait_timeout):
+    # TODO: This is a temporary enhancement for harvester#4027, consider just check return code after fix.
+    def verify_image_created(self, api_client, unique_name, wait_timeout):
         endtime = datetime.now() + timedelta(seconds=wait_timeout)
         while endtime > datetime.now():
             code, data = api_client.images.get(unique_name)
@@ -94,7 +95,7 @@ class TestImages:
         assert len(data['items']) > 0, (code, data)
 
         # Case 2: get created image
-        self.image_do_created(api_client, unique_name, wait_timeout)
+        self.verify_image_created(api_client, unique_name, wait_timeout)
 
     def test_update(self, api_client, unique_name):
         updates = {
@@ -155,7 +156,7 @@ class TestImages:
             f"failed to upload fake image with reused name {unique_name}, "
             f"got error: {resp.status_code}, {resp.content}"
         )
-        self.image_do_created(api_client, unique_name, wait_timeout)
+        self.verify_image_created(api_client, unique_name, wait_timeout)
 
         _ = api_client.images.delete(unique_name)
         endtime = datetime.now() + timedelta(seconds=wait_timeout)


### PR DESCRIPTION
Propose some enhancement during verify harvester#3889 [[ENHANCEMENT] Harvester Single Node Cluster](https://github.com/harvester/harvester/issues/3889)

## Changes
1. Put test generated cache & report to .gitignore, includes:
   1. .tox
   1. test_result.json
   1. .report.json

1. Enhance TC error due to delete an image which is Initialized but still **Importing** 
   * Test Suite: `apis/test_images.py::TestImages`
   * Problem
     1. `api_client.images.get` reply 200 as long as the image status is `Initialized`. But it's possible that Longhorn still `Importing` it (`Initialized` but not `Imported` yet)
        <details>
          <summary>Imported v.s. Importing status in images.get response body</summary>
        
          ![importing_and_imported](https://github.com/harvester/tests/assets/2773781/1338700c-0299-4621-9b63-116a55022361)
        </details>
     1. Due to this, `test_get` is passed since it consider upload (`test_create`) was succeeded, thus immediately trigger `test_delete` on the image which Longhorn is still importing.
     1. This causes image record is deleted on Harvester but still existed on Longhorn, and causes successive TC `test_create_with_reuse_display_name` fail (504) due to it use the same image name `unique_name` which is still processing).
        <details>
          <summary>Fail example on harvester-runtests#277</summary>

          ![test_images-harvester-runtests#277](https://github.com/harvester/tests/assets/2773781/21f56d8c-838b-4ba0-ae2b-36e3c3cc352f)
        </details>
        
        <details>
          <summary>Image is deleted on Harvester but Longhorn is still processing.</summary>
        
          ![Screenshot_20230531_184652](https://github.com/harvester/tests/assets/2773781/4b27b602-8e3a-4024-99f6-076b28570adb)
          ![Screenshot_20230531_152020](https://github.com/harvester/tests/assets/2773781/30788810-eefb-412b-ab0d-82c297a802cd)
        </details>

   * Solution
     * Confirm image DO `Imported` after `api_client.images.create_by_file`
     * Tested on `harvester-runtests#278`
     ![test_images-harvester-runtests#278](https://github.com/harvester/tests/assets/2773781/dfc36407-6390-4027-abf3-b3614b51bec1)

      
   


