### PR TITLE
Enhance integration for single node cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ terraform_test_artifacts/bin
 node_modules
 scripts/**/*.sh
 .vscode/
+.tox
+.report.json
+test_result.json


### PR DESCRIPTION
Propose 2 enhancements during verifying [[ENHANCEMENT] Harvester Single Node Cluster#3889](https://github.com/harvester/harvester/issues/3889)

1. **integration/test_backup_restore.py**
   * Add check after deleting VM backup to avoid config_backup_target too early.
   * Symptom
     * Sometimes config_backup_target fail due to "VMBackup still creating or deleting".
     * Example (harvester-runtests#316)
       ![image](https://github.com/harvester/tests/assets/2773781/1a3b5bfa-fa25-4a77-a7d4-1854e9de4e75)
   * tested on harvester-runtests#318
     ![image](https://github.com/harvester/tests/assets/2773781/39b610db-50a1-44ea-b90d-facdfce242e4)


2. **integration/test_hosts.py**
   * Fail fast on `test_host_poweroff_state` when there is no or only 1 node in cluster.
     > **Note**
     > `pytest.xfail()` is also an option, but seems not current convention.
     > Ref. https://docs.pytest.org/en/7.0.x/how-to/skipping.html#xfail-mark-test-functions-as-expected-to-fail
   * Symptom
     * In single node profile, TC will power-off the only node.
   * Tested on harvester-runtests#319
     ![image](https://github.com/harvester/tests/assets/2773781/03048258-4ae6-4ebb-b522-f26ab8525f03)
     
