### PR TITLE
Support on-demand unique_name

### DIFF
--- a/harvester_e2e_tests/apis/test_images.py
+++ b/harvester_e2e_tests/apis/test_images.py
@@ -162,7 +162,8 @@ class TestImages:
 @pytest.mark.p0
 @pytest.mark.negative
 @pytest.mark.images
-def test_create_with_invalid_url(api_client, unique_name, wait_timeout):
+def test_create_with_invalid_url(api_client, gen_unique_name, wait_timeout):
+    unique_name = gen_unique_name()
     code, data = api_client.images.create_by_url(unique_name, f"https://{unique_name}.img")
 
     assert 201 == code, (code, data)

--- a/harvester_e2e_tests/fixtures/api_client.py
+++ b/harvester_e2e_tests/fixtures/api_client.py
@@ -64,7 +64,14 @@ def host_state(request):
 
 @pytest.fixture(scope='module')
 def unique_name():
+    """Default unique name"""
     return datetime.now().strftime("%Hh%Mm%Ss%f-%m-%d")
+
+
+@pytest.fixture(scope='module')
+def gen_unique_name():
+    """Generate unique name on-demand"""
+    return lambda: datetime.now().strftime("%Hh%Mm%Ss%f-%m-%d")
 
 
 @pytest.fixture(scope="module")

--- a/harvester_e2e_tests/integration/test_images.py
+++ b/harvester_e2e_tests/integration/test_images.py
@@ -241,7 +241,7 @@ class TestBackendImages:
 
     @pytest.mark.p0
     def test_create_invalid_file(
-        self, api_client, unique_name, fake_invalid_image_file, wait_timeout
+        self, api_client, gen_unique_name, fake_invalid_image_file, wait_timeout
     ):
         """
         Test create upload image from invalid file type
@@ -251,7 +251,7 @@ class TestBackendImages:
         2. Try to upload invalid image file which to images page
         2. Check should get an error
         """
-
+        unique_name = gen_unique_name()
         resp = api_client.images.create_by_file(unique_name, fake_invalid_image_file)
 
         assert (


### PR DESCRIPTION
## Changes
1. Add `gen_unique_name` fixture for TCs needs more thank 1 unique name.
2. Fix #861 by `gen_unique_name`.
   * **`apis/test_images.py`**, tested on harvester-runtests#336
     <details>
     
       ![image](https://github.com/harvester/tests/assets/2773781/e04ee6dd-b490-4101-863f-02b885a45fb6)
     </details>
   * **`integration/test_images.py`**, tested on harvester-runtests#337
     <details>

       ![image](https://github.com/harvester/tests/assets/2773781/4c3168de-4294-4a71-ae0e-1ba42867e6ab)
     </details>
