### PR TITLE
[e2e] add configure options for RKE1 and RKE2

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -63,7 +63,9 @@ rancher-version: 'v2.6-head'
 #rancher-admin-password: 'rancher_password'
 
 # Kubernetes version to use for Rancher integration tests
-kubernetes-version: 'v1.24.8+rke2r1'
+kubernetes-version: 'v1.24.11+rke2r1'
+RKE1-version: 'v1.24.11-rancher2-1'
+RKE2-version: 'v1.24.11+rke2r1'
 
 # Wait time for polling Rancher cluster status.
 rancher-cluster-wait-timeout: 7200

--- a/harvester_e2e_tests/conftest.py
+++ b/harvester_e2e_tests/conftest.py
@@ -210,19 +210,19 @@ def pytest_addoption(parser):
     parser.addoption(
         '--kubernetes-version',
         action='store',
-        default=config_data.get('kubernetes-version', 'v1.24.11+rke2r1'),
+        default=config_data.get('kubernetes-version'),
         help='Kubernetes version to use for Rancher integration tests'
     )
     parser.addoption(
         '--RKE2-version',
         action='store',
-        default=config_data.get('RKE2-version', 'v1.24.11+rke2r1'),
+        default=config_data.get('RKE2-version'),
         help='RKE2 Kubernetes version to use for Rancher integration tests'
     )
     parser.addoption(
         '--RKE1-version',
         action='store',
-        default=config_data.get('RKE1-version', 'v1.24.11-rancher2-1'),
+        default=config_data.get('RKE1-version'),
         help='RKE1 Kubernetes version to use for Rancher integration tests'
     )
     parser.addoption(

--- a/harvester_e2e_tests/conftest.py
+++ b/harvester_e2e_tests/conftest.py
@@ -210,8 +210,20 @@ def pytest_addoption(parser):
     parser.addoption(
         '--kubernetes-version',
         action='store',
-        default=config_data.get('kubernetes-version', 'v1.21.6+rke2r1'),
+        default=config_data.get('kubernetes-version', 'v1.24.11+rke2r1'),
         help='Kubernetes version to use for Rancher integration tests'
+    )
+    parser.addoption(
+        '--RKE2-version',
+        action='store',
+        default=config_data.get('RKE2-version', 'v1.24.11+rke2r1'),
+        help='RKE2 Kubernetes version to use for Rancher integration tests'
+    )
+    parser.addoption(
+        '--RKE1-version',
+        action='store',
+        default=config_data.get('RKE1-version', 'v1.24.11-rancher2-1'),
+        help='RKE1 Kubernetes version to use for Rancher integration tests'
     )
     parser.addoption(
         '--test-environment',

--- a/harvester_e2e_tests/fixtures/api_client.py
+++ b/harvester_e2e_tests/fixtures/api_client.py
@@ -146,11 +146,6 @@ def expected_settings():
     }
 
 
-@pytest.fixture(scope="session")
-def k8s_version(request):
-    return request.config.getoption("--kubernetes-version")
-
-
 @pytest.fixture(autouse=True)
 def skip_version_before(request, api_client):
     mark = request.node.get_closest_marker("skip_version_before")

--- a/harvester_e2e_tests/fixtures/rancher_api_client.py
+++ b/harvester_e2e_tests/fixtures/rancher_api_client.py
@@ -15,3 +15,9 @@ def rancher_api_client(request):
     api.session.verify = ssl_verify
 
     return api
+
+
+@pytest.fixture(scope="session")
+def k8s_version(request):
+    return (request.config.getoption("--RKE2-version")
+            or request.config.getoption("--kubernetes-version"))

--- a/harvester_e2e_tests/integration/test_rancher_integration.py
+++ b/harvester_e2e_tests/integration/test_rancher_integration.py
@@ -46,7 +46,11 @@ def rke2_cluster_name(unique_name):
 
 
 @pytest.fixture(scope='module')
-def rke1_k8s_version(k8s_version, rancher_api_client):
+def rke1_k8s_version(request, k8s_version, rancher_api_client):
+    configured = request.config.getoption("--RKE1-version")
+    if configured:
+        return configured
+
     # `v1.24.11+rke2r1` -> `v1.24.11-rancher2-1`
     version = re.sub(r'\+rke(\d+)r(\d+)', lambda g: "-rancher%s-%s" % g.groups(), k8s_version)
 


### PR DESCRIPTION
## Changes
- **ADD** configure options: `RKE1-version`, `RKE2-version`
- **UPDATE** fixtures to use new configure options if available


ref to #794 