### PR TITLE
Revert "* [apiclient] update for new kubeconfig endpoint"

### DIFF
--- a/apiclient/harvester_api/api.py
+++ b/apiclient/harvester_api/api.py
@@ -129,13 +129,7 @@ class HarvesterAPI:
         self.session.mount("http://", adapter)
 
     def generate_kubeconfig(self):
-        # `v1.2-xxx-head` will less than v1.2.0, so use `v1.1.99` instead.
-        if self.cluster_version < parse_version('v1.1.99'):
-            path = "v1/management.cattle.io.clusters/local?action=generateKubeconfig"
-        else:
-            # new endpoint since embeded rancher introduced
-            path = "v3/clusters/local?action=generateKubeconfig"
-
+        path = "v1/management.cattle.io.clusters/local?action=generateKubeconfig"
         r = self._post(path)
         return r.json()['config']
 


### PR DESCRIPTION
This reverts commit 483f8d4b7583b238ce0c2c5223cffeb948c24357

The design of MCM has changed, so this commit will no longer workable, thus we are going to revert it.
