### PR TITLE
[Cy] Remove cypress.env.json in .dockerignore

### DIFF
--- a/cypress/.dockerignore
+++ b/cypress/.dockerignore
@@ -3,4 +3,3 @@ cypress/downloads
 cypress/results
 cypress/screenshots
 cypress/videos
-cypress.env.json


### PR DESCRIPTION
Remove cypress.env.json in .dockerignore as this file is rendered by pipeline, we need to docker build into image.