### PR TITLE
[CY] Add cypress env to report context

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -85,6 +85,19 @@ Cypress.on("test:after:run", (test, runnable) => {
 
     const screenshot =`assets/${specDir}/${Cypress.spec.name}/${fileName}`;    
     
-    addContext({ test }, screenshot);  
+    addContext({ test }, screenshot);
+
+    addContext({ test }, 'Environment variables:');
+    const env = Cypress.env();
+
+    Object.keys(env).forEach(key => {
+      const value = Cypress.env(key) 
+
+      if (typeof(value) !== 'object') {
+        addContext({ test }, `${key}: ${Cypress.env(key)}`);
+      } else {
+        addContext({ test }, `${key}: ${JSON.stringify(Cypress.env(key))}`); 
+      }
+    })
   }
 });


### PR DESCRIPTION
![image](https://github.com/harvester/tests/assets/18737885/bc58aa34-5e45-4023-a6a7-2f84caccfefa)


Test steps:

1. Mock a failed test case, e.g. testcases/networks/network.spec.ts
2. npx cypress run --reporter mochawesome --spec testcases/networks/network.spec.ts
3. yarn report:html