### PR TITLE
Fix "implicitly has `any` type" lint

### DIFF
--- a/cypress/testcases/virtualmachines/scheduling.spec.ts
+++ b/cypress/testcases/virtualmachines/scheduling.spec.ts
@@ -14,7 +14,7 @@ describe('VM scheduling on Specific node', () => {
 
   it('Schedule VM on the Node which is Enable Maintenance Mode', () => {
     const hostList = Cypress.env('host');
-    const hostNames: string[] = hostList.map(host => host.name);
+    const hostNames: string[] = hostList.map((host: any) => host.name);
     const maintenanceNode = hostNames[0]
     const filterMaintenanceNames = hostNames.filter(name => name !== maintenanceNode);
 


### PR DESCRIPTION
This was causing CI to fail on an unrelated PR.

Now it has an explicit `any` type :)