### PR TITLE
e2e rework: test_vm_actions.py

### DIFF
--- a/apiclient/harvester_api/managers.py
+++ b/apiclient/harvester_api/managers.py
@@ -400,6 +400,13 @@ class BackupManager(BaseManager):
         # Delegate to vm.backups
         return self.api.vms.backup(*args, **kwargs)
 
+    def update(
+        self, name, backup_spec, namespace=DEFAULT_NAMESPACE, *,
+        raw=False, as_json=True, **kwargs
+    ):
+        path = self.BACKUP_fmt.format(uid=f"/{name}", ns=namespace)
+        return self._update(path, backup_spec, raw=raw, as_json=as_json, **kwargs)
+
     def restore(self, name, restore_spec, namespace=DEFAULT_NAMESPACE, *, raw=False, **kwargs):
         code, data = self.get(name, namespace)
         try:

--- a/harvester_e2e_tests/fixtures/virtualmachines.py
+++ b/harvester_e2e_tests/fixtures/virtualmachines.py
@@ -1,7 +1,11 @@
 from io import StringIO
+from time import sleep
+from datetime import datetime, timedelta
+from contextlib import contextmanager
 
 import pytest
 from paramiko import SSHClient, RSAKey, MissingHostKeyPolicy
+from paramiko.ssh_exception import ChannelException
 
 
 @pytest.fixture(scope="session")
@@ -60,3 +64,133 @@ def vm_shell():
             return out.read().decode(), err.read().decode()
 
     return VMShell
+
+
+@pytest.fixture(scope="session")
+def vm_shell_from_host(vm_shell, host_shell, wait_timeout):
+    @contextmanager
+    def vm_login_from_host(
+        host_ip, vm_ip, username, password=None, pkey=None, wait_timeout=wait_timeout
+    ):
+        with host_shell.login(host_ip, jumphost=True) as h:
+            vm_sh = vm_shell(username, password, pkey)
+            endtime = datetime.now() + timedelta(seconds=wait_timeout)
+            while endtime > datetime.now():
+                try:
+                    vm_sh.connect(vm_ip, jumphost=h.client)
+                except ChannelException as e:
+                    login_ex = e
+                    sleep(3)
+                else:
+                    break
+            else:
+                raise AssertionError(f"Unable to login to VM {vm_ip}") from login_ex
+
+            with vm_sh as sh:
+                yield sh
+
+    return vm_login_from_host
+
+
+@pytest.fixture(scope="session")
+def vm_checker(api_client, wait_timeout):
+    def _cb(code, data):
+        return True
+
+    class VMChecker:
+        def __init__(self, vm_api, wait_timeout, snooze=3):
+            self.vms = vm_api
+            self.wait_timeout = wait_timeout
+            self.snooze = snooze
+
+        def _endtime(self):
+            return datetime.now() + timedelta(seconds=self.wait_timeout)
+
+        def wait_stopped(self, vm_name, endtime=None, callback=_cb, **kws):
+            code, data = self.vms.stop(vm_name)
+            if 204 != code:
+                return False, (code, data)
+
+            endtime = endtime or self._endtime()
+            while endtime > datetime.now():
+                code, data = self.vms.get_status(vm_name)
+                if 404 == code and _cb(code, data):
+                    break
+                sleep(self.snooze)
+            else:
+                return False, (code, data)
+            return True, (code, data)
+
+        def wait_deleted(self, vm_name, endtime=None, callback=_cb, **kws):
+            self.vms.delete(vm_name)
+            endtime = endtime or self._endtime()
+            while endtime > datetime.now():
+                code, data = api_client.vms.get_status(vm_name)
+                if 404 == code:
+                    break
+                sleep(self.snooze)
+            else:
+                return False, (code, data)
+            return True, (code, data)
+
+        def wait_started(self, vm_name, endtime=None, callback=_cb, **kws):
+            endtime = endtime or self._endtime()
+            while endtime > datetime.now():
+                code, data = self.vms.get_status(vm_name, **kws)
+                if (
+                    200 == code
+                    and "Running" == data.get('status', {}).get('phase')
+                    and _cb(code, data)
+                ):
+                    break
+                sleep(self.snooze)
+            else:
+                return False, (code, data)
+            return True, (code, data)
+
+        def wait_agent_connected(self, vm_name, endtime=None, callback=_cb, **kws):
+            def cb_(code, data):
+                conds = data.get('status', {}).get('conditions', [{}])
+                return (
+                    "AgentConnected" == conds[-1].get('type')
+                    and _cb(code, data)
+                )
+
+            return self.wait_started(vm_name, endtime, cb_, **kws)
+
+        def wait_interfaces(self, vm_name, endtime=None, callback=_cb, **kws):
+            def cb_(code, data):
+                return (
+                    data.get('status', {}).get('interfaces')
+                    and _cb(code, data)
+                )
+            return self.wait_agent_connected(vm_name, endtime, callback, **kws)
+
+        def wait_cloudinit_done(self, shell, endtime=None, callback=_cb, **kws):
+            endtime = endtime or self._endtime()
+            while endtime > datetime.now():
+                out, err = shell.exec_command('cloud-init status')
+                if 'done' in out and _cb(out, err):
+                    break
+                sleep(self.snooze)
+            else:
+                return False, (out, err)
+            return True, (out, err)
+
+        def wait_migrated(self, vm_name, new_host, endtime=None, callback=_cb, **kws):
+            code, data = self.vms.migrate(vm_name, new_host)
+            if 204 != code:
+                return False, (code, data)
+
+            endtime = endtime or self._endtime()
+            while endtime > datetime.now():
+                code, data = self.vms.get_status(vm_name)
+                migrating = data['metadata']['annotations'].get("harvesterhci.io/migrationState")
+                if not migrating and new_host == data['status']['nodeName'] and _cb(code, data):
+                    break
+                sleep(self.snooze)
+            else:
+                return False, (code, data)
+            return True, (code, data)
+
+    return VMChecker(api_client.vms, wait_timeout)

--- a/harvester_e2e_tests/integration/test_backup_restore.py
+++ b/harvester_e2e_tests/integration/test_backup_restore.py
@@ -153,9 +153,7 @@ def config_backup_target(api_client, conflict_retries, backup_config, wait_timeo
 
 
 @pytest.fixture(scope="class")
-def base_vm_with_data(
-    api_client, host_shell, vm_shell, ssh_keypair, wait_timeout, unique_name, image, backup_config
-):
+def base_vm(api_client, ssh_keypair, unique_name, vm_checker, image, backup_config):
     unique_vm_name = f"{datetime.now().strftime('%m%S%f')}-{unique_name}"
     cpu, mem = 1, 2
     pub_key, pri_key = ssh_keypair
@@ -171,63 +169,93 @@ def base_vm_with_data(
     code, data = api_client.vms.create(unique_vm_name, vm_spec)
 
     # Check VM started and get IPs (vm and host)
-    endtime = datetime.now() + timedelta(seconds=wait_timeout)
-    while endtime > datetime.now():
-        code, data = api_client.vms.get_status(unique_vm_name)
-        if 200 == code:
-            phase = data.get('status', {}).get('phase')
-            conds = data.get('status', {}).get('conditions', [{}])
-            if ("Running" == phase
-               and "AgentConnected" == conds[-1].get('type')
-               and data['status'].get('interfaces')):
-                break
-        sleep(3)
-    else:
-        raise AssertionError(
-            f"Failed to Start VM({unique_vm_name}) with errors:\n"
-            f"Status: {data.get('status')}\n"
-            f"API Status({code}): {data}"
-        )
+    vm_got_ips, (code, data) = vm_checker.wait_interfaces(unique_vm_name)
+    assert vm_got_ips, (
+        f"Failed to Start VM({unique_vm_name}) with errors:\n"
+        f"Status: {data.get('status')}\n"
+        f"API Status({code}): {data}"
+    )
     vm_ip = next(iface['ipAddress'] for iface in data['status']['interfaces']
                  if iface['name'] == 'default')
     code, data = api_client.hosts.get(data['status']['nodeName'])
     host_ip = next(addr['address'] for addr in data['status']['addresses']
                    if addr['type'] == 'InternalIP')
+    yield {
+        "name": unique_vm_name,
+        "host_ip": host_ip,
+        "vm_ip": vm_ip,
+        "ssh_user": image['user'],
+    }
+
+    # remove created VM
+    code, data = api_client.vms.get(unique_vm_name)
+    vm_spec = api_client.vms.Spec.from_dict(data)
+    vm_deleted, (code, data) = vm_checker.wait_deleted(unique_vm_name)
+
+    for vol in vm_spec.volumes:
+        vol_name = vol['volume']['persistentVolumeClaim']['claimName']
+        api_client.volumes.delete(vol_name)
+
+
+@pytest.fixture(scope="class")
+def base_vm_migrated(api_client, vm_checker, backup_config, base_vm):
+    unique_vm_name = base_vm['name']
+
+    code, host_data = api_client.hosts.get()
+    assert 200 == code, (code, host_data)
+    code, data = api_client.vms.get_status(unique_vm_name)
+    cur_host = data['status'].get('nodeName')
+    assert cur_host, (
+        f"VMI exists but `nodeName` is empty.\n"
+        f"{data}"
+    )
+
+    new_host = next(h['id'] for h in host_data['data']
+                    if cur_host != h['id'] and not h['spec'].get('taint'))
+
+    vm_migrated, (code, data) = vm_checker.wait_migrated(unique_vm_name, new_host)
+    assert vm_migrated, (
+        f"Failed to Migrate VM({unique_vm_name}) from {cur_host} to {new_host}\n"
+        f"API Status({code}): {data}"
+    )
+
+    # update for new IPs
+    vm_ip = next(iface['ipAddress'] for iface in data['status']['interfaces']
+                 if iface['name'] == 'default')
+    code, data = api_client.hosts.get(data['status']['nodeName'])
+    host_ip = next(addr['address'] for addr in data['status']['addresses']
+                   if addr['type'] == 'InternalIP')
+    base_vm['vm_ip'] = vm_ip
+    base_vm['host_ip'] = host_ip
+
+    return (cur_host, new_host)
+
+
+@pytest.fixture(scope="class")
+def base_vm_with_data(
+    api_client, vm_shell_from_host, ssh_keypair, wait_timeout, vm_checker, backup_config, base_vm
+):
+    pub_key, pri_key = ssh_keypair
+    unique_vm_name = base_vm['name']
 
     # Log into VM to make some data
-    with host_shell.login(host_ip, jumphost=True) as h:
-        vm_sh = vm_shell(image['user'], pkey=pri_key)
-        endtime = datetime.now() + timedelta(seconds=wait_timeout)
-        while endtime > datetime.now():
-            try:
-                vm_sh.connect(vm_ip, jumphost=h.client)
-            except ChannelException as e:
-                login_ex = e
-                sleep(3)
-            else:
-                break
-        else:
-            raise AssertionError(f"Unable to login to VM {unique_vm_name}") from login_ex
-
-        with vm_sh as sh:
-            endtime = datetime.now() + timedelta(seconds=wait_timeout)
-            while endtime > datetime.now():
-                out, err = sh.exec_command('cloud-init status')
-                if 'done' in out:
-                    break
-                sleep(3)
-            else:
-                raise AssertionError(
-                    f"VM {unique_vm_name} Started {wait_timeout} seconds"
-                    f", but cloud-init still in {out}"
-                )
-            out, err = sh.exec_command(f'echo {unique_vm_name!r} > ~/vmname')
-            assert not err, (out, err)
-            sh.exec_command('sync')
+    with vm_shell_from_host(
+        base_vm['host_ip'], base_vm['vm_ip'], base_vm['ssh_user'], pkey=pri_key
+    ) as sh:
+        cloud_inited, (out, err) = vm_checker.wait_cloudinit_done(sh)
+        assert cloud_inited, (
+            f"VM {unique_vm_name} Started {vm_checker.wait_timeout} seconds"
+            f", but cloud-init still in {out}"
+        )
+        out, err = sh.exec_command(f'echo {unique_vm_name!r} > ~/vmname')
+        assert not err, (out, err)
+        sh.exec_command('sync')
 
     yield {
         "name": unique_vm_name,
-        "ssh_user": image['user'],
+        "host_ip": base_vm['host_ip'],
+        "vm_ip": base_vm['vm_ip'],
+        "ssh_user": base_vm['ssh_user'],
         "data": dict(path="~/vmname", content=f'{unique_vm_name}')
     }
 
@@ -255,22 +283,6 @@ def base_vm_with_data(
             f"Failed to delete backups: {check_names}\n"
             f"Last API Status({code}): {data}"
             )
-
-    # remove created VM
-    code, data = api_client.vms.get(unique_vm_name)
-    vm_spec = api_client.vms.Spec.from_dict(data)
-
-    api_client.vms.delete(unique_vm_name)
-    endtime = datetime.now() + timedelta(seconds=wait_timeout)
-    while endtime > datetime.now():
-        code, data = api_client.vms.get_status(unique_vm_name)
-        if 404 == code:
-            break
-        sleep(3)
-
-    for vol in vm_spec.volumes:
-        vol_name = vol['volume']['persistentVolumeClaim']['claimName']
-        api_client.volumes.delete(vol_name)
 
 
 @pytest.mark.p0
@@ -309,12 +321,22 @@ class TestBackupRestore:
 
     @pytest.mark.dependency(depends=["TestBackupRestore::tests_backup_vm"], param=True)
     def test_restore_with_new_vm(
-        self, api_client, host_shell, vm_shell, ssh_keypair, wait_timeout,
+        self, api_client, vm_shell_from_host, ssh_keypair, wait_timeout,
         backup_config, base_vm_with_data
     ):
         unique_vm_name, backup_data = base_vm_with_data['name'], base_vm_with_data['data']
         pub_key, pri_key = ssh_keypair
 
+        # mess up the existing data
+        with vm_shell_from_host(
+            base_vm_with_data['host_ip'], base_vm_with_data['vm_ip'],
+            base_vm_with_data['ssh_user'], pkey=pri_key
+        ) as sh:
+            out, err = sh.exec_command(f"echo {pub_key!r} > {base_vm_with_data['data']['path']}")
+            assert not err, (out, err)
+            sh.exec_command('sync')
+
+        # Restore VM into new
         restored_vm_name = f"nfs-restore-{unique_vm_name}"
         spec = api_client.backups.RestoreSpec.for_new(restored_vm_name)
         code, data = api_client.backups.restore(unique_vm_name, spec)
@@ -345,39 +367,26 @@ class TestBackupRestore:
                        if addr['type'] == 'InternalIP')
 
         # Login to the new VM and check data is existing
-        with host_shell.login(host_ip, jumphost=True) as h:
-            vm_sh = vm_shell(base_vm_with_data['ssh_user'], pkey=pri_key)
+        with vm_shell_from_host(host_ip, vm_ip, base_vm_with_data['ssh_user'], pkey=pri_key) as sh:
             endtime = datetime.now() + timedelta(seconds=wait_timeout)
             while endtime > datetime.now():
-                try:
-                    vm_sh.connect(vm_ip, jumphost=h.client)
-                except ChannelException as e:
-                    login_ex = e
-                    sleep(3)
-                else:
+                out, err = sh.exec_command('cloud-init status')
+                if 'done' in out:
                     break
+                sleep(3)
             else:
-                raise AssertionError(f"Unable to login to VM {restored_vm_name}") from login_ex
+                raise AssertionError(
+                    f"VM {restored_vm_name} Started {wait_timeout} seconds"
+                    f", but cloud-init still in {out}"
+                )
 
-            with vm_sh as sh:
-                endtime = datetime.now() + timedelta(seconds=wait_timeout)
-                while endtime > datetime.now():
-                    out, err = sh.exec_command('cloud-init status')
-                    if 'done' in out:
-                        break
-                    sleep(3)
-                else:
-                    raise AssertionError(
-                        f"VM {restored_vm_name} Started {wait_timeout} seconds"
-                        f", but cloud-init still in {out}"
-                    )
+            out, err = sh.exec_command(f"cat {backup_data['path']}")
 
-                out, err = sh.exec_command(f"cat {backup_data['path']}")
-            assert backup_data['content'] in out, (
-                f"cloud-init writefile failed\n"
-                f"Executed stdout: {out}\n"
-                f"Executed stderr: {err}"
-            )
+        assert backup_data['content'] in out, (
+            f"cloud-init writefile failed\n"
+            f"Executed stdout: {out}\n"
+            f"Executed stderr: {err}"
+        )
 
         # teardown: delete restored vm and volumes
         code, data = api_client.vms.get(restored_vm_name)
@@ -399,50 +408,40 @@ class TestBackupRestore:
             api_client.volumes.delete(vol_name)
 
     @pytest.mark.dependency(depends=["TestBackupRestore::tests_backup_vm"], param=True)
-    def test_restore_replace_and_delete_vols(
-        self, api_client, host_shell, vm_shell, ssh_keypair, wait_timeout,
+    def test_restore_replace_with_delete_vols(
+        self, api_client, vm_shell_from_host, ssh_keypair, wait_timeout, vm_checker,
         backup_config, base_vm_with_data
     ):
         unique_vm_name, backup_data = base_vm_with_data['name'], base_vm_with_data['data']
         pub_key, pri_key = ssh_keypair
 
-        # Stop the VM
-        code, data = api_client.vms.stop(unique_vm_name)
-        assert 204 == code, "`Stop` return unexpected status code"
-        endtime = datetime.now() + timedelta(seconds=wait_timeout)
-        while endtime > datetime.now():
-            code, data = api_client.vms.get_status(unique_vm_name)
-            if 404 == code:
-                break
-            sleep(3)
-        else:
-            raise AssertionError(
-                f"Failed to Stop VM({unique_vm_name}) with errors:\n"
-                f"Status({code}): {data}"
-            )
+        # mess up the existing data
+        with vm_shell_from_host(
+            base_vm_with_data['host_ip'], base_vm_with_data['vm_ip'],
+            base_vm_with_data['ssh_user'], pkey=pri_key
+        ) as sh:
+            out, err = sh.exec_command(f"echo {pub_key!r} > {base_vm_with_data['data']['path']}")
+            assert not err, (out, err)
+            sh.exec_command('sync')
+
+        # Stop the VM then restore existing
+        vm_stopped, (code, data) = vm_checker.wait_stopped(unique_vm_name)
+        assert vm_stopped, (
+            f"Failed to Stop VM({unique_vm_name}) with errors:\n"
+            f"Status({code}): {data}"
+        )
 
         spec = api_client.backups.RestoreSpec.for_existing(delete_volumes=True)
         code, data = api_client.backups.restore(unique_vm_name, spec)
         assert 201 == code, f'Failed to restore backup with current VM replaced, {data}'
 
         # Check VM Started then get IPs (vm and host)
-        endtime = datetime.now() + timedelta(seconds=wait_timeout)
-        while endtime > datetime.now():
-            code, data = api_client.vms.get_status(unique_vm_name)
-            if 200 == code:
-                phase = data.get('status', {}).get('phase')
-                conds = data.get('status', {}).get('conditions', [{}])
-                if ("Running" == phase
-                   and "AgentConnected" == conds[-1].get('type')
-                   and data['status'].get('interfaces')):
-                    break
-            sleep(3)
-        else:
-            raise AssertionError(
-                f"Failed to Start VM({unique_vm_name}) with errors:\n"
-                f"Status: {data.get('status')}\n"
-                f"API Status({code}): {data}"
-            )
+        vm_got_ips, (code, data) = vm_checker.wait_interfaces(unique_vm_name)
+        assert vm_got_ips, (
+            f"Failed to Start VM({unique_vm_name}) with errors:\n"
+            f"Status: {data.get('status')}\n"
+            f"API Status({code}): {data}"
+        )
         vm_ip = next(iface['ipAddress'] for iface in data['status']['interfaces']
                      if iface['name'] == 'default')
         code, data = api_client.hosts.get(data['status']['nodeName'])
@@ -450,39 +449,131 @@ class TestBackupRestore:
                        if addr['type'] == 'InternalIP')
 
         # Login to the new VM and check data is existing
-        with host_shell.login(host_ip, jumphost=True) as h:
-            vm_sh = vm_shell(base_vm_with_data['ssh_user'], pkey=pri_key)
-            endtime = datetime.now() + timedelta(seconds=wait_timeout)
-            while endtime > datetime.now():
-                try:
-                    vm_sh.connect(vm_ip, jumphost=h.client)
-                except ChannelException as e:
-                    login_ex = e
-                    sleep(3)
-                else:
-                    break
-            else:
-                raise AssertionError(f"Unable to login to VM {unique_vm_name}") from login_ex
-
-            with vm_sh as sh:
-                endtime = datetime.now() + timedelta(seconds=wait_timeout)
-                while endtime > datetime.now():
-                    out, err = sh.exec_command('cloud-init status')
-                    if 'done' in out:
-                        break
-                    sleep(3)
-                else:
-                    raise AssertionError(
-                        f"VM {unique_vm_name} Started {wait_timeout} seconds"
-                        f", but cloud-init still in {out}"
-                    )
-
-                out, err = sh.exec_command(f"cat {backup_data['path']}")
-            assert backup_data['content'] in out, (
-                f"cloud-init writefile failed\n"
-                f"Executed stdout: {out}\n"
-                f"Executed stderr: {err}"
+        with vm_shell_from_host(host_ip, vm_ip, base_vm_with_data['ssh_user'], pkey=pri_key) as sh:
+            cloud_inited, (out, err) = vm_checker.wait_cloudinit_done(sh)
+            assert cloud_inited, (
+                f"VM {unique_vm_name} Started {wait_timeout} seconds"
+                f", but cloud-init still in {out}"
             )
+            out, err = sh.exec_command(f"cat {backup_data['path']}")
+
+        assert backup_data['content'] in out, (
+            f"cloud-init writefile failed\n"
+            f"Executed stdout: {out}\n"
+            f"Executed stderr: {err}"
+        )
+
+    @pytest.mark.negative
+    @pytest.mark.dependency(depends=["TestBackupRestore::tests_backup_vm"], param=True)
+    def test_restore_replace_vm_not_stop(self, api_client, backup_config, base_vm_with_data):
+        spec = api_client.backups.RestoreSpec.for_existing(delete_volumes=True)
+        code, data = api_client.backups.restore(base_vm_with_data['name'], spec)
+
+        assert 422 == code, (code, data)
+
+
+@pytest.mark.skip("https://github.com/harvester/harvester/issues/1473")
+@pytest.mark.p0
+@pytest.mark.backup_target
+@pytest.mark.parametrize(
+    "backup_config", [
+        pytest.param("S3", marks=pytest.mark.S3),
+        pytest.param("NFS", marks=pytest.mark.NFS)
+    ],
+    indirect=True
+)
+class TestBackupRestoreOnMigration:
+    @pytest.mark.dependency(param=True)
+    def test_backup_migrated_vm(
+        self, api_client, wait_timeout, backup_config, config_backup_target,
+        base_vm_migrated, base_vm_with_data
+    ):
+        unique_vm_name = base_vm_with_data['name']
+
+        # Create backup with the name as VM's name
+        code, data = api_client.vms.backup(unique_vm_name, unique_vm_name)
+        assert 204 == code, (code, data)
+        # Check backup is ready
+        endtime = datetime.now() + timedelta(seconds=wait_timeout)
+        while endtime > datetime.now():
+            code, backup = api_client.backups.get(unique_vm_name)
+            if 200 == code and backup.get('status', {}).get('readyToUse'):
+                break
+            sleep(3)
+        else:
+            raise AssertionError(
+                f'Timed-out waiting for the backup \'{unique_vm_name}\' to be ready.'
+            )
+
+    @pytest.mark.dependency(
+        depends=["TestBackupRestoreOnMigration::test_backup_migrated_vm"],
+        param=True
+    )
+    def test_restore_replace_migrated_vm(
+        self, api_client, wait_timeout, ssh_keypair, vm_shell_from_host, vm_checker, backup_config,
+        base_vm_migrated, base_vm_with_data
+    ):
+        unique_vm_name, backup_data = base_vm_with_data['name'], base_vm_with_data['data']
+        pub_key, pri_key = ssh_keypair
+
+        # mess up the existing data
+        with vm_shell_from_host(
+            base_vm_with_data['host_ip'], base_vm_with_data['vm_ip'],
+            base_vm_with_data['ssh_user'], pkey=pri_key
+        ) as sh:
+            out, err = sh.exec_command(f"echo {pub_key!r} > {base_vm_with_data['data']['path']}")
+            assert not err, (out, err)
+            sh.exec_command('sync')
+
+        # Stop the VM then restore existing
+        vm_stopped, (code, data) = vm_checker.wait_stopped(unique_vm_name)
+        assert vm_stopped, (
+            f"Failed to Stop VM({unique_vm_name}) with errors:\n"
+            f"Status({code}): {data}"
+        )
+
+        spec = api_client.backups.RestoreSpec.for_existing()
+        code, data = api_client.backups.restore(unique_vm_name, spec)
+        assert 201 == code, f'Failed to restore backup with current VM replaced, {data}'
+
+        # Check VM Started
+        vm_got_ips, (code, data) = vm_checker.wait_interfaces(unique_vm_name)
+        assert vm_got_ips, (
+            f"Failed to Start VM({unique_vm_name}) with errors:\n"
+            f"Status: {data.get('status')}\n"
+            f"API Status({code}): {data}"
+        )
+
+        # Check VM is not hosting on the migrated node
+        host = data['status']['nodeName']
+        original_host, migrated_host = base_vm_migrated
+
+        assert host == migrated_host, (
+            f"Restored VM is not hosted on {migrated_host} but {host},"
+            f" the VM was initialized hosted on {original_host}"
+        )
+
+        # Get IP of VM and host
+        vm_ip = next(iface['ipAddress'] for iface in data['status']['interfaces']
+                     if iface['name'] == 'default')
+        code, data = api_client.hosts.get(data['status']['nodeName'])
+        host_ip = next(addr['address'] for addr in data['status']['addresses']
+                       if addr['type'] == 'InternalIP')
+
+        # Login to the new VM and check data is existing
+        with vm_shell_from_host(host_ip, vm_ip, base_vm_with_data['ssh_user'], pkey=pri_key) as sh:
+            cloud_inited, (out, err) = vm_checker.wait_cloudinit_done(sh)
+            assert cloud_inited, (
+                f"VM {unique_vm_name} Started {vm_checker.wait_timeout} seconds"
+                f", but cloud-init still in {out}"
+            )
+            out, err = sh.exec_command(f"cat {backup_data['path']}")
+
+        assert backup_data['content'] in out, (
+            f"cloud-init writefile failed\n"
+            f"Executed stdout: {out}\n"
+            f"Executed stderr: {err}"
+        )
 
 
 @pytest.mark.p1

--- a/harvester_e2e_tests/integration/test_backup_restore.py
+++ b/harvester_e2e_tests/integration/test_backup_restore.py
@@ -365,7 +365,7 @@ class TestBackupRestore:
             sh.exec_command('sync')
 
         # Restore VM into new
-        restored_vm_name = f"{backup_config[0]}.lower()-restore-{unique_vm_name}"
+        restored_vm_name = f"{backup_config[0].lower()}-restore-{unique_vm_name}"
         spec = api_client.backups.RestoreSpec.for_new(restored_vm_name)
         code, data = api_client.backups.restore(unique_vm_name, spec)
         assert 201 == code, (code, data)


### PR DESCRIPTION
## Changes
- **NEW** VM fixtures: `vm_shell_from_host`, `vm_checker` to eliminate duplicated code
- **NEW** test cases
    1. `test_restore_replace_vm_not_stop` for `test_restore_backup_vm_on` in legacy code
    2. `test_backup_migrated_vm` and `test_restore_replace_migrated_vm` for `test_backup_restore_migrated_vm_[s3|nfs]` in legacy code
    3. `test_restore_replace_migrated_vm` be marked skipped because https://github.com/harvester/harvester/issues/1473
 - **NEW** fixtures in `test_backup_restore`
    1. `base_vm` separated from `base_vm_with_data`
    2. `base_vm_migrated`
- **UPDATE** test cases in `TestBackupRestore`
    1. write new data before restore
    2. reorganize with new fixtures
- **NEW** test case: `test_update_backup_by_yaml` to for `test_update_backup_yaml_[s3|nfs]` in legacy code
    1. add **update** api endpoint: `api.backups.update`
    2. update `restored_vm_name` to fit the correct backup-target. (change to lower case because https://github.com/harvester/harvester/issues/4544)