### PR TITLE
Add TCs for Rancher Integration

### DIFF
--- a/apiclient/rancher_api/api.py
+++ b/apiclient/rancher_api/api.py
@@ -7,7 +7,8 @@ from requests.packages.urllib3.util.retry import Retry
 from .managers import (
     CloudCredentialManager, ClusterRegistrationTokenManager, HarvesterConfigManager,
     KubeConfigManager, MgmtClusterManager, SecretManager, SettingManager,
-    ClusterManager, NodeTemplateManager, NodePoolManager, UserManager
+    ClusterManager, NodeTemplateManager, NodePoolManager, UserManager,
+    ClusterDeploymentManager, ClusterServiceManager, PVCManager
 )
 
 
@@ -44,6 +45,9 @@ class RancherAPI:
         self.clusters = ClusterManager(self)
         self.node_templates = NodeTemplateManager(self)
         self.node_pools = NodePoolManager(self)
+        self.cluster_deployments = ClusterDeploymentManager(self)
+        self.cluster_services = ClusterServiceManager(self)
+        self.pvcs = PVCManager(self)
 
     @property
     def cluster_version(self):

--- a/apiclient/rancher_api/managers.py
+++ b/apiclient/rancher_api/managers.py
@@ -346,6 +346,151 @@ class KubeConfigManager(BaseManager):
         return self._create(self.PATH_fmt.format(cluster_id=cluster_id), json=data, raw=raw)
 
 
+class ClusterDeploymentManager(BaseManager):
+    PATH_fmt = "k8s/clusters/{cluster_id}/v1/apps.deployments"
+
+    def get(self, cluster_id, namespace=DEFAULT_NAMESPACE, name="", raw=False):
+        url = self.PATH_fmt.format(cluster_id=cluster_id)
+        if namespace:
+            url = f"{url}/{namespace}"
+            if name:
+                url = f"{url}/{name}"
+        return self._get(url, raw=raw)
+
+    def _create_data(self, namespace, name, image, pvc):
+        workloadselector = f"apps.deployment-{namespace}-{name}"
+        volumes, volume_mounts = [], []
+        if pvc:
+            volumes = [{
+                "name": f"vol-{pvc}",
+                "persistentVolumeClaim": {
+                    "claimName": pvc
+                }
+            }]
+            volume_mounts = [{
+                "mountPath": "/data",
+                "name": f"vol-{pvc}"
+            }]
+
+        return {
+            "type": "apps.deployment",
+            "metadata": {
+                "namespace": namespace,
+                "labels": {
+                    "workload.user.cattle.io/workloadselector": workloadselector
+                },
+                "name": name
+            },
+            "spec": {
+                "replicas": 1,
+                "template": {
+                    "spec": {
+                        "restartPolicy": "Always",
+                        "containers": [
+                            {
+                                "imagePullPolicy": "Always",
+                                "name": "container-0",
+                                "securityContext": {
+                                    "runAsNonRoot": False,
+                                    "readOnlyRootFilesystem": False,
+                                    "privileged": False,
+                                    "allowPrivilegeEscalation": False
+                                },
+                                "_init": False,
+                                "volumeMounts": volume_mounts,
+                                "__active": True,
+                                "image": image
+                            }
+                        ],
+                        "initContainers": [],
+                        "imagePullSecrets": [],
+                        "volumes": volumes,
+                        "affinity": {}
+                    },
+                    "metadata": {
+                        "labels": {
+                            "name": name,
+                            "workload.user.cattle.io/workloadselector": workloadselector
+                        },
+                        "namespace": namespace
+                    }
+                },
+                "selector": {
+                    "matchLabels": {
+                        "workload.user.cattle.io/workloadselector": workloadselector
+                    }
+                }
+            }
+        }
+
+    def create(self, cluster_id, namespace, name, image, pvc="", raw=False):
+        url = self.PATH_fmt.format(cluster_id=cluster_id)
+        data = self._create_data(namespace, name, image, pvc)
+        return self._create(url, json=data, raw=raw)
+
+    def delete(self, cluster_id, namespace, name, raw=False):
+        url = f"{self.PATH_fmt.format(cluster_id=cluster_id)}/{namespace}/{name}"
+        return self._delete(url, raw=raw)
+
+
+class ClusterServiceManager(BaseManager):
+    PATH_fmt = "k8s/clusters/{cluster_id}/v1/services"
+
+    def get(self, cluster_id, name="", namespace=DEFAULT_NAMESPACE, raw=False):
+        url = self.PATH_fmt.format(cluster_id=cluster_id)
+        if namespace:
+            url = f"{url}/{namespace}"
+            if name:
+                url = f"{url}/{name}"
+        return self._get(url, raw=raw)
+
+    def create(self, cluster_id, data, raw=False):
+        url = self.PATH_fmt.format(cluster_id=cluster_id)
+        return self._create(url, json=data, raw=raw)
+
+    def delete(self, cluster_id, name, namespace=DEFAULT_NAMESPACE, raw=False):
+        url = f"{self.PATH_fmt.format(cluster_id=cluster_id)}/{namespace}/{name}"
+        return self._delete(url, raw=raw)
+
+
+class PVCManager(BaseManager):
+    PATH_fmt = "k8s/clusters/{cluster_id}/v1/persistentvolumeclaims"
+
+    def get(self, cluster_id, name="", namespace=DEFAULT_NAMESPACE, raw=False):
+        url = self.PATH_fmt.format(cluster_id=cluster_id)
+        if namespace:
+            url = f"{url}/{namespace}"
+            if name:
+                url = f"{url}/{name}"
+        return self._get(url, raw=raw)
+
+    def create(self, cluster_id, name, namespace=DEFAULT_NAMESPACE, raw=False):
+        url = self.PATH_fmt.format(cluster_id=cluster_id)
+        data = {
+            "type": "persistentvolumeclaim",
+            "metadata": {
+                "namespace": namespace,
+                "name": name
+            },
+            "spec": {
+                "accessModes": [
+                    "ReadWriteOnce"
+                ],
+                "volumeName": "",
+                "resources": {
+                    "requests": {
+                        "storage": "1Gi"
+                    }
+                }
+            }
+        }
+        return self._create(url, json=data, raw=raw)
+
+    def delete(self, cluster_id, name, namespace=DEFAULT_NAMESPACE, raw=False):
+        url = f"{self.PATH_fmt.format(cluster_id=cluster_id)}/{namespace}/{name}"
+        return self._delete(url, raw=raw)
+
+
 class SecretManager(BaseManager):
     PATH_fmt = "v1/secrets"
 


### PR DESCRIPTION
## Changes
### Add managers in `rancher_api`
1. `ClusterDeploymentManager`
1. `ClusterServiceManager`
1. `PVCManager`

### `test_rancher_integration.py`
1. Grouping TCs to classes `TestRKE2` and `TestRKE1`
1. Update `test_create_rke2`: check kube-system deployments `cloud-provider` and `csi-driver`
1. New `test_deploy_nginx`: general deployment
1. New `test_load_balancer_service`: Test service creation and LB routing to nginx deployment
1. New `test_csi_deployment`: deployment with pvc attached

## Verification
Tested on harvester-runtests#394 with
* RKE1-version `v1.24.17-rancher1-1`
* RKE2-version `v1.24.17+rke2r1`

![image](https://github.com/harvester/tests/assets/2773781/6cdb53c0-9da1-4385-9d70-a863e8c73793)
