### PR TITLE
* [apiclient] add TxQLen to clusternetwork argument

### DIFF
--- a/apiclient/harvester_api/managers.py
+++ b/apiclient/harvester_api/managers.py
@@ -679,6 +679,9 @@ class ClusterNetworkManager(BaseManager):
                     "bondOptions": {
                         "mode": bond_mode or self._default_bond_mode,
                     },
+                    "linkAttributes": {
+                        "TxQLen": -1
+                    },
                     "nics": nics
                 }
             }


### PR DESCRIPTION
To fix bug when creating `cluster_config`

related to https://github.com/harvester/harvester/issues/3744 and https://github.com/harvester/network-controller-harvester/pull/80