### PR TITLE
[e2e] rework legacy volume test cases

### DIFF
--- a/apiclient/harvester_api/managers.py
+++ b/apiclient/harvester_api/managers.py
@@ -194,12 +194,16 @@ class VolumeManager(BaseManager):
         path = self.PATH_fmt.format(uid=f"/{name}", ns=namespace)
         return self._get(path, raw=raw)
 
-    def create(self, name, volume_spec, namespace=DEFAULT_NAMESPACE, image_id=None, *, raw=False):
+    def create(
+        self, name, volume_spec, namespace=DEFAULT_NAMESPACE, image_id=None,
+        *, raw=False, **kwargs
+    ):
         if isinstance(volume_spec, self.Spec):
             volume_spec = volume_spec.to_dict(name, namespace, image_id)
 
         path = self.PATH_fmt.format(uid="", ns=namespace)
-        return self._create(path, json=volume_spec, raw=raw)
+        kws = merge_dict(kwargs, dict(json=volume_spec))
+        return self._create(path, raw=raw, **kws)
 
     def update(self, name, volume_spec, namespace=DEFAULT_NAMESPACE, *,
                raw=False, as_json=True, **kwargs):


### PR DESCRIPTION
## Changes
- **UPDATE** `API.volumes.create` to support keyword arguments
- **UPDATE** test mark **p1** -> **p0**
- **UPDATE** `test_create_volume_backing_image` to test create with **json** and **yaml**
- **REMOVE** legacy `test_create_volume_image_form` which be covered in **test_create_volume_backing_image[json]**
- **REMOVE** legacy `test_create_volume_using_image_by_yaml` which be merged into **test_create_volume_backing_image[yaml]**