### PR TITLE
[e2e] fix bug in TestVMResource

### DIFF
--- a/harvester_e2e_tests/integration/test_vm_functions.py
+++ b/harvester_e2e_tests/integration/test_vm_functions.py
@@ -161,9 +161,10 @@ def unset_cpu_memory_overcommit(api_client):
     code, data = api_client.settings.get('overcommit-config')
     assert 200 == code, (code, data)
 
-    origin_val = json.loads(data.get('value', "{}"))
+    origin_val = json.loads(data.get('value', data['default']))
     spec = api_client.settings.Spec.from_dict(data)
     spec.cpu = spec.memory = 100
+    spec.storage = origin_val['storage']
     code, data = api_client.settings.update('overcommit-config', spec)
     assert 200 == code, (code, data)
 


### PR DESCRIPTION
## Changes
1. Fix fixture `unset_cpu_memory_overcommit`
fix the side-effect from #964, when `overcommit-config` using default value, the response would be something like:
    ```python
    data = {'apiVersion': 'harvesterhci.io/v1beta1',
     'default': '{"cpu":1600,"memory":150,"storage":200}',
     'kind': 'Setting',
     'metadata': {'creationTimestamp': '2023-10-16T14:10:44Z',
                  'generation': 1,
                  'managedFields': [{'apiVersion': 'harvesterhci.io/v1beta1',
                                     'fieldsType': 'FieldsV1',
                                     'fieldsV1': {'f:default': {}, 'f:status': {}},
                                     'manager': 'harvester',
                                     'operation': 'Update',
                                     'time': '2023-10-16T14:10:44Z'}],
                  'name': 'overcommit-config',
                  'resourceVersion': '7286',
                  'uid': '3aeb7877-2edb-44c3-ad3d-f1f8538f6a39'},
     'status': {}}
    ```
    `overcommit-config` will not accept empty value for cpu/memory/storage, so we would need to use `default` value instead of a empty dict.
    and we would also need overwrite `spec.storage` for sure.
    The bug presented in `harvester-runtests#399` and `harvester-runtests#401`

2. Fix bug in `test_create_schedule_on_maximum`
Add one more expected condition when to check that there have schedulable hosts and the VM be scheduled on expected host.
3. Fix bug in `test_update_schedule_on_maximum`
Same as above and also add a teardown to prevent affect to following test cases. (the fixture `stopped_vm`)