### PR TITLE
* update pytest-html config for deprecation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,4 +27,4 @@ commands =
 max-line-length = 99
 
 [pytest]
-render_collapsed = True
+render_collapsed = all


### PR DESCRIPTION
For `pytest-html > 4.0` https://pytest-html.readthedocs.io/en/latest/deprecations.html#render-collapsed