### PR TITLE
* fix pytest config in different python version

### DIFF
--- a/py36_pytest.ini
+++ b/py36_pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+render_collapsed = True

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps = pytest
 commands =
   {toxinidir}/terraform_test_artifacts/terraform_install.sh
   find . -type f -name "*.pyc" -delete
-  pytest {posargs}
+  pytest -c {env:PYTEST_CONFIG:{toxinidir}/tox.ini} {posargs}
 allowlist_externals = {toxinidir}/*,bash,find
 passenv = http_proxy,HTTP_PROXY,https_proxy,HTTPS_PROXY,no_proxy,NO_PROXY,PBR_VERSION
 
@@ -28,3 +28,7 @@ max-line-length = 99
 
 [pytest]
 render_collapsed = all
+
+[testenv:py36]
+setenv =
+    PYTEST_CONFIG = {toxinidir}/py36_pytest.ini


### PR DESCRIPTION
Ref to #988 

To fix the `pytest-html >= 4.0` will not support `python3.6`, and the configure option is not compatible.

to verify this, do `tox --showconfig` and the `commands` should be rendered as the file located.