### PR TITLE
Add testcase on RKE1 cluster

### DIFF
--- a/apiclient/rancher_api/api.py
+++ b/apiclient/rancher_api/api.py
@@ -8,7 +8,7 @@ from .managers import (
     CloudCredentialManager, ClusterRegistrationTokenManager, HarvesterConfigManager,
     KubeConfigManager, MgmtClusterManager, SecretManager, SettingManager,
     ClusterManager, NodeTemplateManager, NodePoolManager, UserManager,
-    ClusterDeploymentManager, ClusterServiceManager, PVCManager
+    ChartManager, ClusterDeploymentManager, ClusterServiceManager, PVCManager
 )
 
 
@@ -45,6 +45,7 @@ class RancherAPI:
         self.clusters = ClusterManager(self)
         self.node_templates = NodeTemplateManager(self)
         self.node_pools = NodePoolManager(self)
+        self.charts = ChartManager(self)
         self.cluster_deployments = ClusterDeploymentManager(self)
         self.cluster_services = ClusterServiceManager(self)
         self.pvcs = PVCManager(self)

--- a/apiclient/rancher_api/models.py
+++ b/apiclient/rancher_api/models.py
@@ -35,3 +35,43 @@ class UserSpec:
         ))
         obj._data = data
         return obj
+
+
+class ChartSpec:
+    def __init__(self, cluster_id, namespace, chart):
+        self.cluster_id = cluster_id
+        self.namespace = namespace
+        self.chart = chart
+
+    def to_dict(self):
+        data = {
+            "charts": [
+                {
+                    "chartName": self.chart,
+                    "releaseName": self.chart,
+                    "annotations": {
+                        "catalog.cattle.io/ui-source-repo-type": "cluster",
+                        "catalog.cattle.io/ui-source-repo": "rancher-charts"
+                    },
+                    "values": {
+                        "global": {
+                            "cattle": {
+                                "systemDefaultRegistry": "",
+                                "clusterId": self.cluster_id,
+                                "rkePathPrefix": "",
+                                "rkeWindowsPathPrefix": ""
+                            },
+                            "systemDefaultRegistry": ""
+                        }
+                    }
+                }
+            ],
+            "noHooks": False,
+            "timeout": "600s",
+            "wait": True,
+            "namespace": self.namespace,
+            "disableOpenAPIValidation": False,
+            "skipCRDs": False
+        }
+
+        return data


### PR DESCRIPTION
## Changes
1. **Adding** test cases for `harvester-cloud-provider` chart on RKE1 cluster
   * Install chart/app
   * Nginx deployment
   * Load-Balancer to Nginx deployment
3. **Adding** test cases for `harvester-csi-driver` chart on RKE1 cluster
   * Install chart/app
   * Deployment with PVC
   
## Verification
### `harvester-runtests#422` (RKE1)
![image](https://github.com/harvester/tests/assets/2773781/9687c9e9-21e9-4287-a36d-87551a8082e5)
> [!NOTE]  
> Failed LB case which has 200 OK status but `<pending>` external-ip, which is an known issue https://github.com/harvester/harvester/issues/4689

### `harvester-runtests#422` (RKE2)
![image](https://github.com/harvester/tests/assets/2773781/85bf6e70-4366-4523-a2d6-f4145848f4fc)


## Note
K3s TCs will be add later ([#974](https://github.com/harvester/tests/issues/974)) together with refactor ([#960](https://github.com/harvester/tests/issues/960))