### PR TITLE
* [e2e] to not use github api to fetch provider versions

### DIFF
--- a/harvester_e2e_tests/fixtures/terraform.py
+++ b/harvester_e2e_tests/fixtures/terraform.py
@@ -41,9 +41,8 @@ def tf_provider_version(request):
     version = request.config.getoption('--terraform-provider-harvester')
     if not version:
         import requests
-        return requests.get(
-            "https://api.github.com/repos/harvester/terraform-provider-harvester/releases/latest"
-        ).json()['name'].lstrip('v')
+        resp = requests.get("https://registry.terraform.io/v1/providers/harvester/harvester")
+        version = max(resp.json()['versions'], key=parse_version)
     return version
 
 


### PR DESCRIPTION
## Changes
- use terraform public API to fetch Harvester provider versions to prevent rate limit.

```python3
>>> url = 'https://registry.terraform.io/v1/providers/harvester/harvester'
>>> import requests
>>> r = requests.get(url)
>>> r.json()['versions']
['0.2.7', '0.2.8', '0.2.9', '0.3.0', '0.3.1', '0.3.2', '0.4.0', '0.5.0', '0.5.1', '0.5.2', '0.5.3', '0.5.4', '0.6.0', '0.6.1', '0.6.2', '0.6.3']
>>> vers = _
>>> from pkg_resources import parse_version
>>> max(vers, key=parse_version)
'0.6.3'
```