### PR TITLE
networking tests: fix ssh auth, clean up code

### DIFF
--- a/harvester_e2e_tests/fixtures/api_client.py
+++ b/harvester_e2e_tests/fixtures/api_client.py
@@ -220,6 +220,13 @@ def host_shell(request):
                 cli.set_missing_host_key_policy(MissingHostKeyPolicy())
                 kws = dict(username=self.username, password=self.password, pkey=self.pkey)
                 kws.update(kwargs)
+
+                # in case we're using a password to log into the host, this
+                # prevents paramiko from getting confused by ssh keys in the ssh
+                # agent:
+                if self.password and not self.pkey:
+                    kws.update(dict(allow_agent=False, look_for_keys=False))
+
                 cli.connect(ipaddr, port, **kws)
                 self._client = cli
 

--- a/harvester_e2e_tests/fixtures/api_client.py
+++ b/harvester_e2e_tests/fixtures/api_client.py
@@ -214,7 +214,8 @@ def host_shell(request):
                 kws.update(kwargs)
                 cli.connect(ipaddr, port, **kws)
 
-        def login(self, ipaddr, port=22, jumphost=False, **kwargs):
+        def login(self, ipaddr, port=22, jumphost=False, allow_agent=False,
+                  look_for_keys=False, **kwargs):
             if not self.client:
                 cli = SSHClient()
                 cli.set_missing_host_key_policy(MissingHostKeyPolicy())
@@ -225,7 +226,8 @@ def host_shell(request):
                 # prevents paramiko from getting confused by ssh keys in the ssh
                 # agent:
                 if self.password and not self.pkey:
-                    kws.update(dict(allow_agent=False, look_for_keys=False))
+                    kws.update(dict(allow_agent=allow_agent,
+                                    look_for_keys=look_for_keys))
 
                 cli.connect(ipaddr, port, **kws)
                 self._client = cli

--- a/harvester_e2e_tests/fixtures/networks.py
+++ b/harvester_e2e_tests/fixtures/networks.py
@@ -1,0 +1,15 @@
+import pytest
+
+
+@pytest.fixture(scope="session")
+def vlan_id(request):
+    vlan_id = request.config.getoption('--vlan-id')
+    assert 0 < vlan_id < 4095, f"VLAN ID should be in range 1-4094, not {vlan_id}"
+    return vlan_id
+
+
+@pytest.fixture(scope="session")
+def vlan_nic(request):
+    vlan_nic = request.config.getoption('--vlan-nic')
+    assert vlan_nic, f"VLAN NIC {vlan_nic} not configured correctly."
+    return vlan_nic

--- a/harvester_e2e_tests/integration/test_0_storage_network.py
+++ b/harvester_e2e_tests/integration/test_0_storage_network.py
@@ -8,7 +8,8 @@ from datetime import datetime, timedelta
 import pytest
 
 pytest_plugins = [
-    "harvester_e2e_tests.fixtures.api_client"
+    "harvester_e2e_tests.fixtures.api_client",
+    "harvester_e2e_tests.fixtures.networks"
 ]
 
 
@@ -71,14 +72,6 @@ def cluster_network(request, api_client, unique_name):
 
     code, data = api_client.clusternetworks.delete(cnet)
     assert 200 == code, (code, data)
-
-
-@pytest.fixture(scope='module')
-def vlan_id(request):
-    vlan_id = request.config.getoption('--vlan-id')
-    assert 4095 > vlan_id > 0, (f"VLAN ID should in range 1-4094, not {vlan_id}")
-
-    return vlan_id
 
 
 @pytest.mark.p0

--- a/harvester_e2e_tests/integration/test_networks.py
+++ b/harvester_e2e_tests/integration/test_networks.py
@@ -12,6 +12,7 @@ import paramiko
 
 pytest_plugins = [
     "harvester_e2e_tests.fixtures.api_client",
+    "harvester_e2e_tests.fixtures.networks",
     "harvester_e2e_tests.fixtures.virtualmachines"
 ]
 
@@ -49,22 +50,6 @@ def client():
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     yield client
     client.close()
-
-
-@pytest.fixture(scope='session')
-def vlan_id(request):
-    vlan_id = request.config.getoption('--vlan-id')
-    assert 4095 > vlan_id > 0, f"VLAN ID should in range 1-4094, not {vlan_id}"
-
-    return vlan_id
-
-
-@pytest.fixture(scope="session")
-def vlan_nic(request):
-    vlan_nic = request.config.getoption('--vlan-nic')
-    assert vlan_nic, f"VLAN NIC {vlan_nic} not configured correctly."
-
-    return vlan_nic
 
 
 @pytest.fixture(scope='module')

--- a/harvester_e2e_tests/integration/test_vm_networks.py
+++ b/harvester_e2e_tests/integration/test_vm_networks.py
@@ -12,24 +12,9 @@ import pytest
 pytest_plugins = [
     "harvester_e2e_tests.fixtures.api_client",
     "harvester_e2e_tests.fixtures.images",
+    "harvester_e2e_tests.fixtures.networks",
     "harvester_e2e_tests.fixtures.virtualmachines"
 ]
-
-
-@pytest.fixture(scope='session')
-def vlan_id(request):
-    vlan_id = request.config.getoption('--vlan-id')
-    assert 4095 > vlan_id > 0, (f"VLAN ID should in range 1-4094, not {vlan_id}")
-
-    return vlan_id
-
-
-@pytest.fixture(scope="session")
-def vlan_nic(request):
-    vlan_nic = request.config.getoption('--vlan-nic')
-    assert vlan_nic, f"VLAN NIC {vlan_nic} not configured correctly."
-
-    return vlan_nic
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
- Fix SSH auth using password. Paramiko can get confused when using password authentication while having SSH keys in the SSH agent. In case the test suite is being run using password based authentication, the options `allow_agent=False` and `look_for_key=False` prevent paramiko from trying to get keys from the SSH agent, allowing password based authentication to proceed without error.

- Clean up duplicated fixture `vlan_id` and `vlan_nic`. These pytest fixtures were copy-and-pasted into several places, so to simplify the code they are consolidated in a single place where other network fixtures can be kept in the future as well.