### PR TITLE
feat: Ignore Hugo Build Lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ scripts/**/*.sh
 .tox
 .report.json
 test_result.json
+
+*.hugo_build.lock


### PR DESCRIPTION
* if checking .md doc files locally via Hugo, a .hugo_build.lock file will be built - this allows for git to ignore that built file from wherever it should reside in the project

Resolves: feat/ignore-hugo-build-locks

X-Ref:
![Screenshot from 2024-02-15 14-49-34](https://github.com/harvester/tests/assets/5370752/fe947fc1-9e86-4f6a-a83d-f7a6ca5a52fd)
