### PR TITLE
add fixture *skip_version_if*

### DIFF
--- a/harvester_e2e_tests/conftest.py
+++ b/harvester_e2e_tests/conftest.py
@@ -260,6 +260,7 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     # Register marker as the format (marker, (description))
     markers = [
+        ("skip_version_if", "Mark test skipped when cluster version hit the condition"),
         ("skip_version_before", (
             "mark test skipped when cluster version < provided version")),
         ("skip_version_after", (


### PR DESCRIPTION
To let us skip tests more flexible.

we might need to consider support more complicated case like:
- Version only support in `v1.2` but not `v1.2.1`
- Version support both `v1.2` and `v1.3` but not `v1.3.1`