### PR TITLE
Skip tests expected failed (bring back when fixed in Harvester 1.4.0)

### DIFF
--- a/harvester_e2e_tests/apis/test_images.py
+++ b/harvester_e2e_tests/apis/test_images.py
@@ -129,6 +129,7 @@ class TestImages:
                 f"Still got {code} with {data}"
             )
 
+    @pytest.mark.skip_version_if("> v1.2.0", "<= v1.4.0", reason="Issue#4293 fix after `v1.4.0`")
     @pytest.mark.dependency(depends=["create_image", "get_image", "delete_image"])
     def test_create_with_reuse_display_name(
             self, wait_timeout, api_client, unique_name, fake_image_file):

--- a/harvester_e2e_tests/integrations/test_1_images.py
+++ b/harvester_e2e_tests/integrations/test_1_images.py
@@ -186,6 +186,7 @@ class TestBackendImages:
         image_url = image_info.url
         create_image_url(api_client, image_name, image_url, wait_timeout)
 
+    @pytest.mark.skip_version_if("> v1.2.0", "<= v1.4.0", reason="Issue#4293 fix after `v1.4.0`")
     @pytest.mark.p0
     @pytest.mark.dependency(name="delete_image_recreate", depends=["create_image_url"])
     def test_delete_image_recreate(


### PR DESCRIPTION
after https://github.com/harvester/harvester/issues/4293 is ready, we can just revert this PR.