### PR TITLE
* [e2e] fix pytest version

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest
+pytest == 7.*
 pytest-drop-dup-tests
 pytest-ordering
 pytest-html


### PR DESCRIPTION
Upgrade test `build#58` failed, after some investigating, it is caused by new version of `pytest`, so this PR will fix `pytest` version to be less than `v8.0` as we don't sure whether the plugin is used in somewhere and we are not actually using new pytest features.

![image](https://github.com/harvester/tests/assets/5169694/ace735bb-e829-4198-aea5-3f422e9ec320)
