### PR TITLE
* [e2e] fix abort migration, terraform bug

### DIFF
--- a/harvester_e2e_tests/integrations/test_3_vm_functions.py
+++ b/harvester_e2e_tests/integrations/test_3_vm_functions.py
@@ -512,6 +512,9 @@ class TestVMOperations:
                     assert 204 == code, (code, err)
                 else:
                     break
+            elif len(states) == 1 and not m_state:
+                # we did abort migration, and the anootation removed
+                break
             sleep(3)
         else:
             raise AssertionError(

--- a/harvester_e2e_tests/integrations/test_z_terraform.py
+++ b/harvester_e2e_tests/integrations/test_z_terraform.py
@@ -45,7 +45,7 @@ def vlanconfig_resource(request, unique_name, tf_resource, clusternetwork_resour
     assert vlan_nic, f"VLAN NIC {vlan_nic} not configured correctly."
 
     _, clusternetwork_name = clusternetwork_resource
-    name, nics = f"{clusternetwork_name}-{vlan_nic}", [vlan_nic]
+    name, nics = f"{clusternetwork_name}-{vlan_nic}".lower(), [vlan_nic]
     spec = tf_resource.vlanconfig(f"tf_{unique_name}", name, clusternetwork_name, nics)
 
     return spec, name, clusternetwork_name, nics


### PR DESCRIPTION
## Changes
- Fix #1158 which is about abort migration
- Fix the `vlanconfig` naming bug discovered in https://github.com/harvester/harvester/issues/371#issuecomment-1997189608
![image](https://github.com/harvester/tests/assets/5169694/c7deb69b-6736-4c59-b97c-bee93d98529d)

The NIC named camel case, and it is not allowed to use upper case in `vlanconfig` name.