### PR TITLE
[e2e] fix machine type, ssh bugs

### DIFF
--- a/harvester_e2e_tests/apis/test_hosts.py
+++ b/harvester_e2e_tests/apis/test_hosts.py
@@ -69,6 +69,8 @@ def test_update_node(api_client):
 
     status_code, node_stats = api_client.hosts.update(node['id'], test_data)
 
+    assert 200 == status_code, (status_code, node_stats)
+
     not_updated_fields = list()
     for k, v in test_annotations.items():
         if node_stats['metadata']['annotations'].get(k) != v:

--- a/harvester_e2e_tests/integrations/test_3_vm_functions.py
+++ b/harvester_e2e_tests/integrations/test_3_vm_functions.py
@@ -174,6 +174,15 @@ def unset_cpu_memory_overcommit(api_client):
     api_client.settings.update('overcommit-config', spec)
 
 
+@pytest.fixture
+def machine_types(request, api_client):
+    major, minor, micro = api_client.cluster_version.release
+    if major > 1 or minor > 2 or (minor == 2 and micro > 1):
+        # > 1.y.z || > 1.3.z || > 1.2.1
+        return "_".join(request.param).replace("pc", "pc-q35").split("_")
+    return request.param
+
+
 @pytest.mark.p0
 @pytest.mark.virtualmachines
 @pytest.mark.dependency(name="minimal_vm")
@@ -1642,10 +1651,12 @@ def test_create_vm_no_available_resources(resource, api_client, image,
 
 @pytest.mark.p0
 @pytest.mark.virtualmachines
-@pytest.mark.parametrize("machine_types", [("pc", "q35"), ("q35", "pc")],
-                         ids=['pc_to_q35', 'q35_to_pc'])
-def test_update_vm_machine_type(api_client, image, unique_vm_name,
-                                wait_timeout, machine_types, sleep_timeout):
+@pytest.mark.parametrize(
+    "machine_types", [("q35", "pc"), ("pc", "q35")], ids=['q35_to_pc', 'pc_to_q35'], indirect=True
+)
+def test_update_vm_machine_type(
+    api_client, image, unique_vm_name, wait_timeout, machine_types, sleep_timeout
+):
     """Create a VM with machine type then update to another
 
     Prerequisite:


### PR DESCRIPTION
## Changes
- **UPDATE** add fixture `machine_types` to adjust `pc` to `pc-q35` for newer Harvester version
- **UPDATE** add new check point for `test_update_node`
- **UPDATE** change to use `host_shell` and `vm_shell_from_host` to fix the bug of ssh to node using private key in our lab, to close https://github.com/harvester/tests/issues/1127

`add_vlan` already filed new issue in https://github.com/harvester/harvester/issues/5401