### PR TITLE
* [CI] update github action versions

### DIFF
--- a/.github/workflows/ci-worflow.yml
+++ b/.github/workflows/ci-worflow.yml
@@ -19,9 +19,9 @@ jobs:
         python: [3.8]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: Install Tox and any other packages

--- a/.github/workflows/gh-pages-pr-workflow.yml
+++ b/.github/workflows/gh-pages-pr-workflow.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Fetch gh-pages branch
         run: |
           git fetch --depth=1 origin gh-pages

--- a/.github/workflows/gh-pages-push-workflow.yml
+++ b/.github/workflows/gh-pages-push-workflow.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Fetch gh-pages branch
         run: |
           git fetch --depth=1 origin gh-pages


### PR DESCRIPTION
Refs:
![image](https://github.com/harvester/tests/assets/5169694/c487f6dd-d4f8-44ac-aaf2-c6c42e1d2806)
- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
- https://github.com/actions/setup-python
- https://github.com/actions/checkout