### PR TITLE
Implement k8s version picker and fix LB teardown

### DIFF
--- a/apiclient/harvester_api/api.py
+++ b/apiclient/harvester_api/api.py
@@ -62,6 +62,7 @@ class HarvesterAPI:
         self.images = mgrs.ImageManager.for_version(version)(self, version)
         self.networks = mgrs.NetworkManager.for_version(version)(self, version)
         self.ippools = mgrs.IPPoolManager.for_version(version)(self, version)
+        self.loadbalancers = mgrs.LoadBalancerManager.for_version(version)(self, version)
         self.volumes = mgrs.VolumeManager.for_version(version)(self, version)
         self.volsnapshots = mgrs.VolumeSnapshotManager.for_version(version)(self, version)
         self.templates = mgrs.TemplateManager.for_version(version)(self, version)

--- a/apiclient/harvester_api/managers/__init__.py
+++ b/apiclient/harvester_api/managers/__init__.py
@@ -5,7 +5,7 @@ from .volumes import VolumeManager
 from .backups import BackupManager, VirtualMachineSnapshotManager
 from .keypairs import KeypairManager
 from .settings import SettingManager
-from .networks import NetworkManager, IPPoolManager
+from .networks import NetworkManager, IPPoolManager, LoadBalancerManager
 from .templates import TemplateManager
 from .supportbundles import SupportBundleManager
 from .storageclasses import StorageClassManager
@@ -25,7 +25,7 @@ __all__ = [
  "VolumeManager",
  "KeypairManager",
  "SettingManager",
- "NetworkManager", "IPPoolManager",
+ "NetworkManager", "IPPoolManager", "LoadBalancerManager",
  "TemplateManager",
  "SupportBundleManager",
  "VolumeSnapshotManager",

--- a/apiclient/harvester_api/managers/networks.py
+++ b/apiclient/harvester_api/managers/networks.py
@@ -110,13 +110,13 @@ class IPPoolManager(BaseManager):
 
 
 class LoadBalancerManager(BaseManager):
-    PATH_fmt = "{API_VERSION}/harvester/loadbalancer.harvesterhci.io.loadbalancers{lb_id}"
+    PATH_fmt = "{API_VERSION}/harvester/loadbalancer.harvesterhci.io.loadbalancers{uid}"
     API_VERSION = "v1"
 
-    def get(self, lb_id="", *, raw=False):
-        path = self.PATH_fmt.format(lb_id=f"/{lb_id}", API_VERSION=self.API_VERSION)
+    def get(self, uid="", *, raw=False):
+        path = self.PATH_fmt.format(uid=f"/{uid}", API_VERSION=self.API_VERSION)
         return self._get(path, raw=raw)
 
-    def delete(self, lb_id, *, raw=False):
-        path = self.PATH_fmt.format(lb_id=f"/{lb_id}", API_VERSION=self.API_VERSION)
+    def delete(self, uid, *, raw=False):
+        path = self.PATH_fmt.format(uid=f"/{uid}", API_VERSION=self.API_VERSION)
         return self._delete(path, raw=raw)

--- a/apiclient/harvester_api/managers/networks.py
+++ b/apiclient/harvester_api/managers/networks.py
@@ -107,3 +107,16 @@ class IPPoolManager(BaseManager):
     def delete(self, name, *, raw=False):
         path = self.PATH_fmt.format(name=f"/{name}", API_VERSION=self.API_VERSION)
         return self._delete(path, raw=raw)
+
+
+class LoadBalancerManager(BaseManager):
+    PATH_fmt = "{API_VERSION}/harvester/loadbalancer.harvesterhci.io.loadbalancers{lb_id}"
+    API_VERSION = "v1"
+
+    def get(self, lb_id="", *, raw=False):
+        path = self.PATH_fmt.format(lb_id=f"/{lb_id}", API_VERSION=self.API_VERSION)
+        return self._get(path, raw=raw)
+
+    def delete(self, lb_id, *, raw=False):
+        path = self.PATH_fmt.format(lb_id=f"/{lb_id}", API_VERSION=self.API_VERSION)
+        return self._delete(path, raw=raw)

--- a/config.yml
+++ b/config.yml
@@ -43,9 +43,8 @@ nfs-mount-dir: 'nfsshare'
 # Rancher Cluster
 rancher-endpoint: 'https://127.0.0.1'
 rancher-admin-password: 'rancher_password'
-# Kubernetes version for RKE
-RKE1-version: 'v1.26.11-rancher2-1'
-RKE2-version: 'v1.26.11+rke2r1'
+# Prefix of K8s version for to create downstream cluster
+k8s-version: 'v1.27'
 # Wait time for polling Rancher cluster status.
 rancher-cluster-wait-timeout: 7200
 

--- a/config.yml
+++ b/config.yml
@@ -20,7 +20,7 @@ sleep-timeout: 3
 # script location to manipulate node power cycle
 node-scripts-location: 'scripts/vagrant'
 
-opensuse-image-url: https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.3/images/openSUSE-Leap-15.3.x86_64-NoCloud.qcow2
+opensuse-image-url: https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.5/images/openSUSE-Leap-15.5.x86_64-NoCloud.qcow2
 ubuntu-image-url: https://cloud-images.ubuntu.com/releases/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img
 # URL to download all images
 image-cache-url: ''

--- a/harvester_e2e_tests/conftest.py
+++ b/harvester_e2e_tests/conftest.py
@@ -195,16 +195,10 @@ def pytest_addoption(parser):
         help='Rancher admin user password'
     )
     parser.addoption(
-        '--RKE2-version',
+        '--k8s-version',
         action='store',
-        default=config_data.get('RKE2-version'),
-        help='RKE2 Kubernetes version to use for Rancher integration tests'
-    )
-    parser.addoption(
-        '--RKE1-version',
-        action='store',
-        default=config_data.get('RKE1-version'),
-        help='RKE1 Kubernetes version to use for Rancher integration tests'
+        default=config_data.get('k8s-version'),
+        help='K8s version to use for downstream cluster in Rancher integration tests'
     )
     parser.addoption(
         '--rancher-cluster-wait-timeout',

--- a/harvester_e2e_tests/fixtures/images.py
+++ b/harvester_e2e_tests/fixtures/images.py
@@ -4,12 +4,6 @@ import pytest
 
 pytest_plugins = ["harvester_e2e_tests.fixtures.api_client"]
 
-# TODO: remove it after update CI's config.yml
-DEFAULT_OPENSUSE_IMAGE_URL = (
-    "https://download.opensuse.org/repositories/Cloud:/Images:"
-    "/Leap_15.3/images/openSUSE-Leap-15.3.x86_64-NoCloud.qcow2"
-)
-
 DEFAULT_UBUNTU_IMAGE_URL = (
     "https://cloud-images.ubuntu.com"
     "/focal/current/focal-server-cloudimg-amd64.img"
@@ -20,7 +14,7 @@ DEFAULT_UBUNTU_IMAGE_URL = (
 def image_opensuse(request, api_client):
     image_server = request.config.getoption("--image-cache-url")
     url = urlparse(
-        request.config.getoption("--opensuse-image-url") or DEFAULT_OPENSUSE_IMAGE_URL
+        request.config.getoption("--opensuse-image-url")
     )
 
     if image_server:

--- a/harvester_e2e_tests/fixtures/rancher_api_client.py
+++ b/harvester_e2e_tests/fixtures/rancher_api_client.py
@@ -20,10 +20,10 @@ def rancher_api_client(request):
     return api
 
 
-def _pickup_k8s_version(versions: [str], target_version: str):
+def _pickup_k8s_version(versions, target_version):
     """
-    versions:       e.g. ['v1.26.16-rancher2-3', 'v1.25.15-rancher1-1', ...]
-    target_version: e.g. v1.26, v1.26.16...
+    versions: list of str, e.g. ['v1.26.16-rancher2-3', 'v1.25.15-rancher1-1', ...]
+    target_version: str, e.g. 'v1.26', 'v1.26.16', ...
     """
     # e.g. v1.26.16-rancher2-3 / v1.26.16+rke2r1 will be sort as v1.26.16
     sorted_vers = sorted(versions,
@@ -35,7 +35,7 @@ def _pickup_k8s_version(versions: [str], target_version: str):
             warnings.warn(UserWarning(f"Adopt {ver} for target k8s-version {target_version}"))
             return ver
 
-    assert False, (
+    raise AssertionError(
         f"No supported version fits target k8s-version {target_version}\n"
         f"Rancher endpoint supports {versions}"
     )
@@ -48,7 +48,6 @@ def rke1_version(request, rancher_api_client):
     code, data = rancher_api_client.settings.get("k8s-versions-current")
     assert 200 == code, (code, data)
     supported_vers = data["value"].split(",")
-    assert supported_vers
 
     return _pickup_k8s_version(supported_vers, target_ver)
 
@@ -61,7 +60,6 @@ def rke2_version(request, api_client, rancher_api_client):
     resp = rancher_api_client._get("v1-rke2-release/releases")
     assert resp.ok
     supported_vers = [r['id'] for r in resp.json()['data']]
-    assert supported_vers
 
     return _pickup_k8s_version(supported_vers, target_ver)
 
@@ -73,6 +71,5 @@ def k3s_version(request, api_client, rancher_api_client):
     resp = rancher_api_client._get("v1-k3s-release/releases")
     assert resp.ok
     supported_vers = [r['id'] for r in resp.json()['data']]
-    assert supported_vers
 
     return _pickup_k8s_version(supported_vers, target_ver)


### PR DESCRIPTION
## Changes
1. **IMPLEMENT** RKE1/RKE2 version picker via config option `k8s-version` (`vX.Y`)
   * No need to specify full `RKE1-version` and `RKE2-version`
   * `k8s-version` act as prefix for filtering available versions.
     > e.g.
     > `v1.26` will get `v1.26.15-rancher1-1` from supports `['v1.25.16-rancher2-3', 'v1.26.15-rancher1-1', 'v1.27.12-rancher1-1']`
   * Fail fast if no matched versions. Help us to fix ASAP if target `k8s-version` is not compatible with current Rancher.
     > e.g.
     > Following previous example, if `k8s-version` is `v1.28`, TC will fail directly since Rancher endpoint do not support at all instead of use hightest supported but non-target `v1.27.12`.

2. **FIX** `409` error hit in daily test by enhancing load balancer teardown
   <details>

   ![image](https://github.com/harvester/tests/assets/2773781/acd9dac8-3b42-4a98-89c9-4837624b3c88)
   </summary>

3. **UPDATE** openSUSE Leap to 15.5
   * Ref. [[TEST] Upgrade the openSUSE image to 15.5, RKE1 & RKE2 versions to 1.27 in test CI](https://github.com/harvester/tests/issues/1087#issuecomment-2060465519)


## Notes
1. Bundle with **harvester-baremetal-ansible/PR#32** - [Fix ip pool subnet for vlan100](https://github.com/harvester/harvester-baremetal-ansible/pull/32#top) to take effect on daily test

## Verification
* `harvester_e2e_tests/integrations/test_9_rancher_integration.py`
### Daily Env.
* `harvester-v1.3.0`
* `rancher-v2.8.2`: supports K8s `v1.25` ~ `v1.27`
  * RKE2: `['v1.25.13+rke2r1', 'v1.25.15+rke2r2', 'v1.25.16+rke2r1', 'v1.26.8+rke2r1', 'v1.26.10+rke2r2', 'v1.26.11+rke2r1', 'v1.26.13+rke2r1', 'v1.26.14+rke2r1', 'v1.26.15+rke2r1', 'v1.27.5+rke2r1', 'v1.27.7+rke2r2', 'v1.27.8+rke2r1', 'v1.27.10+rke2r1', 'v1.27.11+rke2r1', 'v1.27.12+rke2r1']`
  * RKE1: `['v1.25.16-rancher2-3', 'v1.26.15-rancher1-1', 'v1.27.12-rancher1-1']`

#### Positive TCs
* `k8s-version`: `v1.27`
  * <details>
    <summary> :green_circle: RKE2: Should pick up <code>v1.27.12+rke2r1</code>
    </summary>

    ![image](https://github.com/harvester/tests/assets/2773781/483b2076-8e8d-4418-bf57-415f304dfe0d)
    </details>

  * <details>
    <summary> :green_circle: RKE1: Should pick up <code>v1.27.12-rancher1-1</code>
    </summary>

    ![image](https://github.com/harvester/tests/assets/2773781/c072b013-5999-400e-94dc-d3b6237cc712)
    ![image](https://github.com/harvester/tests/assets/2773781/10895a1e-6c33-4171-8111-a8e61ad55da3)
    </details>

  * <details>
    <summary> :green_circle: Test pass
    </summary>
    
    ![image](https://github.com/harvester/tests/assets/2773781/7e6c9a2b-8b9a-479a-bf4d-e2080270dfee)
    </details>

#### Negtive TCs
1. `k8s-version`: `v1.28` (Too new)
   * <details open>
     <summary> :green_circle: RKE2: Fail due to no matched version
     </summary>
 
     ![image](https://github.com/harvester/tests/assets/2773781/38a0a4e9-40fa-4acb-bc77-b3b2532d9a46)
     </details>
   
   * <details open>
     <summary> :green_circle: RKE1: Fail due to no matched version
     </summary>
     
     ![image](https://github.com/harvester/tests/assets/2773781/4264b0aa-cf40-471b-ad22-62caa23e7fcc)
     </details>

1. `k8s-version`: `v1.24` (Too old)
   * <details open>
     <summary> :green_circle: RKE2: Fail due to no matched version
     </summary>
 
     ![image](https://github.com/harvester/tests/assets/2773781/19867d02-143e-45d7-bf33-343f0f2e19e2)
     </details>
   
   * <details open>
     <summary> :green_circle: RKE1: Fail due to no matched version
     </summary>
     
     ![image](https://github.com/harvester/tests/assets/2773781/a37a4b69-8eec-41cc-bc76-7f3316ec2e94)
     </details>

### Local iPXE
#### Environment
* `harvester-v1.2.2-dev-20240329`
* `rancher-v2.7.10`: supports K8s `v1.23` ~ `v1.26`
   * RKE2: `['v1.23.10+rke2r1', 'v1.23.13+rke2r1', 'v1.23.14+rke2r1', 'v1.23.15+rke2r1', 'v1.23.16+rke2r1', 'v1.23.17+rke2r1', 'v1.24.4+rke2r1', 'v1.24.7+rke2r1', 'v1.24.8+rke2r1', 'v1.24.9+rke2r2', 'v1.24.10+rke2r1', 'v1.24.11+rke2r1', 'v1.24.13+rke2r1', 'v1.24.14+rke2r1', 'v1.24.15+rke2r1', 'v1.24.16+rke2r1', 'v1.24.17+rke2r1', 'v1.25.7+rke2r1', 'v1.25.9+rke2r1', 'v1.25.10+rke2r1', 'v1.25.11+rke2r1', 'v1.25.12+rke2r1', 'v1.25.13+rke2r1', 'v1.25.15+rke2r2', 'v1.25.16+rke2r1', 'v1.26.5+rke2r1', 'v1.26.6+rke2r1', 'v1.26.7+rke2r1', 'v1.26.8+rke2r1', 'v1.26.10+rke2r2', 'v1.26.11+rke2r1', 'v1.26.13+rke2r1', 'v1.26.14+rke2r1', 'v1.26.15+rke2r1']`
   * RKE1: `['v1.23.16-rancher2-3', 'v1.24.17-rancher1-1', 'v1.25.16-rancher2-3', 'v1.26.15-rancher1-1']`

#### Positive TCs
* `k8s-version`: `v1.26`
  * <details>
    <summary> :green_circle: RKE2: Should pick up <code>v1.26.15+rke2r1</code>
    </summary>

    ![pick-rke2](https://github.com/harvester/tests/assets/2773781/411f3881-15ab-4f29-877a-f6dff145f057)
    </details>

  * <details>
    <summary> :green_circle: RKE1: Should pick up <code>v1.26.15-rancher1-1</code>
    </summary>

    ![pick-rke1](https://github.com/harvester/tests/assets/2773781/c7c6f452-47b3-4fb0-a4b6-e00b85505a0f)
    </details>

  * <details>
    <summary> :green_circle: Test pass
    </summary>
    
    ![image](https://github.com/harvester/tests/assets/2773781/05787287-cd7d-4068-a826-ea1289e68510)
    </details>

* `k8s-version`: `v1.25`
  * :green_circle: RKE2: Should pick up <code>v1.25.16+rke2r1</code>
  * <details>
    <summary> :green_circle: RKE1: Should pick up <code>v1.25.16-rancher2-3</code>
    </summary>

    ![image](https://github.com/harvester/tests/assets/2773781/0c9e15cc-ed23-488a-8664-25c4b9257e22)
    </details>

  * <details>
    <summary> :green_circle: Test pass
    </summary>
    
    ![image](https://github.com/harvester/tests/assets/2773781/37ecb257-f267-4f85-a67a-7662754d984b)
    </details>

#### Negtive TCs
1. `k8s-version`: `v1.27` (Too new)
   * <details open>
     <summary> :green_circle: RKE2: Fail due to no matched version
     </summary>
 
     ![image](https://github.com/harvester/tests/assets/2773781/b65e39a2-0574-4071-b16c-29a88f73849e)
     </details>
   
   * <details open>
     <summary> :green_circle: RKE1: Fail due to no matched version
     </summary>
     
     ![image](https://github.com/harvester/tests/assets/2773781/f462d184-080f-45af-a0fd-97e5bffebc20)
     </details>

1. `k8s-version`: `v1.22` (Too old)
   * <details open>
     <summary> :green_circle: RKE2: Fail due to no matched version
     </summary>
 
     ![image](https://github.com/harvester/tests/assets/2773781/f8cac5ac-bb92-49e8-82e2-8f25237161d0)
     </details>
   
   * <details open>
     <summary> :green_circle: RKE1: Fail due to no matched version
     </summary>
     
     ![image](https://github.com/harvester/tests/assets/2773781/0ecf3399-34e7-4da9-9a25-eb8f2d5d6c84)
     </details>