### PR TITLE
Add part2 manual test case from v1.3.0 validated tickets

### DIFF
--- a/docs/content/manual/advanced/addons/5337-enable-addons-check-deployment.md
+++ b/docs/content/manual/advanced/addons/5337-enable-addons-check-deployment.md
@@ -1,0 +1,24 @@
+---
+title: Enable Harvester addons and check deployment state
+---
+
+* Related issues: [#5337](https://github.com/harvester/harvester/issues/5337) [BUG] Failed to enable vm-importer, pcidevices and harvester-seeder controller addons, keep stuck in "Enabling" state
+
+## Category: 
+* Addons
+
+## Verification Steps
+1. Prepare three nodes Harvester cluster
+1. Open Addvanced -> `Addons` page
+1. Access to harvester node machine
+1. Switch to root user and open k9s
+1. Enable the `vm-importer`, `pci-devices` and `harvester-seeder` addons
+1. Check the corresponding jobs and logs
+1. Enable rest of the addons `nvidia-driver-toolkit`, `rancher-monitoring` and `rancher-logging`
+
+## Expected Results
+* Check the `vm-importer`, `pci-devices` and `harvester-seeder` display in `Deployment Successful`
+* Check the `vm-importer-controller`, `pci-devices-controller` and `harvester-seeder` jobs and the related helm-install chart job all running well on the K9s
+* Check the `nvidia-driver-toolkit`, `rancher-monitoring` and `rancher-logging` display in `Deployment Successful`
+* Check the `nvidia-driver-toolkit`, `rancher-monitoring` and `rancher-logging` jobs and the related helm-install chart job all running well on the K9s
+

--- a/docs/content/manual/virtual-machines/5264-edit-vm-config-after-eject-cdrom-delete-volume.md
+++ b/docs/content/manual/virtual-machines/5264-edit-vm-config-after-eject-cdrom-delete-volume.md
@@ -1,0 +1,24 @@
+---
+title: Edit vm config after Eject CDROM and delete volume
+---
+
+* Related issues: [#5264](https://github.com/harvester/harvester/issues/5264) 
+[BUG] After EjectCD from vm and edit config of vm displays empty page: "Cannot read properties of null"
+
+## Category: 
+* Virtual Machines
+
+## Verification Steps
+1. Upload the ISO type desktop image (e.g ubuntu-20.04.4-desktop-amd64.iso)
+1. Create a vm named `vm1` with the iso image
+1. Open the web console to check content
+1. Click EjectCD after vm running
+1. Select the `delete volume` option
+1. Wait until vm restart to running
+1. Click the edit config
+1. Back to the virtual machine page
+1. Click the `vm1` name 
+
+## Expected Results
+* Check can edit vm config of `vm1` to display all settings correctly
+* Check can display the current `vm1` settings correctly 

--- a/docs/content/manual/virtual-machines/5266-view-log-function.md
+++ b/docs/content/manual/virtual-machines/5266-view-log-function.md
@@ -1,0 +1,31 @@
+---
+title: View log function on virtual machine
+---
+
+* Related issues: [#5266](https://github.com/harvester/harvester/issues/5266) [BUG] Click View Logs option on virtual machine dashboard can't display any log entry
+
+
+## Category: 
+* Virtual Machines
+
+## Verification Steps
+1. Create one virtual machines named `vm1` in the Harvester virtual machine page
+1. Wait until the `vm1` in running state
+1. Click the View Logs in the side option menu
+1. Check the log panel content of vm
+1. Click the `Clear` button
+1. Click the `Download` button
+1. Enter some query sting in the `Filter` field
+1. Click settings, change the `Show the latest` to different options
+1. Uncheck/Check the `Wrap Lines`
+1. Uncheck/Check the `Show Timestamps`
+
+## Expected Results
+* Should display the detailed log entries on the vm log panel including timestamp and content
+* All existing logs would be cleaned up 
+* Ensure new logs will display on the panel
+* Check can correctly download the log to the `.log` file and contain all the details
+* Check the log entries contains the filter string can display correctly
+* Check each different options of `Show the latest` log option can display log according to the settings
+* Check the log entries can be wrapped or unwrapped 
+* Check the log entries can display with/without timestamp


### PR DESCRIPTION


Add the part 2 of manual test cases from v1.3.0 validated tickets including:

* #5266 [[BUG] Click View Logs option on virtual machine dashboard can't display any log entry](https://github.com/harvester/harvester/issues/5266)
* #5337 [[BUG] Failed to enable vm-importer, pcidevices and harvester-seeder controller addons, keep stuck in "Enabling" state](https://github.com/harvester/harvester/issues/5337)
* #5264 [[BUG] After EjectCD from vm and edit config of vm displays empty page: "Cannot read properties of null"](https://github.com/harvester/harvester/issues/5264)



Tested on the local hugo server preview content.


