### PR TITLE
Sort report with execution time and add Time field in report

### DIFF
--- a/harvester_e2e_tests/conftest.py
+++ b/harvester_e2e_tests/conftest.py
@@ -17,6 +17,7 @@
 
 import pytest
 import yaml
+from datetime import datetime
 from pytest_dependency import DependencyManager as DepMgr
 
 
@@ -412,3 +413,11 @@ def pytest_collection_modifyitems(session, config, items):
     deselected = [t for t in all_items if t not in items]
     # update to let the report shows correct counts
     config.pluginmanager.get_plugin('terminalreporter').stats['deselected'] = deselected
+
+
+def pytest_html_results_table_header(cells):
+    cells.insert(1, '<th class="sortable time" data-column-type="time">EndTime</th>')
+
+
+def pytest_html_results_table_row(report, cells):
+    cells.insert(1, f'<td class="col-time">{datetime.utcnow()}</td>')

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ commands =
 max-line-length = 99
 
 [pytest]
+initial_sort = original
 render_collapsed = all
 
 [testenv:py36]


### PR DESCRIPTION
From recent discussion, I think we can enhance report by sorting with execution order thus helps to get the context of skipped & failed TCs.

## Changes
1. Sort report with execution time
   Ref. https://pytest-html.readthedocs.io/en/latest/user_guide.html#results-table-sorting
2. Add Time field in report
   Ref. https://pytest-html.readthedocs.io/en/latest/user_guide.html#modifying-the-results-table

## Result
### Before: Sort by `result` (pytest-html default)
![report-before](https://github.com/harvester/tests/assets/2773781/94652a11-df39-4129-a244-718fe016c744)

### After: Sort by `original` (best effort as the order of execution)
![report-after](https://github.com/harvester/tests/assets/2773781/280295ef-703a-4823-9f7e-5b969f19bead)
You can sort with new added **Time** field explicitly
![image](https://github.com/harvester/tests/assets/2773781/2a1a64ce-b5b7-44ef-8351-a517d747429c)

 