### PR TITLE
[e2e] fix upgrade bugs

### DIFF
--- a/apiclient/harvester_api/managers/storageclasses.py
+++ b/apiclient/harvester_api/managers/storageclasses.py
@@ -17,7 +17,8 @@ class StorageClassManager(BaseManager):
     def get_default(self):
         code, data = self.get()
         for sc in data['items']:
-            if 'true' == sc['metadata']['annotations'].get(DEFAULT_STORAGE_CLASS_ANNOTATION):
+            if 'true' == sc['metadata'].get('annotations', {}).get(
+              DEFAULT_STORAGE_CLASS_ANNOTATION):
                 return code, sc
         else:
             return code, data


### PR DESCRIPTION
## Changes
- **REMOVE** intercept method to shut down VMs during upgrade, as https://github.com/harvester/harvester/issues/5076 been applied
- **ADD** checker to check VM is created before check VMI is existence
- **ADD** TimeoutError to exceptions