### PR TITLE
[e2e] fix generate support bundle test

### DIFF
--- a/cypress/constants/constants.ts
+++ b/cypress/constants/constants.ts
@@ -1,5 +1,5 @@
 export class Constants {
-    public timeout = { timeout: 10000, maxTimeout: 60000, uploadTimeout: 600000, downloadTimeout: 120000, provisionTimeout: 1500000};
+    public timeout = { timeout: 10000, maxTimeout: 60000, uploadTimeout: 600000, downloadTimeout: 240000, provisionTimeout: 1500000};
     public username = Cypress.env("username");
     public password = Cypress.env("password");
     public mockPassword = Cypress.env("mockPassword");

--- a/cypress/testcases/backupAndSnapshot/vmBackup.spec.ts
+++ b/cypress/testcases/backupAndSnapshot/vmBackup.spec.ts
@@ -49,7 +49,7 @@ describe('VM Backup Validation', () => {
     createVMBackupSuccess = true
   })
 
-  it('Resotre New VM from vm backup', () => {
+  it('Restore new VM from vm backup', () => {
     onlyOn(createVMBackupSuccess);
     
     const newVMName = 'create-new-from-backup';
@@ -63,7 +63,7 @@ describe('VM Backup Validation', () => {
     vms.deleteVMFromStore(`default/${newVMName}`);
   })
 
-  it('Resotre New VM in another namespace from vm backup', () => {
+  it('Restore New VM in another namespace from vm backup', () => {
     onlyOn(createVMBackupSuccess);
     
     const newVMName = 'create-new-from-backup';
@@ -77,7 +77,7 @@ describe('VM Backup Validation', () => {
     vms.deleteVMFromStore(`default/${newVMName}`);
   })
 
-  it('Resotre Existing VM from vm backup', () => {
+  it('Restore Existing VM from vm backup', () => {
     onlyOn(createVMBackupSuccess);
     
     vms.goToList();
@@ -91,7 +91,7 @@ describe('VM Backup Validation', () => {
     vms.deleteVMFromStore(`default/test`);
   })
 
-  it('delete backup', () => {
+  it('Delete backup', () => {
     onlyOn(createVMBackupSuccess);
     
     vmBackups.goToList();

--- a/cypress/testcases/backupAndSnapshot/vmSnapshot.spec.ts
+++ b/cypress/testcases/backupAndSnapshot/vmSnapshot.spec.ts
@@ -15,7 +15,7 @@ describe('VM snapshot Form Validation', () => {
     cy.login({url: PageUrl.virtualMachine});
   });
 
-  it('Take a vm snaphost from vm', () => {
+  it('Take a vm snapshot from vm', () => {
     // Create a vm to test the snapshot operation
     const namespace = 'default';
 
@@ -47,7 +47,7 @@ describe('VM snapshot Form Validation', () => {
     createVMSnapshotSuccess = true
   })
 
-  it('Resotre New VM from vm snapshot', () => {
+  it('Restore New VM from vm snapshot', () => {
     onlyOn(createVMSnapshotSuccess);
     
     const newVMName = 'create-new-from-snapshot';
@@ -61,7 +61,7 @@ describe('VM snapshot Form Validation', () => {
     vms.deleteVMFromStore(`default/${newVMName}`);
   })
 
-  it('Resotre Existing VM from vm snapshot', () => {
+  it('Restore Existing VM from vm snapshot', () => {
     onlyOn(createVMSnapshotSuccess);
     
     vms.goToList();

--- a/cypress/testcases/backupAndSnapshot/volumeSnapshot.spec.ts
+++ b/cypress/testcases/backupAndSnapshot/volumeSnapshot.spec.ts
@@ -43,7 +43,7 @@ describe('Validation volume snapshot', () => {
     createVolumeSnapshotSuccess = true
   })
 
-  it('Resotre New volume from volume snapshot', () => {
+  it('Restore New volume from volume snapshot', () => {
     onlyOn(createVolumeSnapshotSuccess);
     
     const newName = 'create-new-from-snapshot';

--- a/cypress/testcases/dashboard/0_FirstTimeLogin.spec.ts
+++ b/cypress/testcases/dashboard/0_FirstTimeLogin.spec.ts
@@ -37,7 +37,7 @@ describe("First Time Login Page", () => {
   });
 
   context("Set Password", () => {
-    specify("Password inconsistant", () => {
+    specify("Password inconsistent", () => {
       onlyOn(isFirstTimeLogin);
       const page = new LoginPage();
       page.visit();
@@ -52,7 +52,7 @@ describe("First Time Login Page", () => {
 
     });
 
-    specify("Password consistant", () => {
+    specify("Password consistent", () => {
       onlyOn(isFirstTimeLogin);
       const page = new LoginPage();
       page.visit();

--- a/cypress/testcases/dashboard/support.spec.ts
+++ b/cypress/testcases/dashboard/support.spec.ts
@@ -38,7 +38,7 @@ describe("Support Page", () => {
     })
   })
 
-  context('Generate Support Bundle', () => {
+  context.only('Generate Support Bundle', () => {
     it('is required to input Description', () => {
       page.generateSupportBundleBtn.click()
 

--- a/cypress/testcases/virtualmachines/virtual-machine.spec.ts
+++ b/cypress/testcases/virtualmachines/virtual-machine.spec.ts
@@ -166,7 +166,7 @@ describe('VM runStategy Validation (Halted)', () => {
 
   const namespace = 'default'
 
-  it('Craete VM use Halted (Run Strategy)', () => {
+  it('Create VM use Halted (Run Strategy)', () => {
     vms.goToCreate();
 
     const imageEnv = Cypress.env('image');


### PR DESCRIPTION
### Goal
- Fix typo in some test cases description
- Fix  and stablize `Generate support bundle` test case.

### Issue 
https://github.com/harvester/tests/issues/1195


###  Result
I ran mutliple times against to `v1.3.0` harvester machine (https://172.19.108.23/) in ECM lab.
It average costs 1:55 ~ 2:10 min to generate and download the support bundle.

I increase the `downloadTimeout` to 240 second to avoid timeout issue and add some promise reject to make test case failed for any unexpected behavior.




<img width="1426" alt="Screenshot 2024-05-08 at 3 15 34 PM" src="https://github.com/harvester/tests/assets/5744158/eb1a8878-5413-4dda-a527-8c5d32cc1065">

<img width="1466" alt="Screenshot 2024-05-08 at 3 36 18 PM" src="https://github.com/harvester/tests/assets/5744158/3c6257a3-0455-4297-a4c0-4cee4c68aca3">
 
