### PR TITLE
[e2e] fix e2e bugs found in 1.2.2 regression

### DIFF
--- a/harvester_e2e_tests/fixtures/virtualmachines.py
+++ b/harvester_e2e_tests/fixtures/virtualmachines.py
@@ -280,6 +280,19 @@ def vm_checker(api_client, wait_timeout, sleep_timeout, vm_shell):
                 )
             return self.wait_agent_connected(vm_name, endtime, cb, **kws)
 
+        def wait_ip_addresses(self, vm_name, ifnames, endtime=None, callback=default_cb, **kws):
+            def cb(ctx):
+                if ctx.callee == 'vm.start':
+                    return callback(ctx)
+                ifaces = {d['name']: d for d in ctx.data.get('status', {}).get('interfaces', {})}
+                return (
+                    all(ifaces.get(name, {}).get('ipAddress') for name in ifnames)
+                    and callback(ctx)
+                )
+
+            ifnames = list(ifnames)
+            return self.wait_interfaces(vm_name, endtime, cb, **kws)
+
         def wait_cloudinit_done(self, shell, endtime=None, callback=default_cb, **kws):
             cmd = 'cloud-init status'
             endtime = endtime or self._endtime()

--- a/harvester_e2e_tests/integrations/test_3_vm_functions.py
+++ b/harvester_e2e_tests/integrations/test_3_vm_functions.py
@@ -174,15 +174,6 @@ def unset_cpu_memory_overcommit(api_client):
     api_client.settings.update('overcommit-config', spec)
 
 
-@pytest.fixture
-def machine_types(request, api_client):
-    major, minor, micro = api_client.cluster_version.release
-    if major > 1 or minor > 2 or (minor == 2 and micro > 1):
-        # > 1.y.z || > 1.3.z || > 1.2.1
-        return "_".join(request.param).replace("pc", "pc-q35").split("_")
-    return request.param
-
-
 @pytest.mark.p0
 @pytest.mark.virtualmachines
 @pytest.mark.dependency(name="minimal_vm")
@@ -1601,8 +1592,12 @@ def test_create_vm_no_available_resources(resource, api_client, image,
 
 @pytest.mark.p0
 @pytest.mark.virtualmachines
+@pytest.mark.skip_version_if(
+    "> v1.2.1", "> v1.3.0",
+    reason="`pc type removed, ref: https://github.com/harvester/harvester/issues/5437"
+)
 @pytest.mark.parametrize(
-    "machine_types", [("q35", "pc"), ("pc", "q35")], ids=['q35_to_pc', 'pc_to_q35'], indirect=True
+    "machine_types", [("q35", "pc"), ("pc", "q35")], ids=['q35_to_pc', 'pc_to_q35']
 )
 def test_update_vm_machine_type(
     api_client, image, unique_vm_name, wait_timeout, machine_types, sleep_timeout

--- a/harvester_e2e_tests/integrations/test_5_vm_networks.py
+++ b/harvester_e2e_tests/integrations/test_5_vm_networks.py
@@ -222,8 +222,8 @@ class TestVMNetwork:
     ):
         # clean cloud-init for rerun, and get the correct ifname
         (unique_vm_name, ssh_user), (_, pri_key) = minimal_vm, ssh_keypair
-        vm_started, (code, data) = vm_checker.wait_interfaces(unique_vm_name)
-        assert vm_started, (
+        vm_got_ips, (code, data) = vm_checker.wait_ip_addresses(unique_vm_name, ['default'])
+        assert vm_got_ips, (
             f"Failed to Start VM({unique_vm_name}) with errors:\n"
             f"Status: {data.get('status')}\n"
             f"API Status({code}): {data}"
@@ -262,7 +262,7 @@ class TestVMNetwork:
             f"Failed to Restart VM({unique_vm_name}),"
             f" timed out while executing {ctx.callee!r}"
         )
-        vm_got_ips, (code, data) = vm_checker.wait_interfaces(unique_vm_name)
+        vm_got_ips, (code, data) = vm_checker.wait_ip_addresses(unique_vm_name, ['default'])
         assert vm_got_ips, (
             f"Failed to Start VM({unique_vm_name}) with errors:\n"
             f"Status: {data.get('status')}\n"

--- a/harvester_e2e_tests/integrations/test_upgrade.py
+++ b/harvester_e2e_tests/integrations/test_upgrade.py
@@ -581,7 +581,7 @@ class TestAnyNodesUpgrade:
 
         code, data = api_client.vms.create(unique_vm_name, vm_spec)
         assert 201 == code, (code, data)
-        vm_got_ips, (code, data) = vm_checker.wait_interfaces(unique_vm_name)
+        vm_got_ips, (code, data) = vm_checker.wait_ip_addresses(unique_vm_name, ["nic-1"])
         assert vm_got_ips, (
             f"Failed to Start VM({unique_vm_name}) with errors:\n"
             f"Status: {data.get('status')}\n"
@@ -639,7 +639,7 @@ class TestAnyNodesUpgrade:
             raise AssertionError(
                 f"restored VM {restored_vm_name} is not created"
             )
-        vm_got_ips, (code, data) = vm_checker.wait_interfaces(restored_vm_name)
+        vm_got_ips, (code, data) = vm_checker.wait_ip_addresses(restored_vm_name, ["nic-1"])
         assert vm_got_ips, (
             f"Failed to Start VM({restored_vm_name}) with errors:\n"
             f"Status: {data.get('status')}\n"
@@ -673,7 +673,7 @@ class TestAnyNodesUpgrade:
         vm_spec.add_volume("vol-1", 5, storage_cls=new_sc['metadata']['name'])
         code, data = api_client.vms.create(f"sc-{unique_vm_name}", vm_spec)
         assert 201 == code, (code, data)
-        vm_got_ips, (code, data) = vm_checker.wait_interfaces(f"sc-{unique_vm_name}")
+        vm_got_ips, (code, data) = vm_checker.wait_ip_addresses(f"sc-{unique_vm_name}", ["nic-1"])
         assert vm_got_ips, (
             f"Failed to Start VM(sc-{unique_vm_name}) with errors:\n"
             f"Status: {data.get('status')}\n"
@@ -899,7 +899,7 @@ class TestAnyNodesUpgrade:
             raise AssertionError(
                 f"restored VM {restored_vm_name} is not created"
             )
-        vm_got_ips, (code, data) = vm_checker.wait_interfaces(restored_vm_name)
+        vm_got_ips, (code, data) = vm_checker.wait_ip_addresses(restored_vm_name, ["nic-1"])
         assert vm_got_ips, (
             f"Failed to Start VM({restored_vm_name}) with errors:\n"
             f"Status: {data.get('status')}\n"


### PR DESCRIPTION
## Changes
- **ADD** implement `vm_checker.wait_ip_addresses` to check IP's availability.
- **UPDATE** `test_update_vm_machine_type` to skip in newer version.
- **UPDATE** change the way to get VM's IP in following test cases:
    - `test_3_vm_functions.py`
    - `test_4_vm_backup_restore.py`
    - `test_5_vm_networks.py`

The fix based on `job/harvester-install-and-test-e2e-daily/195`, to close #1284