### PR TITLE
[cypress] Fix failed rancher integration tests

### DIFF
--- a/cypress/pageobjects/rancher.po.ts
+++ b/cypress/pageobjects/rancher.po.ts
@@ -41,7 +41,8 @@ export class rancherPage {
     private boostrap_page_newPWRepeat = '[style=""] > .labeled-input > input';
     // private boostrap_page_checkAgreeEULA = '#checkbox-eula > .checkbox-container > .checkbox-custom';
     private boostrap_page_checkAgreeEULA = '[data-testid="setup-agreement"] > .checkbox-container > .checkbox-custom';
-    private boostrap_page_confirmLogin = '.btn > span';
+    // private boostrap_page_confirmLogin = '.btn > span';
+    private boostrap_page_confirmLogin = 'button[data-testid="setup-submit"]';
     private home_page_mainMenu = '.menu';
     private home_page_virtualManagement = ':nth-child(7) > .option > div';
 
@@ -111,9 +112,9 @@ export class rancherPage {
             cy.intercept('GET', '/v1/management.cattle.io.setting?exclude=metadata.managedFields').as('getFirstLogin')
                 .visit("/")
                 .wait('@getFirstLogin').then(login => {
-                const data: any[] = login.response?.body.data;
-                const firstLogin = data.find(v => v?.id === "first-login");
-                resolve(firstLogin.value === 'true');
+                    const data: any[] = login.response?.body.data;
+                    const firstLogin = data.find(v => v?.id === "first-login");
+                    resolve(firstLogin.value === 'true');
                 })
                 .end();
         });
@@ -123,23 +124,23 @@ export class rancherPage {
      * First time login using ssh 
      */
     public firstTimeLogin() {
-      cy.get(this.boostrap_page_boostrapPWInput).type(Cypress.env('rancherBootstrapPassword')).log('Input bootstrap secret');
-      cy.get(this.boostrap_page_boostrapPWSubmit).click();
+        cy.get(this.boostrap_page_boostrapPWInput).type(Cypress.env('rancherBootstrapPassword')).log('Input bootstrap secret');
+        cy.get(this.boostrap_page_boostrapPWSubmit).click();
 
-      // cy.log('Select a specific password to use')
-      cy.get(this.boostrap_page_radioSelectPW).click().log('Select a specific password to use');
+        //   // cy.log('Select a specific password to use')
+        //   cy.get(this.boostrap_page_radioSelectPW).click().log('Select a specific password to use');
 
-      // cy.log('Input new password')
-      cy.get(this.boostrap_page_newPWInput).type(constants.rancher_password).log('Input new password');
-      // cy.log('Confirm password again')
-      cy.get(this.boostrap_page_newPWRepeat).type(constants.rancher_password).log('Confirm password again');
+        //   // cy.log('Input new password')
+        //   cy.get(this.boostrap_page_newPWInput).type(constants.rancher_password).log('Input new password');
+        //   // cy.log('Confirm password again')
+        //   cy.get(this.boostrap_page_newPWRepeat).type(constants.rancher_password).log('Confirm password again');
 
-      // cy.log('Agree EULA')
-      cy.get(this.boostrap_page_checkAgreeEULA).click().log('Agree EULA');
+        // cy.log('Agree EULA')
+        cy.get(this.boostrap_page_checkAgreeEULA).click().log('Agree EULA');
 
-      cy.get(this.boostrap_page_confirmLogin).click().log('Continue to access rancher');
+        cy.get(this.boostrap_page_confirmLogin).click().log('Continue to access rancher');
 
-      cy.url().should('include', 'dashboard/home').log('Login Success');
+        cy.url().should('include', 'dashboard/home').log('Login Success');
     }
 
     /**
@@ -186,7 +187,7 @@ export class rancherPage {
         cy.get(this.clusterLink).click().then(() => {
             cy.log('Open virtualization dashboard');
         });
-}
+    }
 
     public visit_clusterManagement() {
         cy.visit(constants.rancher_clusterManagmentPage);
@@ -202,8 +203,8 @@ export class rancherPage {
 
     public importHarvester() {
         cy.visit('/home')
-        cy.get(this.home_page_mainMenu).click();
-        cy.get(this.home_page_virtualManagement).should('contain', 'Virtualization Management').click();
+        // cy.get(this.home_page_mainMenu).click();
+        // cy.get(this.home_page_virtualManagement).should('contain', 'Virtualization Management').click();
         cy.visit(constants.virtualManagePage)
         cy.get(this.virtual_page_importButton).should('contain', 'Import Existing').click();
         cy.get(this.virtual_page_clusterName).type('harvester')

--- a/cypress/testcases/rancher/rancher_integration.spec.ts
+++ b/cypress/testcases/rancher/rancher_integration.spec.ts
@@ -131,10 +131,39 @@ describe('Harvester import Rancher', function () {
         });
     })
 
+    let isHarvFirstTimeLogin: boolean = false;
+    before(async () => {
+        isHarvFirstTimeLogin = await LoginPage.isFirstTimeLogin();
+
+    })
+
     it('Harvester import Rancher', () => {
-        cy.login();
+        // cy.login();
+        if (isHarvFirstTimeLogin) {
+            const page = new LoginPage();
+            page.visit()
+                .selectSpecificPassword()
+                .checkTelemetry(false)
+                .checkEula(true)
+                .inputPassword()
+                .submitBtn.click();
+
+            page.validateLogin();
+        } else {
+            cy.login();
+        }
         rancher.registerRancher();
     });
+
+})
+
+describe('Rancher integration', function () {
+    beforeEach(() => {
+        cy.fixture('rancher').then((data) => {
+            rData = data;
+        });
+    })
+
 
     it('Check Harvester Cluster Status', { baseUrl: constants.rancherUrl }, () => {
         // cy.login();
@@ -162,7 +191,8 @@ describe('Harvester import Rancher', function () {
         rancher.open_virtualizationDashboard();
 
         virtualizationDashboard.validateClusterName();
-        
+
     });
 
 })
+


### PR DESCRIPTION


In order to fix the failed cypress Rancher integration tests list in issue: https://github.com/harvester/tests/issues/1197
Which were found in the main cypress Jenkins pipeline.

-  Rancher First Login
-  Rancher import Harvester
-  Harvester import Rancher
-  Check Harvester Cluster Status
-  Check Rancher Harvester dashboard

Tested on the local kvm environment, can **PASS** all test cases on Harvester v1.3-head with Rancher v2.8.2
  ![image](https://github.com/harvester/tests/assets/29251855/d45736fe-221f-4c87-a0fd-1a91dcafddf9)

And also tested on the main Jenkins cypress pipeline on job 
http://jenkins.provo.rancherlabs.com/job/harvester-cypress-test/37/

On the cypress test report: 
https://minio.provo.rancherlabs.com:31524/cypress-test-report/cypress/results/20240521-092441-bf66d5c/index.html 

Can pass the following three cases:
-  Rancher First Login
-  Rancher import Harvester
-  Harvester import Rancher
  ![image](https://github.com/harvester/tests/assets/29251855/aae73b65-9c67-4eae-b3fc-700446c45b0b)

To these three failed cases we need to test along with the harvester-baremetal-ansible PR:
https://github.com/harvester/harvester-baremetal-ansible/pull/41

For the last two cases, it may related to the environment network setup, which require further investigation. 