### PR TITLE
Update manual TCs steps according release testing

### DIFF
--- a/docs/content/manual/backup-and-restore/negative-power-down-node-while-restoring-replace.md
+++ b/docs/content/manual/backup-and-restore/negative-power-down-node-while-restoring-replace.md
@@ -1,8 +1,27 @@
 ---
 title: Negative Power down the node where the VM is getting replaced by the restore
 ---
-1. Initiate a restore with existing VM.
+
+* Related issues
+    - [tests#1263](https://github.com/harvester/tests/issues/1263) [ReleaseTesting] Negative Power down the node where the VM is getting replaced by the restore
+
+
+## Verification Steps
+1. Setup a 3 nodes harvester
+1. Create a VM w/ extra disk and some data
+1. Backup and shutdown VM
+1. Start to observe `pod/virt-launcher-VMNAME` to get the node VM restoring on for next step. 
+1. Initiate a restore with existing VM, get node info from `pod/virt-launcher-VMNAME`.
+   ![image](https://github.com/harvester/tests/assets/2773781/eb3750eb-26a1-4785-b2d5-a41a4c749dcb)
+
 1. While the restore is in progress and VM is starting on a node, shut down the node
 
 ## Expected Results
-1. You should get an error
+1. 1st restore should fail 
+   ![image](https://github.com/harvester/tests/assets/2773781/49fcf50e-6c84-4198-bc91-b42cbc123c51)
+   
+2. VM should be restore to another node and `Running`
+   ![image](https://github.com/harvester/tests/assets/2773781/a316c185-3a43-44be-a9d3-a65480837b18)
+   
+3. Test data still available and not broken
+   ![image](https://github.com/harvester/tests/assets/2773781/62cd07d1-9ba5-4ff9-9120-41695beb966d)

--- a/docs/content/manual/volumes/1334-evict-disks-check-vms.md
+++ b/docs/content/manual/volumes/1334-evict-disks-check-vms.md
@@ -4,7 +4,7 @@ title: Verify that VMs stay up when disks are evicted
 
 * Related issues
     - [#1334](https://github.com/harvester/harvester/issues/1334) Volumes fail with Scheduling Failure after evicting disc on multi-disc node
-    - [#5307](https://github.com/harvester/harvester/issues/5307) Replicas should be evicted and rescheduled to other disks before removing extrak disk
+    - [#5307](https://github.com/harvester/harvester/issues/5307) Replicas should be evicted and rescheduled to other disks before removing extra disk
 
 ## Verification Steps
 

--- a/docs/content/manual/volumes/1334-evict-disks-check-vms.md
+++ b/docs/content/manual/volumes/1334-evict-disks-check-vms.md
@@ -14,20 +14,19 @@ title: Verify that VMs stay up when disks are evicted
     1. disk A of node0
     1. root disk of node1
     1. root disk of node2
-1. Created storage class with disk tag `test`.
+1. Created storage class with disk tag `test` and replica `3`.
 1. Created volume (called B) with previous storage class. You should check scheduling status in the longhorn page.
 1. Created VM with volume B as extra volume (not boot volume).
-1. The node scheduling status should look like this. {{< image "images/volumes/1334-image-01.png" >}}
-1. Deleted disk A in the harvester node page, error message should be displayed.
-1. Added disk tag `test` to **root disk of node0**.
-1. Requested eviction and disabled scheduling on disk A in the longhorn dashboard.
-    Before:
-    {{< image "images/volumes/1334-image-02.png" >}} 
-    
-    After:
-    {{< image "images/volumes/1334-image-03.png" >}}
+1. The node scheduling status should look like this.
+   {{< image "images/volumes/1334-image-01.png" >}}
 
-1. Removed disk A in the harvester node page, and it should be removed.
+1. Delete disk A in the harvester node page and revisit it, error message should be displayed.
+1. Check **Eviction Requested** is `True` and **Scheduling** is `Disable` on disk A in the longhorn dashboard.
+   {{< image "images/volumes/1334-image-02.png" >}} 
+
+1. Add disk tag `test` to **root disk of node0**.
+1. Now disk A should be removed since replica condition is satisfied again.
+   {{< image "images/volumes/1334-image-03.png" >}}
 
 ## Expected Results
 1. Disk A is removed on the harvester node page.


### PR DESCRIPTION
## Changes
1. TC `Negative Power down the node where the VM is getting replaced by the restore`
   * Add detail steps
3. TC `Verify that VMs stay up when disks are evicted`
   * Correct step order
   * Storage class's replica count should be `3` in this context