### PR TITLE
Fix VM related test cases

### DIFF
--- a/cypress/cypress.config.ts
+++ b/cypress/cypress.config.ts
@@ -22,12 +22,14 @@ export default defineConfig({
     baseUrl: 'https://online-server',
     host: [{
       name: 'harvester-node-1',
+      customName: '',
       disks: [
         {
           name: '',
           devPath: '',
         },
       ],
+      witnessNode: false
     }],
     image: {
       name: 'openSUSE-Leap-15.3-3-NET-x86_64.qcow2',

--- a/cypress/cypress.env.json.example
+++ b/cypress/cypress.env.json.example
@@ -8,17 +8,19 @@
   "rancherUser": "admin",
   "rancherPassword": "admin",
   "rancherBootstrapPassword": "admin",
-  "host":
-  {
-    "name": "",
-    "disks":
-    [
-      {
-        "name": "",
-        "devPath": ""
-      }
-    ]
-  },
+  "host": [
+    {
+      "name": "",
+      "customName": "",
+      "disks": [
+        {
+          "name": "",
+          "devPath": ""
+        }
+      ],
+      "witnessNode": false
+    }
+  ],
   "largeImage": {
     "name": "openSUSE-Leap-15.3-3-DVD-x86_64-Build38.1-Media.iso",
     "url": "https://mirrors.bfsu.edu.cn/opensuse/distribution/leap/15.3/iso/openSUSE-Leap-15.3-3-DVD-x86_64-Build38.1-Media.iso"

--- a/cypress/models/host.ts
+++ b/cypress/models/host.ts
@@ -1,0 +1,4 @@
+export interface Node {
+  name: string;
+  customName: string;
+}

--- a/cypress/pageobjects/hosts.po.ts
+++ b/cypress/pageobjects/hosts.po.ts
@@ -12,6 +12,11 @@ interface ValueInterface {
   consoleUrl?: string,
 }
 
+export interface Node {
+  name: string;
+  customName: string;
+}
+
 export class HostsPage extends CruResourcePo {
   private hostList = '.host-list';
   private actionsDropdown = '.role-multi-action';
@@ -69,13 +74,13 @@ export class HostsPage extends CruResourcePo {
     }
   }
 
-  enableMaintenance(name:string) {
-    cy.intercept('POST', `/v1/harvester/${this.realType}s/${name}?action=enableMaintenanceMode`).as('enable');
-    this.clickAction(name, 'Enable Maintenance Mode');
+  enableMaintenance(node: Node) {
+    cy.intercept('POST', `/v1/harvester/${this.realType}s/${node.name}?action=enableMaintenanceMode`).as('enable');
+    this.clickAction(node.customName || node.name, 'Enable Maintenance Mode');
     // Maintenance
     cy.get('.card-container').contains('Apply').click();
     cy.wait('@enable').then(res => {
-      expect(res.response?.statusCode, `Enable maintenance ${name}`).to.equal(204);
+      expect(res.response?.statusCode, `Enable maintenance ${node.name}`).to.equal(204);
     })
   }
 

--- a/cypress/pageobjects/hosts.po.ts
+++ b/cypress/pageobjects/hosts.po.ts
@@ -3,6 +3,7 @@ const constants = new Constants();
 import CruResourcePo from '@/utils/components/cru-resource.po';
 import { HCI } from '@/constants/types'
 import LabeledInputPo from '@/utils/components/labeled-input.po';
+import { Node } from '@/models/host'
 
 interface ValueInterface {
   namespace?: string,
@@ -10,11 +11,6 @@ interface ValueInterface {
   description?: string,
   customName?: string,
   consoleUrl?: string,
-}
-
-export interface Node {
-  name: string;
-  customName: string;
 }
 
 export class HostsPage extends CruResourcePo {

--- a/cypress/pageobjects/virtualmachine.po.ts
+++ b/cypress/pageobjects/virtualmachine.po.ts
@@ -468,27 +468,27 @@ export class VmsPage extends CruResourcePo {
   setNodeScheduling({
     radio, nodeName, selector
   }: {
-    radio?: string,
+    radio?: 'any' | 'specific' | 'rules',
     nodeName?: string,
     selector?: any,
   }) {
     this.clickTab('nodeScheduling');
-    
-    const anyRadio = new RadioButtonPo('.radio-group', ':contains("Run VM on any available node")') 
-    const specificRadio = new RadioButtonPo('.radio-group', ':contains("Run VM on specific node")') 
-    const rulesRadio = new RadioButtonPo('.radio-group', ':contains("Run VM on node(s) matching scheduling rules")') 
 
-    if (radio === 'any') {
-      // anyRadio.input(null)
-    } else if (radio = 'Run VM on any available node') {
-      specificRadio.input('Run VM on specific node')
+    switch (radio) {
+      case 'rules':
+        const rulesRadio = new RadioButtonPo('.radio-group', ':contains("Run VM on node(s) matching scheduling rules")')
+        rulesRadio.input('Run VM on node(s) matching scheduling rules')
+        break;
+      case 'specific':
+        const specificRadio = new RadioButtonPo('.radio-group', ':contains("Run VM on specific node")') 
+        specificRadio.input('Run VM on specific node')
 
-      const nodeNameSelector = new LabeledSelectPo('.labeled-select', `:contains("Node Name")`)
-      nodeNameSelector.select({
-        option: nodeName,
-      })
-    } else if (radio === 'rules') {
-      rulesRadio.input('Run VM on node(s) matching scheduling rules')
+        const nodeNameSelector = new LabeledSelectPo('.labeled-select', `:contains("Node Name")`)
+        nodeNameSelector.select({
+          selector: '.vs__dropdown-menu',
+          option: nodeName,
+        })
+        break;
     }
   }
 }

--- a/cypress/pageobjects/virtualmachine.po.ts
+++ b/cypress/pageobjects/virtualmachine.po.ts
@@ -474,16 +474,17 @@ export class VmsPage extends CruResourcePo {
   }) {
     this.clickTab('nodeScheduling');
 
+    const rulesRadio = new RadioButtonPo('.radio-group', ':contains("Run VM on node(s) matching scheduling rules")')
+    const specificRadio = new RadioButtonPo('.radio-group', ':contains("Run VM on specific node")')
+    const nodeNameSelector = new LabeledSelectPo('.labeled-select', `:contains("Node Name")`)
+
     switch (radio) {
       case 'rules':
-        const rulesRadio = new RadioButtonPo('.radio-group', ':contains("Run VM on node(s) matching scheduling rules")')
         rulesRadio.input('Run VM on node(s) matching scheduling rules')
         break;
       case 'specific':
-        const specificRadio = new RadioButtonPo('.radio-group', ':contains("Run VM on specific node")') 
         specificRadio.input('Run VM on specific node')
 
-        const nodeNameSelector = new LabeledSelectPo('.labeled-select', `:contains("Node Name")`)
         nodeNameSelector.select({
           selector: '.vs__dropdown-menu',
           option: nodeName,

--- a/cypress/testcases/virtualmachines/node-scheduling.spec.ts
+++ b/cypress/testcases/virtualmachines/node-scheduling.spec.ts
@@ -1,6 +1,6 @@
 import { VmsPage } from "@/pageobjects/virtualmachine.po";
 
-import { generateName } from '@/utils/utils';
+import { generateName, host as hostUtil } from '@/utils/utils';
 import { Constants } from "@/constants/constants";
 
 const vmPO = new VmsPage();
@@ -27,7 +27,7 @@ describe('Stop VM Negative', () => {
     vmPO.setBasics('1', '1');
     vmPO.setVolumes(volume);
 
-    const hostList = Cypress.env('host');
+    const hostList = hostUtil.list();
     const host = hostList[0];
 
     vmPO.setNodeScheduling({

--- a/cypress/testcases/virtualmachines/node-scheduling.spec.ts
+++ b/cypress/testcases/virtualmachines/node-scheduling.spec.ts
@@ -27,11 +27,12 @@ describe('Stop VM Negative', () => {
     vmPO.setBasics('1', '1');
     vmPO.setVolumes(volume);
 
-    const host = Cypress.env('host');
+    const hostList = Cypress.env('host');
+    const host = hostList[0];
 
     vmPO.setNodeScheduling({
       radio: 'specific',
-      nodeName: host.name, 
+      nodeName: host.customName || host.name, 
     });
 
     vmPO.save(); 

--- a/cypress/testcases/virtualmachines/scheduling.spec.ts
+++ b/cypress/testcases/virtualmachines/scheduling.spec.ts
@@ -1,5 +1,5 @@
 import { VmsPage } from "@/pageobjects/virtualmachine.po";
-import { HostsPage } from "@/pageobjects/hosts.po";
+import { HostsPage, Node } from "@/pageobjects/hosts.po";
 
 const vms = new VmsPage();
 const hosts = new HostsPage();
@@ -14,9 +14,11 @@ describe('VM scheduling on Specific node', () => {
 
   it('Schedule VM on the Node which is Enable Maintenance Mode', () => {
     const hostList = Cypress.env('host');
-    const hostNames: string[] = hostList.map((host: any) => host.name);
-    const maintenanceNode = hostNames[0]
-    const filterMaintenanceNames = hostNames.filter(name => name !== maintenanceNode);
+
+    const hostNames: string[] = hostList.map((node: Node) => node.customName || node.name);
+
+    const maintenanceNodeName = hostNames[0]
+    const filterMaintenanceNodeNames = hostNames.filter(name => name !== maintenanceNodeName);
 
     // Check whether all nodes can be selected
     vms.goToCreate();
@@ -24,15 +26,15 @@ describe('VM scheduling on Specific node', () => {
     vms.checkSpecificNodes({includeNodes: hostNames});
     
     hosts.goToList();
-    hosts.enableMaintenance(hostNames[0]);
+    hosts.enableMaintenance(hostList[0]);
     
     // Maintenance nodes should not be selected
     vms.goToCreate();
     vms.selectSchedulingType({type: 'specific'});
-    vms.checkSpecificNodes({includeNodes: filterMaintenanceNames, excludeNodes: [maintenanceNode]});
+    vms.checkSpecificNodes({includeNodes: filterMaintenanceNodeNames, excludeNodes: [maintenanceNodeName]});
 
     hosts.goToList();
-    hosts.clickAction(hostList[0].name, 'Disable Maintenance Mode');
+    hosts.clickAction(hostNames[0], 'Disable Maintenance Mode');
 
     // Check whether all nodes can be selected
     vms.goToCreate();

--- a/cypress/testcases/virtualmachines/scheduling.spec.ts
+++ b/cypress/testcases/virtualmachines/scheduling.spec.ts
@@ -1,5 +1,7 @@
 import { VmsPage } from "@/pageobjects/virtualmachine.po";
-import { HostsPage, Node } from "@/pageobjects/hosts.po";
+import { HostsPage } from "@/pageobjects/hosts.po";
+import { host as hostsUtil } from '@/utils/utils';
+import { Node } from '@/models/host'
 
 const vms = new VmsPage();
 const hosts = new HostsPage();
@@ -13,7 +15,7 @@ describe('VM scheduling on Specific node', () => {
   });
 
   it('Schedule VM on the Node which is Enable Maintenance Mode', () => {
-    const hostList = Cypress.env('host');
+    const hostList = hostsUtil.list();
 
     const hostNames: string[] = hostList.map((node: Node) => node.customName || node.name);
 

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -46,3 +46,15 @@ export function base64DecodeToBuffer(string: string) {
 export function base64Decode(string: string) {
   return !string ? string : base64DecodeToBuffer(string.replace(/[-_]/g, char => char === '-' ? '+' : '/')).toString();
 }
+
+export const nodes = {
+  filterWitnessNode: (hosts: any[]) => {
+    const ret = hosts.filter((host) => !host.witnessNode);
+
+    if (!ret.length) {
+      throw new Error("No eligible hosts found for testing");
+    }
+
+    return ret;
+  }
+}

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -1,5 +1,6 @@
 
 import AdmZip from 'adm-zip';
+import { Node } from '@/models/host'
 /**
  * This will validate the zip file by checking the contents. Assumes that this is in 
  * the downloads folder
@@ -47,7 +48,16 @@ export function base64Decode(string: string) {
   return !string ? string : base64DecodeToBuffer(string.replace(/[-_]/g, char => char === '-' ? '+' : '/')).toString();
 }
 
-export const nodes = {
+export const host = {
+  list(): Node[] {
+    const hosts = Cypress.env('host');
+  
+    if (!hosts || hosts.length < 1) {
+      throw new Error("No hosts defined in cypress env");
+    }
+  
+    return hosts;
+  },
   filterWitnessNode: (hosts: {name: string, witnessNode: boolean}[]) => {
     const ret = hosts.filter((host) => !host.witnessNode);
 

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -48,7 +48,7 @@ export function base64Decode(string: string) {
 }
 
 export const nodes = {
-  filterWitnessNode: (hosts: any[]) => {
+  filterWitnessNode: (hosts: {name: string, witnessNode: boolean}[]) => {
     const ret = hosts.filter((host) => !host.witnessNode);
 
     if (!ret.length) {


### PR DESCRIPTION
Related issue https://github.com/harvester/tests/issues/1196

The VM tests are failing because the node `harvester-node-0` has a  `test-custom-name` customName in Harvester configuration; This breaks the cypress tests in matching the correct UI elements.

![image](https://github.com/harvester/tests/assets/26394656/5c24721c-3f30-4f9f-9f33-f566effa8985)

- I've updated the tests to support host's `customName`.
- I added the `customName` in host config. **This will require to update the config in Jenkins pipelines**:
  - `host` should be always an array
  - if `customName` is empty, the `name` will be used during the tests

```
  "host": [
    {
      "name": "",
      "customName": "",
      "disks": [
        {
          "name": "",
          "devPath": ""
        }
      ],
      "witnessNode": false
    }
  ],
```
