### PR TITLE
Support ippool custom range

### DIFF
--- a/apiclient/harvester_api/managers/networks.py
+++ b/apiclient/harvester_api/managers/networks.py
@@ -72,7 +72,7 @@ class IPPoolManager(BaseManager):
     PATH_fmt = "{API_VERSION}/harvester/loadbalancer.harvesterhci.io.ippools{name}"
     API_VERSION = "v1"
 
-    def create_data(self, name, ip_pool_subnet, network_id):
+    def create_data(self, name, ip_pool_subnet, ip_pool_start, ip_pool_end, network_id):
         return {
             "type": "loadbalancer.harvesterhci.io.ippool",
             "metadata": {
@@ -81,8 +81,10 @@ class IPPoolManager(BaseManager):
             "spec": {
                 "ranges": [{
                     "subnet": ip_pool_subnet,
+                    "rangeStart": ip_pool_start,
+                    "rangeEnd": ip_pool_end,
                     "gateway": "",
-                    "type": "cidr"
+                    "type": "range" if ip_pool_start or ip_pool_end else "cidr"
                 }],
                 "selector": {
                     "network": network_id,
@@ -95,8 +97,8 @@ class IPPoolManager(BaseManager):
             }
         }
 
-    def create(self, name, ip_pool_subnet, network_id, *, raw=False):
-        data = self.create_data(name, ip_pool_subnet, network_id)
+    def create(self, name, ip_pool_subnet, ip_pool_start, ip_pool_end, network_id, *, raw=False):
+        data = self.create_data(name, ip_pool_subnet, ip_pool_start, ip_pool_end, network_id)
         path = self.PATH_fmt.format(name="", API_VERSION=self.API_VERSION)
         return self._create(path, json=data, raw=raw)
 

--- a/config.yml
+++ b/config.yml
@@ -11,6 +11,8 @@ vlan-id: 1
 # Physical NIC for VLAN. Default is "harvester-mgmt"
 vlan-nic: 'harvester-mgmt'
 ip-pool-subnet: '192.168.0.0/24'
+ip-pool-start: ''
+ip-pool-end: ''
 
 # Wait time for polling operations
 wait-timeout: 600

--- a/harvester_e2e_tests/conftest.py
+++ b/harvester_e2e_tests/conftest.py
@@ -100,7 +100,19 @@ def pytest_addoption(parser):
         '--ip-pool-subnet',
         action='store',
         default=config_data['ip-pool-subnet'],
-        help='IP pool range for load balancer'
+        help='Subnet of IP pool for load balancer'
+    )
+    parser.addoption(
+        '--ip-pool-start',
+        action='store',
+        default=config_data['ip-pool-start'],
+        help='Start IP of IP pool for load balancer'
+    )
+    parser.addoption(
+        '--ip-pool-end',
+        action='store',
+        default=config_data['ip-pool-end'],
+        help='End IP of IP pool for load balancer'
     )
     parser.addoption(
         '--wait-timeout',

--- a/harvester_e2e_tests/integrations/test_9_rancher_integration.py
+++ b/harvester_e2e_tests/integrations/test_9_rancher_integration.py
@@ -57,8 +57,12 @@ def vlan_network(request, api_client):
 def ip_pool(request, api_client, unique_name, vlan_network):
     name = f"ippool-{unique_name}"
     ip_pool_subnet = request.config.getoption('--ip-pool-subnet')
+    ip_pool_start = request.config.getoption('--ip-pool-start')
+    ip_pool_end = request.config.getoption('--ip-pool-end')
 
-    code, data = api_client.ippools.create(name, ip_pool_subnet, vlan_network["id"])
+    code, data = api_client.ippools.create(
+        name, ip_pool_subnet, ip_pool_start, ip_pool_end, vlan_network["id"]
+    )
     assert 201 == code, (
         f"Failed to create ip pool {name} with error: {code}, {data}"
     )


### PR DESCRIPTION
## Changes
1. Add `ip-pool-start` and `ip-pool-end` to support range form IP pool.
![ippool_range](https://github.com/harvester/tests/assets/2773781/4e99acac-851c-4df0-b7ab-a7e9c36d1701)


## Verification
### Environment
* Harvester
  * Version: `v1.2.2`
  * Profile: QEMU/KVM, single node (48C/128G/1.6T)
  * ui-source: `Auto`
* Rancher
  * Version: `v2.8.4`
  * Profile: rancher-vcluster
### Test Result
![image](https://github.com/harvester/tests/assets/2773781/09ab8e35-9317-4a32-b236-2ebacdc287ee)
