### PR TITLE
fix terraform scripts

### DIFF
--- a/terraform_test_artifacts/terraform_install.sh
+++ b/terraform_test_artifacts/terraform_install.sh
@@ -31,9 +31,9 @@ if [ -x "$TERDIR/bin/terraform" ] ; then
 fi
 
 pushd "$TERDIR"
-`wget ${DOWNLOAD_URL} -O terraform_bin.zip`
+`wget -q ${DOWNLOAD_URL} -O terraform_bin.zip`
 ## extract archive
-unzip terraform_bin.zip 
+unzip -o terraform_bin.zip 
 terraform_bin=${TERDIR}/bin
 
 mkdir -p "${terraform_bin}"


### PR DESCRIPTION
1) Silence output of wget to make logs more readable.
2) Force unzip to never prompt when extracting files.
   This can break CI pipelines because there the prompt will never be
   answered.