### PR TITLE
feat: add terraform-provider-harvester to config.yaml

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -31,6 +31,8 @@ image-cache-url: ''
 terraform-scripts-location: 'terraform_test_artifacts'
 # Rancher provider version, leave empty for the latest version. e.g. '' or '3.1.1'.
 terraform-provider-rancher: ''
+# Harvester provider version, leave empty for the latest version. e.g. '' or '0.6.3'.
+terraform-provider-harvester: ''
 
 # Backup Target S3
 s3-endpoint: ''


### PR DESCRIPTION
We use `--terraform-provider-harvester` in `tf_provider_version` fixture, but this config is not in `config.yaml`.