### PR TITLE
Align RancherAPI object's session.verify as user specified via login()

### DIFF
--- a/apiclient/rancher_api/api.py
+++ b/apiclient/rancher_api/api.py
@@ -21,6 +21,7 @@ class RancherAPI:
     def login(cls, endpoint, user, passwd, session=None, ssl_verify=True):
         api = cls(endpoint, session=session)
         api.authenticate(user, passwd, verify=ssl_verify)
+        api.session.verify = ssl_verify
 
         return api
 

--- a/config.yml
+++ b/config.yml
@@ -51,7 +51,7 @@ rancher-admin-password: 'password1234'
 # Prefix of K8s version for to create downstream cluster
 k8s-version: 'v1.28'
 # Wait time for polling Rancher cluster status.
-rancher-cluster-wait-timeout: 7200
+rancher-cluster-wait-timeout: 1800
 
 # Upgrade parameters
 upgrade-prepare-dependence: False


### PR DESCRIPTION
## Changes
1. Align `RancherAPI` object's `session.verify` as user specified when `login()`.
   * To fix harvester/tests/issues/1361
     ![image](https://github.com/harvester/tests/assets/2773781/9c888b90-d2c2-4095-aa4b-b9cf263af3f8)
   * It's due to we apply `ssl_verify=False` on `authentication` calling but not the session.
     ![image](https://github.com/harvester/tests/assets/2773781/8a81e0f6-b771-4334-a3ea-0c19a97b2432)
1. Align `rancher-cluster-wait-timeout` with harvester/harvester-baremetal-ansible/pull/65

## Verification
* harvester-runtests/26
  ![image](https://github.com/harvester/tests/assets/2773781/9c6929b6-78c4-4975-8846-fce13504d376)

## Note
1. Possible reason that we do not hit before may due to it's a Rancher change or it's bug from our ssl dependency in pytest. 
