### PR TITLE
Add TestImageWithStorageNetwork

### DIFF
--- a/apiclient/harvester_api/api.py
+++ b/apiclient/harvester_api/api.py
@@ -122,7 +122,8 @@ class HarvesterAPI:
     def set_retries(self, times=5, status_forcelist=(500, 502, 504), **kwargs):
         kwargs.update(backoff_factor=kwargs.get('backoff_factor', 10.0),
                       total=kwargs.get('total', times),
-                      status_forcelist=status_forcelist)
+                      status_forcelist=status_forcelist,
+                      raise_on_status=False)
         retry_strategy = Retry(**kwargs)
         adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
         self.session.mount("https://", adapter)

--- a/apiclient/harvester_api/managers/images.py
+++ b/apiclient/harvester_api/managers/images.py
@@ -8,6 +8,7 @@ class ImageManager(BaseManager):
     # get, create, update, delete
     PATH_fmt = "apis/{{API_VERSION}}/namespaces/{ns}/virtualmachineimages/{uid}"
     UPLOAD_fmt = "v1/harvester/harvesterhci.io.virtualmachineimages/{ns}/{uid}"
+    DOWNLOAD_fmt = "v1/harvester/harvesterhci.io.virtualmachineimages/{ns}/{uid}/download"
     _KIND = "VirtualMachineImage"
 
     def create_data(self, name, url, desc, stype, namespace, display_name=None, storageclass=None):
@@ -71,3 +72,6 @@ class ImageManager(BaseManager):
 
     def delete(self, name, namespace=DEFAULT_NAMESPACE, *, raw=False):
         return self._delete(self.PATH_fmt.format(uid=name, ns=namespace))
+
+    def download(self, name, namespace=DEFAULT_NAMESPACE):
+        return self._get(self.DOWNLOAD_fmt.format(uid=name, ns=namespace), raw=True)


### PR DESCRIPTION
### Which issue(s) this PR fixes:
Issue harvester/tests#1083

### What this PR does / why we need it:
1. Add `test_1_images.py::TestImageWithStorageNetwork` to test image operations within `storage-network` context, includes:
   * `create_image_by_file`
   * `download_image`
   * `delete_image`
1. Set `raise_on_status=False` on session `retry_strategy` to let _requests_ return `5XX` response instead of `Max retries exceeded ...` error for handy testing.
   * https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry
   * https://stackoverflow.com/questions/54356759/python-requests-how-to-determine-response-code-on-maxretries-exception

### Special notes for your reviewer:
1. Use small size `fake_image_file` fixture to test both upload and download quickly.   

### Additional documentation or context
#### Positive Tests
* `v1.2.2` w/ `-k test_1_image` (build _harvester-runtests/40_)
  ![image](https://github.com/user-attachments/assets/6f3fcbf3-3050-4380-8f6c-e42e2a6dc110)
* `v1.2.2` w/ `-k test_0 or test_1` (build _harvester-runtests/41_)
  ![image](https://github.com/user-attachments/assets/d7393541-708b-459b-a4ee-10a1d0d2bbe2)

#### Negtive Tests
* `v1.2.1` w/ `-k test_0 or test_1_image` (local build, can catch fail)
  ![image](https://github.com/user-attachments/assets/871c598f-4006-4753-987d-bdabef576dd5)
