### PR TITLE
test: implement kubeconfig-default-token-ttl-minutes api setting tests

### DIFF
--- a/apiclient/harvester_api/managers/settings.py
+++ b/apiclient/harvester_api/managers/settings.py
@@ -1,6 +1,7 @@
 from collections.abc import Mapping
 
-from harvester_api.models.settings import BaseSettingSpec, BackupTargetSpec, StorageNetworkSpec
+from harvester_api.models.settings import BaseSettingSpec, BackupTargetSpec, \
+    StorageNetworkSpec, KubeconfigDefaultTokenTTLSpec
 from .base import BaseManager, merge_dict
 
 
@@ -13,6 +14,7 @@ class SettingManager(BaseManager):
     Spec = BaseSettingSpec
     BackupTargetSpec = BackupTargetSpec
     StorageNetworkSpec = StorageNetworkSpec
+    KubeconfigDefaultTokenTTLSpec = KubeconfigDefaultTokenTTLSpec
 
     def get(self, name="", *, raw=False):
         return self._get(self.PATH_fmt.format(name=name))

--- a/apiclient/harvester_api/models/settings.py
+++ b/apiclient/harvester_api/models/settings.py
@@ -65,6 +65,27 @@ class BackupTargetSpec(BaseSettingSpec):
         return cls(dict(type="nfs", endpoint=endpoint))
 
 
+class KubeconfigDefaultTokenTTLSpec(BaseSettingSpec):
+    _name = "kubeconfig-default-token-ttl-minutes"
+    _default = 0
+
+    @property
+    def type(self):
+        return self.value.get('type')
+
+    def clear(self):
+        self.value = self._default
+
+    @classmethod
+    def from_dict(cls, data):
+        value = loads(data.get('value', "{}"))
+        return cls(value)
+
+    @classmethod
+    def TTL(cls, minutes):
+        return cls(minutes)
+
+
 class StorageNetworkSpec(BaseSettingSpec):
     _name = "storage-network"
 

--- a/apiclient/harvester_api/models/settings.pyi
+++ b/apiclient/harvester_api/models/settings.pyi
@@ -61,3 +61,37 @@ class BackupTargetSpec(BaseSettingSpec):
     def NFS(cls: Type[BackupTargetSpec], endpoint: str) -> Type[BackupTargetSpec]:
         """
         """
+
+class KubeconfigDefaultTokenTTLSpec(BaseSettingSpec):
+    """Kubeconfig Default Token TTL Spec setting
+
+    Args:
+        BaseSettingSpec (_type_): _description_
+    """
+    value: Optional[dict]
+
+    def __init__(self, value: Optional[dict] = ...) -> NoReturn:
+        """
+        """
+    @property
+    def type(self) -> str | None:
+        """
+        """
+    def clear(self) -> NoReturn:
+        """
+        """
+    def to_dict(self) -> dict:
+        """
+        """
+
+    @classmethod
+    def TTL(cls: Type[KubeconfigDefaultTokenTTLSpec], minutes: int) -> Type[KubeconfigDefaultTokenTTLSpec]:
+        """Class method builds token ttl
+
+        Args:
+            cls (Type[KubeconfigDefaultTokenTTLSpec]): spec of kubeconfig default token ttl
+            minutes (int): minutes must be integer
+
+        Returns:
+            Type[KubeconfigDefaultTokenTTLSpec]: base spec to return with single value int of minutes on token ttl
+        """

--- a/harvester_e2e_tests/apis/test_settings.py
+++ b/harvester_e2e_tests/apis/test_settings.py
@@ -162,3 +162,27 @@ class TestUpdateInvalidBackupTarget:
             f"S3 backup-target should check key/secret/bucket/region"
             f"API Status({code}): {data}"
         )
+
+
+@pytest.mark.p0
+@pytest.mark.settings
+class TestUpdateKubeconfigDefaultToken:
+    @pytest.mark.skip_version_before("v1.3.2", reason="Issue#5891 fixed after v1.3.2")
+    def test_invalid_kubeconfig_ttl_min(self, api_client):
+        KubeconfigTTLMinSpec = api_client.settings.KubeconfigDefaultTokenTTLSpec.TTL
+        spec = KubeconfigTTLMinSpec(99999999999999)
+        code, data = api_client.settings.update('kubeconfig-default-token-ttl-minutes', spec)
+        assert 422 == code, (
+            f"Kubeconfig Default Token TTL Minutes should not exceed 100yrs\n"
+            f"API Status({code}): {data}"
+        )
+
+    @pytest.mark.skip_version_before('v1.3.1')
+    def test_valid_kubeconfig_ttl_min(self, api_client):
+        KubeconfigTTLMinSpec = api_client.settings.KubeconfigDefaultTokenTTLSpec.TTL
+        spec = KubeconfigTTLMinSpec(172800)
+        code, data = api_client.settings.update('kubeconfig-default-token-ttl-minutes', spec)
+        assert 200 == code, (
+            f"Kubeconfig Default Token TTL Minutes be allowed to be set for 120 days\n"
+            f"API Status({code}): {data}"
+        )


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue: https://github.com/harvester/tests/issues/1392
Resolves: test/implement-1392
See also: https://github.com/harvester/harvester/issues/6011

#### What this PR does / why we need it:
- base cases for `kubeconfig-default-token-ttl-minutes` setting in api (positive & negative)
- manager enhancement 
- model enhancement 

#### Special notes for your reviewer:
- N/A

#### Additional documentation or context
- does baseline test of updating the setting from default value of 0 
- only applicable with Harvester versions greater than or equal to v1.3.1 (currently)