### PR TITLE
Wait VM becomes getable after triggering restore

### DIFF
--- a/harvester_e2e_tests/fixtures/virtualmachines.py
+++ b/harvester_e2e_tests/fixtures/virtualmachines.py
@@ -170,6 +170,17 @@ def vm_checker(api_client, wait_timeout, sleep_timeout, vm_shell):
             finally:
                 self.snooze, self.wait_timeout = s, t
 
+        def wait_getable(self, vm_name, endtime=None, callback=default_cb, **kws):
+            endtime = endtime or self._endtime()
+            while endtime > datetime.now():
+                ctx = ResponseContext('vm.get', *self.vms.get(vm_name, **kws))
+                if 200 == ctx.code and callback(ctx):
+                    break
+                sleep(self.snooze)
+            else:
+                return False, ctx
+            return True, ctx
+
         def wait_stopped(self, vm_name, endtime=None, callback=default_cb, **kws):
             ctx = ResponseContext('vm.stop', *self.vms.stop(vm_name, **kws))
             if 404 == ctx.code and callback(ctx):

--- a/harvester_e2e_tests/integrations/test_4_vm_backup_restore.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_backup_restore.py
@@ -396,6 +396,8 @@ class TestBackupRestore:
         spec = api_client.backups.RestoreSpec.for_new(restored_vm_name)
         code, data = api_client.backups.restore(unique_vm_name, spec)
         assert 201 == code, (code, data)
+        vm_getable, (code, data) = vm_checker.wait_getable(restored_vm_name)
+        assert vm_getable, (code, data)
 
         # Check VM Started then get IPs (vm and host)
         vm_got_ips, (code, data) = vm_checker.wait_ip_addresses(restored_vm_name, ['default'])
@@ -478,6 +480,8 @@ class TestBackupRestore:
         spec = api_client.backups.RestoreSpec.for_existing(delete_volumes=True)
         code, data = api_client.backups.restore(unique_vm_name, spec)
         assert 201 == code, f'Failed to restore backup with current VM replaced, {data}'
+        vm_getable, (code, data) = vm_checker.wait_getable(unique_vm_name)
+        assert vm_getable, (code, data)
 
         # Check VM Started then get IPs (vm and host)
         vm_got_ips, (code, data) = vm_checker.wait_ip_addresses(unique_vm_name, ['default'])
@@ -596,6 +600,8 @@ class TestBackupRestore:
         spec = api_client.backups.RestoreSpec.for_existing(delete_volumes=True)
         code, data = api_client.backups.restore(unique_vm_name, spec)
         assert 201 == code, f'Failed to restore backup with current VM replaced, {data}'
+        vm_getable, (code, data) = vm_checker.wait_getable(unique_vm_name)
+        assert vm_getable, (code, data)
 
         # Check VM Started then get IPs (vm and host)
         vm_got_ips, (code, data) = vm_checker.wait_ip_addresses(unique_vm_name, ['default'])
@@ -689,6 +695,8 @@ class TestBackupRestoreOnMigration:
         spec = api_client.backups.RestoreSpec.for_existing()
         code, data = api_client.backups.restore(unique_vm_name, spec)
         assert 201 == code, f'Failed to restore backup with current VM replaced, {data}'
+        vm_getable, (code, data) = vm_checker.wait_getable(unique_vm_name)
+        assert vm_getable, (code, data)
 
         # Check VM Started
         vm_got_ips, (code, data) = vm_checker.wait_ip_addresses(unique_vm_name, ['default'])
@@ -861,6 +869,8 @@ class TestMultipleBackupRestore:
         spec = api_client.backups.RestoreSpec.for_existing(delete_volumes=True)
         code, data = api_client.backups.restore(latest_backup, spec)
         assert 201 == code, f'Failed to restore backup with current VM replaced, {data}'
+        vm_getable, (code, data) = vm_checker.wait_getable(unique_vm_name)
+        assert vm_getable, (code, data)
 
         # Check VM Started then get IPs (vm and host)
         vm_got_ips, (code, data) = vm_checker.wait_ip_addresses(unique_vm_name, ['default'])
@@ -955,6 +965,8 @@ class TestMultipleBackupRestore:
         spec = api_client.backups.RestoreSpec.for_existing(delete_volumes=True)
         code, data = api_client.backups.restore(latest_backup, spec)
         assert 201 == code, f'Failed to restore backup with current VM replaced, {data}'
+        vm_getable, (code, data) = vm_checker.wait_getable(unique_vm_name)
+        assert vm_getable, (code, data)
 
         # Check VM Started then get IPs (vm and host)
         vm_got_ips, (code, data) = vm_checker.wait_ip_addresses(unique_vm_name, ['default'])
@@ -1049,6 +1061,8 @@ class TestMultipleBackupRestore:
         spec = api_client.backups.RestoreSpec.for_existing(delete_volumes=True)
         code, data = api_client.backups.restore(latest_backup, spec)
         assert 201 == code, f'Failed to restore backup with current VM replaced, {data}'
+        vm_getable, (code, data) = vm_checker.wait_getable(unique_vm_name)
+        assert vm_getable, (code, data)
 
         # Check VM Started then get IPs (vm and host)
         vm_got_ips, (code, data) = vm_checker.wait_ip_addresses(unique_vm_name, ['default'])


### PR DESCRIPTION
### Which issue(s) this PR fixes:
* Issue #1418 

### What this PR does / why we need it:
1. ADD `vm_checker.wait_getable` between `api_client.backups.restore` and `vm_checker.wait_ip_addresses`
   * `vm_checker.wait_ip_addresses` calls `api_client.vms.start` in the callback chain and will assert FAIL if target VM does not exist.
   * `api_client.backups.restore` needs some time to communicate with `backup-target` to restore VM. So depends on the env., VM instance may not be created immediately.

### Special notes for your reviewer:
This is a quick fix.
IMO, coder tends to expect function `wait_XXX` does some polling GET, thus some error-prone. To enhance, we may:
1. Only polling GET and call POST, PUT, DELETE explicitly.
1. Refactor function name to something like `create_AAA_and_wait_XXX`.
1. ...

### Additional documentation or context
#### Verification
* Before (`harvester-runtests#61`)
  ![image](https://github.com/user-attachments/assets/b55e4d0f-db19-40f1-8d95-798eaac2e7d4)

* After (`harvester-runtests#62`)
  ![image](https://github.com/user-attachments/assets/6dd429fa-a0cb-46ba-a2d2-1e2c33793158)
