### PR TITLE
[e2e] fix bugs in terraform, volumecreate and vm update

### DIFF
--- a/apiclient/harvester_api/api.py
+++ b/apiclient/harvester_api/api.py
@@ -20,7 +20,8 @@ class HarvesterAPI:
     @classmethod
     def login(cls, endpoint, user, passwd, session=None, ssl_verify=True):
         api = cls(endpoint, session=session)
-        api.authenticate(user, passwd, verify=ssl_verify)
+        api.session.verify = ssl_verify
+        api.authenticate(user, passwd)
         api.load_managers(api.cluster_version)
         return api
 

--- a/apiclient/harvester_api/managers/virtualmachines.py
+++ b/apiclient/harvester_api/managers/virtualmachines.py
@@ -35,6 +35,7 @@ class VirtualMachineManager(BaseManager):
     def create(self, name, vm_spec, namespace=DEFAULT_NAMESPACE, *, raw=False):
         if isinstance(vm_spec, self.Spec):
             vm_spec = self.Spec.to_dict(vm_spec, name, namespace)
+            vm_spec['metadata'].pop('resourceVersion')  # remove for create new ones
         path = self.PATH_fmt.format(uid="", ns=namespace)
         return self._create(path, json=vm_spec, raw=raw)
 

--- a/apiclient/harvester_api/models/virtualmachines.py
+++ b/apiclient/harvester_api/models/virtualmachines.py
@@ -329,7 +329,6 @@ class VMSpec:
         if self._data:
             self._data['metadata'].update(data['metadata'])
             self._data['spec'].update(data['spec'])
-            self._data['metadata'].pop('resourceVersion')  # remove for create new ones
             return deepcopy(self._data)
 
         return deepcopy(data)

--- a/apiclient/harvester_api/models/volumes.py
+++ b/apiclient/harvester_api/models/volumes.py
@@ -34,7 +34,10 @@ class VolumeSpec:
 
         if image_id is not None:
             annotations.update({"harvesterhci.io/imageId": image_id})
-            self.storage_cls = f"longhorn-{image_id.split('/')[1]}"
+            try:
+                self.storage_cls = f"longhorn-{image_id.split('/')[1]}"
+            except IndexError:
+                self.storage_cls = f"longhorn-{image_id}"
         if self.description is not None:
             annotations.update({"field.cattle.io/description": self.description})
         if self.storage_cls is not None:

--- a/apiclient/rancher_api/api.py
+++ b/apiclient/rancher_api/api.py
@@ -20,8 +20,8 @@ class RancherAPI:
     @classmethod
     def login(cls, endpoint, user, passwd, session=None, ssl_verify=True):
         api = cls(endpoint, session=session)
-        api.authenticate(user, passwd, verify=ssl_verify)
         api.session.verify = ssl_verify
+        api.authenticate(user, passwd)
 
         return api
 

--- a/harvester_e2e_tests/fixtures/terraform.py
+++ b/harvester_e2e_tests/fixtures/terraform.py
@@ -168,22 +168,24 @@ def tf_script_dir(request):
 
 
 @pytest.fixture(scope="session")
-def tf_provider_version(request):
+def tf_provider_version(request, harvester_metadata):
     version = request.config.getoption('--terraform-provider-harvester')
-    if not version:
-        import requests
-        resp = requests.get("https://registry.terraform.io/v1/providers/harvester/harvester")
-        version = max(resp.json()['versions'], key=parse_version)
-    return version
+    import requests
+    resp = requests.get("https://registry.terraform.io/v1/providers/harvester/harvester")
+    latest = max(resp.json()['versions'], key=parse_version)
+    version = None if version == '0.0.0-dev' else version
+    harvester_metadata['Terraform Harvester Provider Version'] = f"{version} || {latest}"
+    return version or latest
 
 
 @pytest.fixture(scope="session")
-def tf_provider_rancher_ver(request):
+def tf_provider_rancher_ver(request, harvester_metadata):
     version = request.config.getoption('--terraform-provider-rancher')
     if not version:
         import requests
         resp = requests.get("https://registry.terraform.io/v1/providers/rancher/rancher2")
         version = max(resp.json()['versions'], key=parse_version)
+    harvester_metadata['Terraform Rancher Provider Version'] = version
     return version
 
 

--- a/harvester_e2e_tests/integrations/test_1_volumes.py
+++ b/harvester_e2e_tests/integrations/test_1_volumes.py
@@ -102,9 +102,6 @@ def test_create_volume(api_client, unique_name, ubuntu_image, create_as, source_
         assert image_id == annotations['harvesterhci.io/imageId'], (code, data)
     else:
         assert not annotations.get('harvesterhci.io/imageId'), (code, data)
-    # attachment
-    assert not annotations.get("harvesterhci.io/owned-by"), (code, data)
-
     # teardown
     polling_for("volume do deleted", lambda code, _: 404 == code,
                 api_client.volumes.delete, unique_name)
@@ -172,8 +169,6 @@ class TestVolumeWithVM:
         assert data['status']['phase'] == "Bound", (code, data)
         # source
         assert ubuntu_image["id"] == annotations['harvesterhci.io/imageId'], (code, data)
-        # attachment
-        assert ubuntu_vm['id'] in annotations.get("harvesterhci.io/owned-by"), data
 
     def test_delete_volume_on_deleted_vm(self, api_client, ubuntu_image, ubuntu_vm, polling_for):
         """


### PR DESCRIPTION
## Changes
- **UPDATE** `api.py` to propagate SSL verification correctly
- **UPDATE**  VM manager and model to fix bug when updating VMs
- **UPDATE** volume model to parse storage class correctly
- **UPDATE** fixture `tf_provider_version` to let `0.0.0-dev` work as the latest version, ref to https://github.com/harvester/tests/pull/1374
- **REMOVE** volume check `owner-by` annotation, ref to https://github.com/harvester/harvester/issues/5383

Snapshots of error messages as below, based on daily#343

![image](https://github.com/user-attachments/assets/272a5718-a9d4-4519-9544-95f9066b686f)
![image](https://github.com/user-attachments/assets/e991aa1f-06ab-4863-b68b-6a679840693a)
![image](https://github.com/user-attachments/assets/384d4904-c449-4d34-8d89-befd0dfad256)
![image](https://github.com/user-attachments/assets/06bf25a8-53b2-4d18-9325-50635c397d0b)
