### PR TITLE
[e2e] add new test cases about volume clone and snapshot

### DIFF
--- a/apiclient/harvester_api/api.py
+++ b/apiclient/harvester_api/api.py
@@ -65,7 +65,7 @@ class HarvesterAPI:
         self.ippools = mgrs.IPPoolManager.for_version(version)(self, version)
         self.loadbalancers = mgrs.LoadBalancerManager.for_version(version)(self, version)
         self.volumes = mgrs.VolumeManager.for_version(version)(self, version)
-        self.volsnapshots = mgrs.VolumeSnapshotManager.for_version(version)(self, version)
+        self.vol_snapshots = mgrs.VolumeSnapshotManager.for_version(version)(self, version)
         self.templates = mgrs.TemplateManager.for_version(version)(self, version)
         self.supportbundle = mgrs.SupportBundleManager.for_version(version)(self, version)
         self.settings = mgrs.SettingManager.for_version(version)(self, version)

--- a/apiclient/harvester_api/managers/volumes.py
+++ b/apiclient/harvester_api/managers/volumes.py
@@ -41,3 +41,9 @@ class VolumeManager(BaseManager):
         path = self.PATH_fmt.format(uid=f"/{name}", ns=namespace)
         params = dict(action="export")
         return self._create(path, params=params, json=export_spec, raw=raw)
+
+    def clone(self, name, cloned_name, namespace=DEFAULT_NAMESPACE, *, raw=False):
+        path = self.PATH_fmt.format(uid=f"/{name}", ns=namespace)
+        params = dict(action="clone")
+        spec = dict(name=cloned_name)
+        return self._create(path, params=params, json=spec, raw=raw)

--- a/apiclient/harvester_api/managers/volumesnapshots.py
+++ b/apiclient/harvester_api/managers/volumesnapshots.py
@@ -2,12 +2,13 @@ from .base import DEFAULT_NAMESPACE, BaseManager
 
 
 class VolumeSnapshotManager(BaseManager):
-    PATH_fmt = "v1/harvester/snapshot.storage.k8s.io.volumesnapshots/{ns}/{uid}"
+    _qs = "?filter=metadata.ownerReferences.kind=PersistentVolumeClaim"
+    PATH_fmt = "v1/harvester/snapshot.storage.k8s.io.volumesnapshots/{ns}/{uid}{qs}"
 
     def delete(self, name, namespace=DEFAULT_NAMESPACE, *, raw=False):
         path = self.PATH_fmt.format(uid=name, ns=namespace)
         return self._delete(path, raw=raw)
 
     def get(self, name="", namespace=DEFAULT_NAMESPACE, *, raw=False):
-        path = self.PATH_fmt.format(uid=name, ns=namespace)
+        path = self.PATH_fmt.format(uid=name, ns=namespace, qs=self._qs)
         return self._get(path, raw=raw)

--- a/apiclient/harvester_api/managers/volumesnapshots.py
+++ b/apiclient/harvester_api/managers/volumesnapshots.py
@@ -2,13 +2,19 @@ from .base import DEFAULT_NAMESPACE, BaseManager
 
 
 class VolumeSnapshotManager(BaseManager):
-    _qs = "?filter=metadata.ownerReferences.kind=PersistentVolumeClaim"
-    PATH_fmt = "v1/harvester/snapshot.storage.k8s.io.volumesnapshots/{ns}/{uid}{qs}"
+    PATH_fmt = "v1/harvester/snapshot.storage.k8s.io.volumesnapshots/{ns}/{uid}"
 
     def delete(self, name, namespace=DEFAULT_NAMESPACE, *, raw=False):
         path = self.PATH_fmt.format(uid=name, ns=namespace)
         return self._delete(path, raw=raw)
 
     def get(self, name="", namespace=DEFAULT_NAMESPACE, *, raw=False):
-        path = self.PATH_fmt.format(uid=name, ns=namespace, qs=self._qs)
-        return self._get(path, raw=raw)
+        path = self.PATH_fmt.format(uid=name, ns=namespace)
+        rv = self._get(path, raw=raw)
+        if not (name or raw):
+            _, ds = rv
+            ds['data'] = [
+                d for d in ds['data']
+                if d['metadata']['ownerReferences'][0]['kind'] == "PersistentVolumeClaim"
+            ]
+        return rv

--- a/harvester_e2e_tests/integrations/test_4_vm_snapshot.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_snapshot.py
@@ -316,6 +316,14 @@ class TestVMSnapshot:
         assert data.get("status", {}).get("readyToUse") is True
 
     @pytest.mark.dependency(depends=["source_vm_snapshot"])
+    def test_volume_snapshot_not_exist(self, api_client):
+        ''' ref: https://github.com/harvester/tests/issues/524 '''
+        code, data = api_client.vol_snapshots.get()
+
+        assert 200 == code, (code, data)
+        assert not data['data'], (code, data)
+
+    @pytest.mark.dependency(depends=["source_vm_snapshot"])
     def test_restore_into_new_vm_from_vm_snapshot(self, api_client,
                                                   restored_from_snapshot_vm,
                                                   ssh_keypair, host_shell,
@@ -548,7 +556,7 @@ class TestVMSnapshot:
         # And assert that it has a volume snapshot associated with it.
         volumesnapshotname = f"vm-snapshot-volume-{volumename}"
 
-        code, data = api_client.volsnapshots.get(volumesnapshotname)
+        code, data = api_client.vol_snapshots.get(volumesnapshotname)
         assert 200 == code
 
         ownerpvc = data.get("spec", {}).get("source", {}).get("persistentVolumeClaimName")
@@ -567,9 +575,9 @@ class TestVMSnapshot:
 
         # Finally, wait for the volume snapshot to be cleaned up
         # automatically.
-        code, _ = api_client.volsnapshots.get(volumesnapshotname)
+        code, _ = api_client.vol_snapshots.get(volumesnapshotname)
         while deadline > datetime.now():
-            code, _ = api_client.volsnapshots.get(volumesnapshotname)
+            code, _ = api_client.vol_snapshots.get(volumesnapshotname)
             if code == 404:
                 break
             sleep(1)


### PR DESCRIPTION
## Changes
- **ADD** volume clone method in apiclient
- **UPDATE** volume snapshot manager to filter out unrelated results, and renaming `volsnapshots` -> `vol_snapshots` to align as `vm_snapshots`
- **ADD** test case to check availability of volume snapshot, ref to https://github.com/harvester/tests/issues/524
- **ADD** test cases to test functionality of volume clone, ref to https://github.com/harvester/tests/issues/525