### PR TITLE
Update VM IP after restore replace

### DIFF
--- a/harvester_e2e_tests/fixtures/virtualmachines.py
+++ b/harvester_e2e_tests/fixtures/virtualmachines.py
@@ -209,6 +209,18 @@ def vm_checker(api_client, wait_timeout, sleep_timeout, vm_shell):
                 )
             return self.wait_stopped(vm_name, endtime, cb, **kws)
 
+        def wait_status_running(self, vm_name, endtime=None, callback=default_cb, **kws):
+            endtime = endtime or self._endtime()
+            while endtime > datetime.now():
+                ctx = ResponseContext('vm.get', *self.vms.get(vm_name, **kws))
+                status = ctx.data.get('status', {}).get('printableStatus')
+                if 200 == ctx.code and "Running" == status and callback(ctx):
+                    break
+                sleep(self.snooze)
+            else:
+                return False, ctx
+            return True, ctx
+
         def wait_deleted(self, vm_name, endtime=None, callback=default_cb, **kws):
             ctx = ResponseContext('vm.delete', *self.vms.delete(vm_name, **kws))
             if 404 == ctx.code and callback(ctx):

--- a/harvester_e2e_tests/integrations/test_4_vm_backup_restore.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_backup_restore.py
@@ -480,8 +480,18 @@ class TestBackupRestore:
         spec = api_client.backups.RestoreSpec.for_existing(delete_volumes=True)
         code, data = api_client.backups.restore(unique_vm_name, spec)
         assert 201 == code, f'Failed to restore backup with current VM replaced, {data}'
-        vm_getable, (code, data) = vm_checker.wait_getable(unique_vm_name)
-        assert vm_getable, (code, data)
+
+        endtime = datetime.now() + timedelta(seconds=wait_timeout)
+        while endtime > datetime.now():
+            code, data = api_client.vms.get(unique_vm_name)
+            if 200 == code and "Running" == data.get('status', {}).get('printableStatus'):
+                break
+            sleep(3)
+        else:
+            raise AssertionError(
+                f"Failed to restore VM({unique_vm_name}) with errors:\n"
+                f"Status({code}): {data}"
+            )
 
         # Check VM Started then get IPs (vm and host)
         vm_got_ips, (code, data) = vm_checker.wait_ip_addresses(unique_vm_name, ['default'])
@@ -495,6 +505,7 @@ class TestBackupRestore:
         code, data = api_client.hosts.get(data['status']['nodeName'])
         host_ip = next(addr['address'] for addr in data['status']['addresses']
                        if addr['type'] == 'InternalIP')
+        base_vm_with_data['host_ip'], base_vm_with_data['vm_ip'] = host_ip, vm_ip
 
         # Login to the new VM and check data is existing
         with vm_shell_from_host(host_ip, vm_ip, base_vm_with_data['ssh_user'], pkey=pri_key) as sh:

--- a/harvester_e2e_tests/integrations/test_4_vm_backup_restore.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_backup_restore.py
@@ -481,17 +481,11 @@ class TestBackupRestore:
         code, data = api_client.backups.restore(unique_vm_name, spec)
         assert 201 == code, f'Failed to restore backup with current VM replaced, {data}'
 
-        endtime = datetime.now() + timedelta(seconds=wait_timeout)
-        while endtime > datetime.now():
-            code, data = api_client.vms.get(unique_vm_name)
-            if 200 == code and "Running" == data.get('status', {}).get('printableStatus'):
-                break
-            sleep(3)
-        else:
-            raise AssertionError(
-                f"Failed to restore VM({unique_vm_name}) with errors:\n"
-                f"Status({code}): {data}"
-            )
+        vm_running, (code, data) = vm_checker.wait_status_running(unique_vm_name)
+        assert vm_running, (
+            f"Failed to restore VM({unique_vm_name}) with errors:\n"
+            f"Status({code}): {data}"
+        )
 
         # Check VM Started then get IPs (vm and host)
         vm_got_ips, (code, data) = vm_checker.wait_ip_addresses(unique_vm_name, ['default'])


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue #1462

#### What this PR does / why we need it:
1. Fix `test_restore_replace_with_vm_shutdown_command` due to VM IP is not update after restore place.
2. After restore replace, wait VM Running to avoid unexpectedly start a Restoring/Stopped VM.

#### Special notes for your reviewer:
n/a

#### Additional documentation or context
* Before (`harvester-runtests/86`)
  ![image](https://github.com/user-attachments/assets/6ca3929a-5bfb-4cb4-adf4-3bf5df9d399f)

* After (`harvester-runtests/89`)
  ![image](https://github.com/user-attachments/assets/689a12b3-b35b-459c-a43b-0bd1500c893c)
