### PR TITLE
added in tests for bad checksums on ubuntu images, and added in some …

### DIFF
--- a/apiclient/harvester_api/managers/images.py
+++ b/apiclient/harvester_api/managers/images.py
@@ -11,7 +11,8 @@ class ImageManager(BaseManager):
     DOWNLOAD_fmt = "v1/harvester/harvesterhci.io.virtualmachineimages/{ns}/{uid}/download"
     _KIND = "VirtualMachineImage"
 
-    def create_data(self, name, url, desc, stype, namespace, display_name=None, storageclass=None):
+    def create_data(self, name, url, desc, stype, namespace, image_checksum=None,
+                    display_name=None, storageclass=None):
         data = {
             "apiVersion": "{API_VERSION}",
             "kind": self._KIND,
@@ -26,6 +27,7 @@ class ImageManager(BaseManager):
             "spec": {
                 "displayName": display_name or name,
                 "sourceType": stype,
+                "checksum": image_checksum,
                 "url": url
             }
         }
@@ -38,10 +40,10 @@ class ImageManager(BaseManager):
         return self._create(self.PATH_fmt.format(uid=name, ns=namespace), **kwargs)
 
     def create_by_url(
-        self, name, url, namespace=DEFAULT_NAMESPACE,
+        self, name, url, imageChecksum=None, namespace=DEFAULT_NAMESPACE,
         description="", display_name=None, storageclass=None
     ):
-        data = self.create_data(name, url, description, "download", namespace,
+        data = self.create_data(name, url, description, "download", namespace, imageChecksum,
                                 display_name, storageclass)
         return self.create("", namespace, json=data)
 

--- a/apiclient/harvester_api/managers/images.pyi
+++ b/apiclient/harvester_api/managers/images.pyi
@@ -18,6 +18,7 @@ class ImageManager(BaseManager):
         desc: str,
         stype: str,
         namespace: str,
+        imageChecksum=str,
         display_name: str = ...
     ) -> dict:
         """
@@ -43,6 +44,7 @@ class ImageManager(BaseManager):
         self,
         name: str,
         url: str,
+        imageChecksum: str,
         namespace: str = ...,
         description: str = ...,
         display_name: str = ...

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,5 @@
 # Harvester Cluster
-endpoint: 'https://localhost:30443'
+endpoint: 'https://localhost'
 username: 'admin'
 password: 'password1234'
 # Be used to access Harvester node, fill in one of following is enough.
@@ -23,7 +23,13 @@ sleep-timeout: 3
 node-scripts-location: 'scripts/vagrant'
 
 opensuse-image-url: https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.5/images/openSUSE-Leap-15.5.x86_64-NoCloud.qcow2
+# sha512sum for opensuse image-url
+opensuse-checksum: ''
+
 ubuntu-image-url: https://cloud-images.ubuntu.com/releases/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img
+# sha512sum for ubuntu image-url
+ubuntu-checksum: ''
+
 # URL to download all images
 image-cache-url: ''
 

--- a/harvester_e2e_tests/conftest.py
+++ b/harvester_e2e_tests/conftest.py
@@ -274,6 +274,18 @@ def pytest_addoption(parser):
         default=config_data.get('terraform-provider-rancher'),
         help=('Version of Terraform Rancher Provider')
     )
+    parser.addoption(
+        '--ubuntu-checksum',
+        action='store',
+        default=config_data.get('ubuntu-checksum'),
+        help=('Checksum for ubuntu_image')
+    )
+    parser.addoption(
+        '--opensuse-checksum',
+        action='store',
+        default=config_data.get('opensuse-checksum'),
+        help=('Checksum for opensuse_image')
+    )
 
 
 def pytest_configure(config):

--- a/harvester_e2e_tests/fixtures/api_client.py
+++ b/harvester_e2e_tests/fixtures/api_client.py
@@ -71,6 +71,18 @@ def rancher_wait_timeout(request):
 
 
 @pytest.fixture(scope="session")
+def ubuntu_checksum(request):
+    """Returns Ubuntu checksum from config"""
+    return request.config.getoption("--ubuntu-checksum")
+
+
+@pytest.fixture(scope="session")
+def opensuse_checksum(request):
+    """Returns openSUSE checksum from config"""
+    return request.config.getoption("--opensuse-checksum")
+
+
+@pytest.fixture(scope="session")
 def host_state(request):
     class HostState:
         files = ("power_off.sh", "power_on.sh", "reboot.sh")  # [False, True, -1]

--- a/harvester_e2e_tests/fixtures/images.py
+++ b/harvester_e2e_tests/fixtures/images.py
@@ -14,6 +14,7 @@ DEFAULT_UBUNTU_IMAGE_URL = (
 @pytest.fixture(scope="session")
 def image_opensuse(request, api_client):
     image_server = request.config.getoption("--image-cache-url")
+    image_checksum = request.config.getoption("--opensuse-checksum", default=None)
     url = urlparse(
         request.config.getoption("--opensuse-image-url")
     )
@@ -22,12 +23,13 @@ def image_opensuse(request, api_client):
         *_, image_name = url.path.rsplit("/", 1)
         url = urlparse(urljoin(f"{image_server}/", image_name))
 
-    return ImageInfo(url, name="opensuse", ssh_user="opensuse")
+    return ImageInfo(url, image_checksum, name="opensuse", ssh_user="opensuse")
 
 
 @pytest.fixture(scope="session")
 def image_ubuntu(request):
     image_server = request.config.getoption("--image-cache-url")
+    image_checksum = request.config.getoption("--ubuntu-checksum", default=None)
     url = urlparse(
         request.config.getoption("--ubuntu-image-url") or DEFAULT_UBUNTU_IMAGE_URL
     )
@@ -36,7 +38,7 @@ def image_ubuntu(request):
         *_, image_name = url.path.rsplit("/", 1)
         url = urlparse(urljoin(f"{image_server}/", image_name))
 
-    return ImageInfo(url, name="ubuntu", ssh_user="ubuntu")
+    return ImageInfo(url, image_checksum, name="ubuntu", ssh_user="ubuntu")
 
 
 @pytest.fixture(scope="session")
@@ -49,13 +51,14 @@ def image_k3s(request):
 
 
 class ImageInfo:
-    def __init__(self, url_result, name="", ssh_user=None):
+    def __init__(self, url_result, image_checksum=None, name="", ssh_user=None):
         self.url_result = url_result
         if name:
             self.name = name
         else:
             self.name = self.url.rsplit("/", 1)[-1]
         self.ssh_user = ssh_user
+        self.image_checksum = image_checksum
 
     def __repr__(self):
         return f"{__class__.__name__}({self.url_result})"

--- a/harvester_e2e_tests/integrations/test_1_images.py
+++ b/harvester_e2e_tests/integrations/test_1_images.py
@@ -37,8 +37,8 @@ def fake_invalid_image_file():
         yield Path(f.name)
 
 
-def create_image_url(api_client, name, image_url, wait_timeout):
-    code, data = api_client.images.create_by_url(name, image_url)
+def create_image_url(api_client, name, image_url, image_checksum, wait_timeout):
+    code, data = api_client.images.create_by_url(name, image_url, image_checksum)
 
     assert 201 == code, (code, data)
     image_spec = data.get("spec")
@@ -112,6 +112,7 @@ def get_image(api_client, image_name):
 
 @pytest.fixture(scope="class")
 def cluster_network(api_client, vlan_nic):
+    # We should change this at some point. It fails if the total cnet name is over 12 chars
     cnet = f"cnet-{vlan_nic}"
     code, data = api_client.clusternetworks.get(cnet)
     if code != 200:
@@ -266,7 +267,8 @@ class TestBackendImages:
         """
         image_name = f"{image_info.name}-{unique_name}"
         image_url = image_info.url
-        create_image_url(api_client, image_name, image_url, wait_timeout)
+        create_image_url(api_client, image_name, image_url,
+                         image_info.image_checksum, wait_timeout)
 
     @pytest.mark.skip_version_if("> v1.2.0", "<= v1.4.0", reason="Issue#4293 fix after `v1.4.0`")
     @pytest.mark.p0

--- a/harvester_e2e_tests/integrations/test_3_vm_functions.py
+++ b/harvester_e2e_tests/integrations/test_3_vm_functions.py
@@ -1698,7 +1698,7 @@ def test_update_vm_machine_type(
     else:
         raise AssertionError(
             f"Failed to create VM({cpu} core, {mem} RAM) with errors:\n"
-            f"Phase: {data.get('status', {}).get('phase','')}\t"
+            f"Phase: {data.get('status', {}).get('phase', '')}\t"
             f"Status: {data.get('status', {})}\n"
             f"API Status({code}): {data}"
         )


### PR DESCRIPTION
…pydoc docs in the images and volumes sections

added in opensuse checksum and added associated config data

fixed pep8 errors

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #1121 

#### What this PR does / why we need it:
This adds image checksum testing to the automation
#### Special notes for your reviewer:
I added in some docs on other tests in the images and volumes scenarios. Also this will allow command line adding of the checksum for the images. This will also work if you just remove the text in the checksum and leave it blank, and the negative test case will still run correctly as well.

#### Additional documentation or context
I checked that the other tests weren't being affected and I don't think any of them should be.