### PR TITLE
Implement cluster size check and loggin addon test case on test_upgrade.py

### DIFF
--- a/harvester_e2e_tests/integrations/test_upgrade.py
+++ b/harvester_e2e_tests/integrations/test_upgrade.py
@@ -501,7 +501,9 @@ class TestInvalidUpgrade:
         """
         # https://github.com/harvester/harvester/issues/6425
         if cluster_state.size < 3:
-            pytest.skip(f"Degraded only checked when nodes >= 3, skip for {cluster_state.size}.")
+            pytest.skip(
+                f"Degraded volumes only checked on 3+ nodes cluster, skip on {cluster_state.size}."
+            )
 
         vm_name, ssh_user, pri_key = stopped_vm
         vm_started, (code, vmi) = vm_checker.wait_started(vm_name)

--- a/harvester_e2e_tests/integrations/test_upgrade.py
+++ b/harvester_e2e_tests/integrations/test_upgrade.py
@@ -499,6 +499,7 @@ class TestInvalidUpgrade:
         3. Immediately upgrade Harvester.
         4. Upgrade should fail.
         """
+        # https://github.com/harvester/harvester/issues/6425
         if cluster_state.size < 3:
             pytest.skip(f"Degraded only checked when nodes >= 3, skip for {cluster_state.size}.")
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes & What it does:
1. harvester/harvester/issues/6425
   * Skip `test_upgrade.py::TestInvalidUpgrade::test_degraded_volume` when cluster size < 3.
   * If not skip, 1 and 2 nodes cluster will just start upgrade in this negtive case Class.
2. #901
   * Implement `test_preq_setup_logging` TODO
   * Post-upgrade check `rancher-logging` addon status in `test_verify_logging_pods` 

#### Special notes for your reviewer:
n/a

#### Additional documentation or context
Verification
![image](https://github.com/user-attachments/assets/0e048c0f-a265-4a0d-909a-1c9e15a06b82)
