### PR TITLE
Fix incorrect if-condition in test_create_with_invalid_url

### DIFF
--- a/harvester_e2e_tests/apis/test_images.py
+++ b/harvester_e2e_tests/apis/test_images.py
@@ -236,7 +236,7 @@ def test_create_with_invalid_url(api_client, gen_unique_name, wait_timeout):
     while endtime > datetime.now():
         code, data = api_client.images.get(unique_name)
         image_conds = data.get('status', {}).get('conditions', [])
-        if len(image_conds) > 0:
+        if "Initialized" == image_conds[-1].get("type"):
             break
         sleep(3)
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

#### What this PR does / why we need it:
before https://github.com/harvester/harvester/commit/13bb968e86cefb43227a18544b4ed1a40a1090b8, if a vm image failed to recognize the image url, we didn't have any condition in status until retry 3 times, while after the commit, we will have RetryLimitExceeded condition in `status` upon retry failure in the first round retry. Now the test didn't wait until the right condition and do assertion thus cause test failed.

This pr mainly move the assertion part into the while loop, make sure the assertion is correct until timeout.

#### Special notes for your reviewer:
N/A

#### Additional documentation or context
N/A