### PR TITLE
Remove legacy image in test_delete_image_recreate

### DIFF
--- a/harvester_e2e_tests/integrations/test_1_images.py
+++ b/harvester_e2e_tests/integrations/test_1_images.py
@@ -318,6 +318,9 @@ class TestBackendImages:
         get_image(api_client, unique_name)
         delete_image(api_client, unique_name, wait_timeout)
 
+        get_image(api_client, image_name)
+        delete_image(api_client, image_name, wait_timeout)
+
     @pytest.mark.p0
     def test_create_invalid_file(
         self, api_client, gen_unique_name, fake_invalid_image_file, wait_timeout


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
n/a

#### What this PR does / why we need it:
During testing for https://github.com/harvester/harvester/issues/4293, I noticed that some images were not being cleaned up after the test finished. Automating the image cleanup would greatly reduce effort, especially when running the same method multiple times. Looping the test 20–30 times can fill up the node's disk quickly as images consume significant space.

#### Special notes for your reviewer:

I didn't run all e2e test but only `test_delete_image_recreate`, if this approach breaks anything or is not appropriate, feel free to close this pr, thanks.

#### Additional documentation or context

n/a
