### PR TITLE
fix: 1568 Fixing S3 Connection Building

### DIFF
--- a/harvester_e2e_tests/integrations/test_4_vm_backup_restore.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_backup_restore.py
@@ -121,6 +121,8 @@ def config_backup_target(api_client, conflict_retries, backup_config, wait_timeo
         f'Failed to update backup target to {backup_type} with {config}\n'
         f"API Status({code}): {data}"
     )
+    # sleeping to allow longhorn secret to be built on Harvester side
+    sleep(5)
 
     yield spec
 


### PR DESCRIPTION
* fixes s3 connection building, allowing us to wait for a short period of time to allow the secret for longhorn-system to be built on Harvester side

Resovles: fix/1568
See also: https://github.com/harvester/tests/issues/1568

#### Which issue(s) this PR fixes:
Fixes #1568 

#### What this PR does / why we need it:
Adds a bit of time before yielding back the backup config -> as Harvester takes a bit more time usually for it to have the secret built in longhorn-system in v1.4.0-rc1

#### Additional documentation or context

In the video, it is demo'd with an external bare-metal hp dl160 2 node v1.4.0-rc1 cluster that we can indeed replicate the issue outlined in 1568.  We see we are moving to fast trying to build the fixture and the secret hasn't yet built on Harvester side in time.  But if we give it a bit of a sleep, to allow Harvester to catch up to build the secret before yielding back the spec, everything is good.  The video illustrates the points back to back.

https://github.com/user-attachments/assets/0acb4385-0fdb-49d6-a090-3117dfcbc2e5

