### PR TITLE
[Cypress] Fix failed test on v1.4.0 for the dashboard string changes

### DIFF
--- a/cypress/constants/constants.ts
+++ b/cypress/constants/constants.ts
@@ -1,5 +1,5 @@
 export class Constants {
-    public timeout = { timeout: 10000, maxTimeout: 60000, uploadTimeout: 600000, downloadTimeout: 240000, provisionTimeout: 1500000};
+    public timeout = { timeout: 10000, maxTimeout: 60000, uploadTimeout: 600000, downloadTimeout: 240000, provisionTimeout: 1500000 };
     public username = Cypress.env("username");
     public password = Cypress.env("password");
     public mockPassword = Cypress.env("mockPassword");
@@ -32,36 +32,36 @@ export class Constants {
 }
 
 export const PageUrl = {
-    setting:          '/harvester/c/local/harvesterhci.io.setting',
-    virtualMachine:   '/harvester/c/local/kubevirt.io.virtualmachine',
-    vmNetwork:        '/harvester/c/local/harvesterhci.io.networkattachmentdefinition',
-    namespace:        '/harvester/c/local/namespace',
-    volumeSnapshot:   '/harvester/c/local/harvesterhci.io.volumesnapshot'
+    setting: '/harvester/c/local/harvesterhci.io.setting',
+    virtualMachine: '/harvester/c/local/kubevirt.io.virtualmachine',
+    vmNetwork: '/harvester/c/local/harvesterhci.io.networkattachmentdefinition',
+    namespace: '/harvester/c/local/namespace',
+    volumeSnapshot: '/harvester/c/local/harvesterhci.io.volumesnapshot'
 }
 
 export const MenuNav = {
-    dashboard:      ['Dashboard', 'harvester/c/local/harvesterhci.io.dashboard', 'Harvester Cluster: local'],
-    Host:           ['Hosts', 'harvester/c/local/harvesterhci.io.host', 'Hosts'],
+    dashboard: ['Dashboard', 'harvester/c/local/harvesterhci.io.dashboard', 'Harvester Cluster: local'],
+    Host: ['Hosts', 'harvester/c/local/harvesterhci.io.host', 'Hosts'],
     virtaulmachine: ['Virtual Machines', 'harvester/c/local/kubevirt.io.virtualmachine', 'Virtual Machines'],
-    volume:         ['Volumes', 'harvester/c/local/harvesterhci.io.volume', 'Volumes'],
-    Images:         ['Images', 'harvester/c/local/harvesterhci.io.virtualmachineimage', 'Images'],
-    namespace:      ['Namespaces', 'harvester/c/local/namespace', 'Namespaces'],
-    clusterNetwork: ['Cluster Networks/Configs', 'harvester/c/local/network.harvesterhci.io.clusternetwork', 'Cluster Networks/Configs', ['Networks']],
-    vmNetwork:      ['VM Networks', 'harvester/c/local/harvesterhci.io.networkattachmentdefinition', 'VM Networks', ['Networks']],
-    vmBackup:       ['VM Backups', 'harvester/c/local/harvesterhci.io.virtualmachinebackup', 'VM Backups', ['Backup & Snapshot']],
-    vmSnapshot:     ['VM Snapshots', 'harvester/c/local/harvesterhci.io.vmsnapshot', 'VM Snapshots', ['Backup & Snapshot']],
-    volumeSnapshot: ['Volume Snapshots', 'harvester/c/local/harvesterhci.io.volumesnapshot', 'Volume Snapshots', ['Backup & Snapshot']],
-    alertmanagerConfig:      ['Alertmanager Configs', 'harvester/c/local/harvesterhci.io.monitoring.alertmanagerconfig', 'Alertmanager Configs', ['Monitoring & Logging', 'Monitoring']],
-    clusterFlow:             ['Cluster Flow', 'harvester/c/local/harvesterhci.io.logging.clusterflow', 'Cluster Flows', ['Monitoring & Logging', 'Logging']],
-    clusterOutput:           ['Cluster Output', 'harvester/c/local/harvesterhci.io.logging.clusteroutput', 'Cluster Outputs', ['Monitoring & Logging', 'Logging']],
-    flow:                    ['Flow', 'harvester/c/local/harvesterhci.io.logging.flow', 'Flows', ['Monitoring & Logging', 'Logging']],
-    Output:                  ['Output', 'harvester/c/local/harvesterhci.io.logging.output', 'Outputs', ['Monitoring & Logging', 'Logging']],
-    Template:                ['Templates', 'harvester/c/local/harvesterhci.io.virtualmachinetemplateversion', 'Templates', ['Advanced']],
-    sshKey:                  ['SSH Keys', 'harvester/c/local/harvesterhci.io.keypair', 'SSH Keys', ['Advanced']],
-    cloudConfigTemplate:     ['Cloud Config Templates', 'harvester/c/local/harvesterhci.io.cloudtemplate', 'Cloud Config Templates', ['Advanced']],
-    storageClass:            ['Storage Classes', 'harvester/c/local/harvesterhci.io.storage', 'Storage Classes', ['Advanced']],
-    pciDevice:               ['PCI Devices', 'harvester/c/local/devices.harvesterhci.io.pcidevice', 'PCI Devices', ['Advanced']],
-    addon:                   ['Addons', 'harvester/c/local/harvesterhci.io.addon', 'Addons', ['Advanced']],
-    secrets:                 ['Secrets', 'harvester/c/local/harvesterhci.io.secret', 'Secrets', ['Advanced']],
-    setting:                 ['Settings', 'harvester/c/local/harvesterhci.io.setting', 'Settings', ['Advanced']]
+    volume: ['Volumes', 'harvester/c/local/harvesterhci.io.volume', 'Volumes'],
+    Images: ['Images', 'harvester/c/local/harvesterhci.io.virtualmachineimage', 'Images'],
+    namespace: ['Namespaces', 'harvester/c/local/namespace', 'Namespaces'],
+    clusterNetwork: ['Cluster Network Configuration', 'harvester/c/local/network.harvesterhci.io.clusternetwork', 'Cluster Network Configuration', ['Networks']],
+    vmNetwork: ['Virtual Machine Networks', 'harvester/c/local/harvesterhci.io.networkattachmentdefinition', 'Virtual Machine Networks', ['Networks']],
+    vmBackup: ['Virtual Machine Backups', 'harvester/c/local/harvesterhci.io.virtualmachinebackup', 'Virtual Machine Backups', ['Backup and Snapshots']],
+    vmSnapshot: ['Virtual Machine Snapshots', 'harvester/c/local/harvesterhci.io.vmsnapshot', 'Virtual Machine Snapshots', ['Backup and Snapshots']],
+    volumeSnapshot: ['Volume Snapshots', 'harvester/c/local/harvesterhci.io.volumesnapshot', 'Volume Snapshots', ['Backup and Snapshots']],
+    alertmanagerConfig: ['Alertmanager Configurations', 'harvester/c/local/harvesterhci.io.monitoring.alertmanagerconfig', 'Alertmanager Configurations', ['Monitoring and Logging', 'Monitoring']],
+    clusterFlow: ['Cluster Flows', 'harvester/c/local/harvesterhci.io.logging.clusterflow', 'Cluster Flows', ['Monitoring and Logging', 'Logging']],
+    clusterOutput: ['Cluster Outputs', 'harvester/c/local/harvesterhci.io.logging.clusteroutput', 'Cluster Outputs', ['Monitoring and Logging', 'Logging']],
+    flow: ['Flows', 'harvester/c/local/harvesterhci.io.logging.flow', 'Flows', ['Monitoring and Logging', 'Logging']],
+    Output: ['Outputs', 'harvester/c/local/harvesterhci.io.logging.output', 'Outputs', ['Monitoring and Logging', 'Logging']],
+    Template: ['Templates', 'harvester/c/local/harvesterhci.io.virtualmachinetemplateversion', 'Templates', ['Advanced']],
+    sshKey: ['SSH Keys', 'harvester/c/local/harvesterhci.io.keypair', 'SSH Keys', ['Advanced']],
+    cloudConfigTemplate: ['Cloud Configuration Templates', 'harvester/c/local/harvesterhci.io.cloudtemplate', 'Cloud Configuration Templates', ['Advanced']],
+    storageClass: ['Storage Classes', 'harvester/c/local/harvesterhci.io.storage', 'Storage Classes', ['Advanced']],
+    pciDevice: ['PCI Devices', 'harvester/c/local/devices.harvesterhci.io.pcidevice', 'PCI Devices', ['Advanced']],
+    addon: ['Add-ons', 'harvester/c/local/harvesterhci.io.addon', 'Add-ons', ['Advanced']],
+    secrets: ['Secrets', 'harvester/c/local/harvesterhci.io.secret', 'Secrets', ['Advanced']],
+    setting: ['Settings', 'harvester/c/local/harvesterhci.io.setting', 'Settings', ['Advanced']]
 }

--- a/cypress/pageobjects/network.po.ts
+++ b/cypress/pageobjects/network.po.ts
@@ -41,7 +41,7 @@ export default class NetworkPage extends CruResourcePo {
   }
 
   vlan() {
-    return new LabeledInputPo('.labeled-input', `:contains("Vlan ID")`)
+    return new LabeledInputPo('.labeled-input', `:contains("VLAN ID")`)
   }
 
   clusterNetwork() {

--- a/cypress/pageobjects/support.po.ts
+++ b/cypress/pageobjects/support.po.ts
@@ -6,7 +6,7 @@ import Dashboard from "@/pageobjects/dashboard.po";
 const constants = new Constants();
 
 export class SupportPage {
-    private supportBundleButton = 'Generate Support Bundle';
+    private supportBundleButton = 'Generate a Support Bundle';
     private supportBundleInput = 'textarea'
     private generateButton = '[type="submit"]';
 
@@ -31,23 +31,23 @@ export class SupportPage {
     }
 
     public get generateSupportBundleBtn(): CypressChainable {
-        return cy.get("main button").contains("Generate Support Bundle")
+        return cy.get("main button").contains("Generate a Support Bundle")
     }
 
     public visit() {
         cy.url().then(url => {
-            if(!url.includes(constants.dashboardUrl)) {
+            if (!url.includes(constants.dashboardUrl)) {
                 cy.login();
             }
             Dashboard.nav.SupportLink.click()
-            cy.get("main h1").should("contain","Harvester Support")
+            cy.get("main h1").should("contain", "Harvester Support")
             cy.url().should("contain", constants.supportPage)
         })
     }
 
-    public inputSupportBundle(description?:string, issueURL?:string): CypressChainable {
+    public inputSupportBundle(description?: string, issueURL?: string): CypressChainable {
         return cy.get("main .bundleModal").as("generateView").then($el => {
-            if(description) cy.wrap($el).get("textarea").type(description)
+            if (description) cy.wrap($el).get("textarea").type(description)
             if (issueURL) cy.wrap($el).get("input").type(issueURL)
 
             cy.wrap($el).get(".footer button").contains("Close").as("closeBtn")
@@ -61,13 +61,13 @@ export class SupportPage {
         });
         // this.validateSupportPage();
     }
-    
+
     public generateSupportBundle(description: string) {
         // cy.task('deleteDownloadsFolder');
         this.visitSupportPage();
         cy.get('.btn').contains(this.supportBundleButton).click();
         cy.get(this.supportBundleInput).each(($elem, index) => {
-            if(index == 1) {
+            if (index == 1) {
                 cy.wrap($elem).type(description)
             }
         });
@@ -85,7 +85,7 @@ export class SupportPage {
         this.visitSupportPage();
 
     }
-    
+
     private validateSupportPage() {
         cy.url().should('contain', constants.supportPage);
     }

--- a/cypress/pageobjects/virtualmachine.po.ts
+++ b/cypress/pageobjects/virtualmachine.po.ts
@@ -44,15 +44,15 @@ export class VmsPage extends CruResourcePo {
     });
   }
 
-  setBasics(cpu?: string, memery?: string, ssh?: {id?: string, createNew?: boolean, value?: string}) {
+  setBasics(cpu?: string, memory?: string, ssh?: { id?: string, createNew?: boolean, value?: string }) {
     this.clickTab('basics');
     this.cpu().input(cpu);
-    this.memory().input(memery);
+    this.memory().input(memory);
 
     if (ssh && ssh.id) {
-      new LabeledSelectPo('.labeled-select', `:contains("SSHKey")`).select({option: ssh.id});
+      new LabeledSelectPo('.labeled-select', `:contains("SSHKey")`).select({ option: ssh.id });
     } else if (ssh && ssh.createNew) {
-      new LabeledSelectPo('.labeled-select', `:contains("SSHKey")`).select({option: 'Create a New...'});
+      new LabeledSelectPo('.labeled-select', `:contains("SSHKey")`).select({ option: 'Create a New...' });
       new LabeledTextAreaPo('.v--modal-box .card-container .labeled-input', `:contains("SSH-Key")`).input(ssh.value, {
         delay: 0,
       });
@@ -74,35 +74,35 @@ export class VmsPage extends CruResourcePo {
         let imageEl: any;
         let volumeEl: any;
         cy.get('.info-box').eq(index).within(() => {
-            if (volume.image) {
-              imageEl = new LabeledSelectPo('.labeled-select', `:contains("Image")`);
-            }
+          if (volume.image) {
+            imageEl = new LabeledSelectPo('.labeled-select', `:contains("Image")`);
+          }
 
-            if (volume.size) {
-              new LabeledInputPo('.labeled-input', `:contains("Size")`).input(volume.size);
-            }
+          if (volume.size) {
+            new LabeledInputPo('.labeled-input', `:contains("Size")`).input(volume.size);
+          }
 
-            if (volume.volume) {
-              volumeEl = new LabeledSelectPo('.labeled-select', `:contains("Volume")`);
-            }
+          if (volume.volume) {
+            volumeEl = new LabeledSelectPo('.labeled-select', `:contains("Volume")`);
+          }
         }).then(() => {
           if (imageEl) {
-            imageEl.select({option: volume.image});
+            imageEl.select({ option: volume.image });
           }
 
           if (volumeEl) {
-            volumeEl.select({option: volume.volume});
+            volumeEl.select({ option: volume.volume });
           }
         })
       })
     })
   }
 
-  selectSchedulingType({ type = 'any' }: { type:string }) {
-    const map:any = {
-      any: 'Run VM on any available node',
-      specific: 'Run VM on specific node - (Live migration is not supported)',
-      rules: 'Run VM on node(s) matching scheduling rules'
+  selectSchedulingType({ type = 'any' }: { type: string }) {
+    const map: any = {
+      any: 'Run virtual machine on any available node',
+      specific: 'Run virtual machine on specific node - (Live migration is not supported))',
+      rules: 'Run virtual machine on node(s) matching scheduling rules'
     }
 
     this.clickTab('nodeScheduling');
@@ -113,18 +113,18 @@ export class VmsPage extends CruResourcePo {
       scheduling.input(map[type]);
     })
   }
-  
-  checkSpecificNodes({includeNodes = [], excludeNodes = []}: { includeNodes: Array<string>, excludeNodes?: Array<string> }) {
+
+  checkSpecificNodes({ includeNodes = [], excludeNodes = [] }: { includeNodes: Array<string>, excludeNodes?: Array<string> }) {
     this.specificNode().self().click();
     includeNodes.forEach((node) => cy.get('.vs__dropdown-menu').should('contain', node));
     excludeNodes.forEach((node) => cy.get('.vs__dropdown-menu').should('not.contain', node));
   }
 
-  setAdvancedOption(option: {[index: string]: any}) {
+  setAdvancedOption(option: { [index: string]: any }) {
     this.clickTab('advanced');
 
     if (option.runStrategy) {
-      new LabeledSelectPo('.labeled-select', `:contains("Run Strategy")`).select({option: option.runStrategy});
+      new LabeledSelectPo('.labeled-select', `:contains("Run Strategy")`).select({ option: option.runStrategy });
     }
 
     if ([true, false].includes(option.efiEnabled)) {
@@ -140,7 +140,7 @@ export class VmsPage extends CruResourcePo {
     }
   }
 
-  checkVMState(name:  string, state: string = 'Running', namespace: string = 'default') {
+  checkVMState(name: string, state: string = 'Running', namespace: string = 'default') {
     this.goToList();
     this.censorInColumn(name, 3, namespace, 4, state, 2, { timeout: constants.timeout.uploadTimeout, nameSelector: '.name-console a' });
   }
@@ -152,8 +152,8 @@ export class VmsPage extends CruResourcePo {
   }
 
   clickVMSnapshotAction(name: string, snapshotName: string) {
-    this.clickAction(name, 'Take VM Snapshot');
-    cy.get('.v--modal-box .card-title').find('h4').contains('Take VM Snapshot');
+    this.clickAction(name, 'Take Virtual Machine Snapshot');
+    cy.get('.v--modal-box .card-title').find('h4').contains('Take Virtual Machine Snapshot');
 
     new LabeledInputPo('.v--modal-box .labeled-input', `:contains("Name *")`).input(snapshotName)
     cy.get('.v--modal-box button').contains('Create').click();
@@ -171,13 +171,13 @@ export class VmsPage extends CruResourcePo {
   }
 
   public setValue(value: ValueInterface) {
-    this.namespace().select({option: value?.namespace})
+    this.namespace().select({ option: value?.namespace })
     this.name().input(value?.name)
     this.description().input(value?.description)
     this.cpu().input(value?.cpu)
     this.memory().input(value?.memory)
     cy.get('.tab#Volume').click()
-    this.image().select({option: value?.image})
+    this.image().select({ option: value?.image })
     this.networks(value?.networks)
     cy.get('.tab#advanced').click()
     this.usbTablet().check(value?.usbTablet)
@@ -269,24 +269,24 @@ export class VmsPage extends CruResourcePo {
   }
 
   specificNode() {
-    return new LabeledSelectPo('.labeled-select', `:contains("Node Name")`); 
+    return new LabeledSelectPo('.labeled-select', `:contains("Node Name")`);
   }
 
   networks(networks: Array<Network> = []) {
-    if (networks.length === 0){
+    if (networks.length === 0) {
       return
     } else {
       cy.get('.tab#Network').click()
 
       cy.get('.info-box.infoBox').then(elms => {
         if (elms?.length < networks?.length) {
-          for(let i=0; i<networks?.length - elms?.length; i++) {
+          for (let i = 0; i < networks?.length - elms?.length; i++) {
             cy.contains('Add Network').click()
           }
         }
 
         networks.map((n, idx) => {
-          this.network().select({option: n?.network, index: idx})
+          this.network().select({ option: n?.network, index: idx })
         })
       })
     }
@@ -323,7 +323,7 @@ export class VmsPage extends CruResourcePo {
 
       const name = Cypress._.toLower(imageEnv.name)
       const url = imageEnv.url
-      const imageFound = images.find((i:any) => i?.spec?.displayName === name)
+      const imageFound = images.find((i: any) => i?.spec?.displayName === name)
 
       if (imageFound) {
         return
@@ -332,14 +332,14 @@ export class VmsPage extends CruResourcePo {
 
         image.goToCreate();
         image.setNameNsDescription(name, namespace);
-        image.setBasics({url});
+        image.setBasics({ url });
         image.save();
-        image.checkState({name, namespace});
+        image.checkState({ name, namespace });
       }
     })
   }
 
-  public checkState({name = '', namespace = 'default', state = 'Running'}: {name?:string, namespace?:string, state?:string}) {
+  public checkState({ name = '', namespace = 'default', state = 'Running' }: { name?: string, namespace?: string, state?: string }) {
     this.censorInColumn(name, 3, namespace, 4, state, 2, { timeout: constants.timeout.maxTimeout, nameSelector: '.name-console a' });
   }
 
@@ -364,7 +364,7 @@ export class VmsPage extends CruResourcePo {
     cy.get('.cru-resource-footer').contains('Save').click()
   }
 
-  public delete(namespace:string, name: string, displayName?: string, { removeRootDisk, id }: { removeRootDisk?: boolean, id?: string } = { removeRootDisk: true }) {
+  public delete(namespace: string, name: string, displayName?: string, { removeRootDisk, id }: { removeRootDisk?: boolean, id?: string } = { removeRootDisk: true }) {
     cy.visit(`/harvester/c/local/${this.type}`)
 
     this.clickAction(name, 'Delete').then((_) => {
@@ -392,7 +392,7 @@ export class VmsPage extends CruResourcePo {
         cy.get('.v--modal-box,.v--modal .card-container').within(() => {
           this.plugVolumeCustomName().input(V);
         })
-        this.plugVolumeName().select({option: V});
+        this.plugVolumeName().select({ option: V });
       })
 
       cy.intercept('POST', `/v1/harvester/${this.realType}s/${namespace}/${vmName}*`).as('plug');
@@ -438,14 +438,14 @@ export class VmsPage extends CruResourcePo {
     return new YamlEditorPo(selector)
   }
 
-  public selectTemplateAndVersion({name, namespace, id, version}: {
+  public selectTemplateAndVersion({ name, namespace, id, version }: {
     name?: string,
     namespace?: string,
     id?: string,
     version?: string,
   }) {
-    cy.contains('Use VM Template').click()
-    this.template().select({option: id || `${namespace}/${name}`})
+    cy.contains('Use the virtual machine template').click()
+    this.template().select({ option: id || `${namespace}/${name}` })
     this.version().select({
       option: version,
       selector: '.vs__dropdown-menu',
@@ -456,7 +456,7 @@ export class VmsPage extends CruResourcePo {
     this.multipleInstance().input('Multiple Instance')
   }
 
-  setMultipleInstance({namePrefix, count}: {
+  setMultipleInstance({ namePrefix, count }: {
     namePrefix?: string,
     count?: string,
   }) {
@@ -474,16 +474,16 @@ export class VmsPage extends CruResourcePo {
   }) {
     this.clickTab('nodeScheduling');
 
-    const rulesRadio = new RadioButtonPo('.radio-group', ':contains("Run VM on node(s) matching scheduling rules")')
-    const specificRadio = new RadioButtonPo('.radio-group', ':contains("Run VM on specific node")')
+    const rulesRadio = new RadioButtonPo('.radio-group', ':contains("Run virtual machine on node(s) matching scheduling rules")')
+    const specificRadio = new RadioButtonPo('.radio-group', ':contains("Run virtual machine on specific node - (Live migration is not supported)")')
     const nodeNameSelector = new LabeledSelectPo('.labeled-select', `:contains("Node Name")`)
 
     switch (radio) {
       case 'rules':
-        rulesRadio.input('Run VM on node(s) matching scheduling rules')
+        rulesRadio.input('Run virtual machine on node(s) matching scheduling rules')
         break;
       case 'specific':
-        specificRadio.input('Run VM on specific node')
+        specificRadio.input('Run virtual machine on specific node - (Live migration is not supported)')
 
         nodeNameSelector.select({
           selector: '.vs__dropdown-menu',

--- a/cypress/pageobjects/volume.po.ts
+++ b/cypress/pageobjects/volume.po.ts
@@ -41,7 +41,7 @@ export class VolumePage extends CruResourcePo {
     return new LabeledSelectPo(".labeled-select", `:contains("Image"):last`);
   }
 
-  checkState(name:  string, state: string = 'Ready', namespace: string = 'default') {
+  checkState(name: string, state: string = 'Ready', namespace: string = 'default') {
     this.goToList();
     this.censorInColumn(name, 3, namespace, 4, state, 2);
   }
@@ -60,15 +60,15 @@ export class VolumePage extends CruResourcePo {
     cy.get('.growl-container .growl-list').find('.growl-text div').contains('Succeed');
   }
 
-  setBasics({source, image, size} : { source?: string, image?: string, size: string }) {
+  setBasics({ source, image, size }: { source?: string, image?: string, size: string }) {
     this.clickTab('basic');
 
     if (source) {
-      this.source().select({option: source});
+      this.source().select({ option: source });
     }
 
     if (image) {
-      this.image().select({option: image});
+      this.image().select({ option: image });
     }
 
     this.size().input(size);
@@ -104,13 +104,13 @@ export class VolumePage extends CruResourcePo {
   }
 
   public setValue(value: ValueInterface) {
-    this.namespace().select({option: value?.namespace})
+    this.namespace().select({ option: value?.namespace })
     this.size().input(value?.size);
     this.name().input(value?.name);
 
     if (!!value.image) {
-      this.source().select({option: "VM Image"});
-      this.image().select({option: value?.image});
+      this.source().select({ option: "Virtual Machine Image" });
+      this.image().select({ option: value?.image });
     }
   }
 

--- a/cypress/testcases/image/images.spec.ts
+++ b/cypress/testcases/image/images.spec.ts
@@ -9,41 +9,41 @@ const vms = new VmsPage();
 const image = new ImagePage();
 
 describe('Auto setup image from cypress environment', () => {
-  it('Auto setup image from cypress environment', () => {
-    const imageEnv = Cypress.env('image');
-    const IMAGE_NAME = Cypress._.toLower(imageEnv.name);
-    const IMAGE_URL = imageEnv.url;
-    
-    const value = {
-        name: IMAGE_NAME,
-        url: IMAGE_URL,
-    }
+    it('Auto setup image from cypress environment', () => {
+        const imageEnv = Cypress.env('image');
+        const IMAGE_NAME = Cypress._.toLower(imageEnv.name);
+        const IMAGE_URL = imageEnv.url;
 
-    cy.login();
+        const value = {
+            name: IMAGE_NAME,
+            url: IMAGE_URL,
+        }
 
-    cy.request({
-      url: `v1/harvester/${HCI.IMAGE}s`,
-      headers: {
-        accept: 'application/json'
-      }
-    }).then(res => {
-      expect(res?.status, 'Check Image list').to.equal(200);
-      const images = res?.body?.data || []
-      const imageFound = images.find((i:any) => i?.spec?.displayName === IMAGE_NAME)
+        cy.login();
 
-      if (imageFound) {
-        return
-      } else {
-        const namespace = 'default';
+        cy.request({
+            url: `v1/harvester/${HCI.IMAGE}s`,
+            headers: {
+                accept: 'application/json'
+            }
+        }).then(res => {
+            expect(res?.status, 'Check Image list').to.equal(200);
+            const images = res?.body?.data || []
+            const imageFound = images.find((i: any) => i?.spec?.displayName === IMAGE_NAME)
 
-        image.goToCreate();
-        image.setNameNsDescription(IMAGE_NAME, namespace);
-        image.setBasics({url: IMAGE_URL});
-        image.save();
-        image.checkState({name: IMAGE_NAME});
-      }
+            if (imageFound) {
+                return
+            } else {
+                const namespace = 'default';
+
+                image.goToCreate();
+                image.setNameNsDescription(IMAGE_NAME, namespace);
+                image.setBasics({ url: IMAGE_URL });
+                image.save();
+                image.checkState({ name: IMAGE_NAME });
+            }
+        })
     })
-  })
 })
 
 /**
@@ -72,17 +72,17 @@ describe('Create an image with valid image URL', () => {
 
         image.goToCreate();
         image.setNameNsDescription(IMAGE_NAME, namespace);
-        image.setBasics({url: IMAGE_URL});
+        image.setBasics({ url: IMAGE_URL });
         image.setLabels({
             labels: {
                 foo: 'foo',
                 bar: 'bar'
             }
         });
-        
+
         cy.wrap(image.save()).then((realName) => {
             // check IMAGE state
-            image.checkState({name: IMAGE_NAME});
+            image.checkState({ name: IMAGE_NAME });
 
             // edit IMAGE
             image.goToEdit(IMAGE_NAME);
@@ -102,10 +102,10 @@ describe('Create an image with valid image URL', () => {
         // create IMAGE with the same name
         image.goToCreate();
         image.setNameNsDescription(IMAGE_NAME, namespace);
-        image.setBasics({url: IMAGE_URL});
+        image.setBasics({ url: IMAGE_URL });
         cy.wrap(image.save()).then((realName) => {
             // check IMAGE state
-            image.checkState({name: IMAGE_NAME});
+            image.checkState({ name: IMAGE_NAME });
 
             // delete IMAGE
             image.delete(namespace, realName as string, IMAGE_NAME);
@@ -118,7 +118,7 @@ describe('Create an image with valid image URL', () => {
  * Expected Results
  * 1. Image state show as Failed
  */
- describe('Create image with invalid URL', () => {
+describe('Create image with invalid URL', () => {
     const IMAGE_NAME = generateName('auto-image-invalid-url-test');
 
     it('Create image with invalid URL', () => {
@@ -129,7 +129,7 @@ describe('Create an image with valid image URL', () => {
 
         image.goToCreate();
         image.setNameNsDescription(IMAGE_NAME, namespace);
-        image.setBasics({url: 'https://test.img'});
+        image.setBasics({ url: 'https://test.img' });
 
         cy.wrap(image.save()).then((realName) => {
             image.censorInColumn(IMAGE_NAME, 3, namespace, 4, 'Failed', 2, { timeout: constants.timeout.uploadTimeout });
@@ -170,11 +170,11 @@ describe('Delete VM with exported image', () => {
         vms.setBasics('1', '1');
         vms.setVolumes(volumes);
         vms.save();
-        
+
         // export IMAGE
         image.exportImage(VM_NAME, IMAGE_NAME, namespace);
         image.goToList();
-        image.checkState({name: IMAGE_NAME, size: '10 GB'});
+        image.checkState({ name: IMAGE_NAME, size: '10 GB' });
 
         // delete VM
         vms.delete(namespace, VM_NAME);
@@ -218,14 +218,14 @@ describe('Update image labels after deleting source VM', () => {
         vms.setBasics('1', '1');
         vms.setVolumes(volumes);
         vms.save();
-        vms.checkState({name: VM_NAME, namespace});
+        vms.checkState({ name: VM_NAME, namespace });
 
         // export IMAGE
         image.exportImage(VM_NAME, IMAGE_NAME, namespace);
 
         // check IMAGE state
         image.goToList();
-        image.checkState({name: IMAGE_NAME, size: '10 GB'});
+        image.checkState({ name: IMAGE_NAME, size: '10 GB' });
 
         // delete VM
         vms.delete(namespace, VM_NAME);
@@ -321,10 +321,10 @@ describe('Create a ISO image via upload', () => {
 
         image.goToCreate();
         image.setNameNsDescription(IMAGE_NAME, namespace);
-        image.setBasics({path: 'cypress/fixtures/cirros-0.5.2-aarch64-disk.img'});
+        image.setBasics({ path: 'cypress/fixtures/cirros-0.5.2-aarch64-disk.img' });
 
-        cy.wrap(image.save({upload: true})).then((realName) => {
-            image.checkState({name: IMAGE_NAME});
+        cy.wrap(image.save({ upload: true })).then((realName) => {
+            image.checkState({ name: IMAGE_NAME });
 
             // create VM
             const volumes = [{
@@ -338,7 +338,7 @@ describe('Create a ISO image via upload', () => {
             vms.setBasics('1', '1');
             vms.setVolumes(volumes);
             vms.save();
-            vms.checkState({name: VM_NAME});
+            vms.checkState({ name: VM_NAME });
 
             // delete VM
             vms.delete(namespace, VM_NAME);
@@ -353,12 +353,12 @@ describe('Create a ISO image via upload', () => {
 /**
  * https://harvester.github.io/tests/manual/_incoming/2562-clone-image/
  */
- describe('Clone image', () => {
+describe('Clone image', () => {
     const IMAGE_NAME = generateName('auto-image-test');
     const CLONED_NAME = generateName('cloned-image');
     const imageEnv = Cypress.env('image');
     const IMAGE_URL = imageEnv.url;
-    let IMAGE_REAL_NAME:string, CLONED_IMAGE_REAL_NAME:string;
+    let IMAGE_REAL_NAME: string, CLONED_IMAGE_REAL_NAME: string;
 
     it('Clone image', () => {
         cy.login();
@@ -372,13 +372,13 @@ describe('Create a ISO image via upload', () => {
         image.setLabels({
             labels: { cloned: 'cloned' }
         });
-        image.setBasics({url: IMAGE_URL});
+        image.setBasics({ url: IMAGE_URL });
 
         cy.wrap(image.save()).then((realName) => {
             IMAGE_REAL_NAME = realName as string;
         })
 
-        image.checkState({name: IMAGE_NAME});
+        image.checkState({ name: IMAGE_NAME });
         image.clickAction(IMAGE_NAME, 'Clone');
         image.setNameNsDescription(CLONED_NAME, namespace);
 
@@ -386,7 +386,7 @@ describe('Create a ISO image via upload', () => {
             CLONED_IMAGE_REAL_NAME = realName as string;
         })
 
-        image.checkState({name: CLONED_NAME});
+        image.checkState({ name: CLONED_NAME });
         image.goToEdit(CLONED_NAME);
         image.clickTab('labels');
         cy.get('.tab-container .kv-item.key input').eq(0).should('have.value', 'cloned');
@@ -401,7 +401,7 @@ describe('Create a ISO image via upload', () => {
 /**
  * https://harvester.github.io/tests/manual/_incoming/2474-image-filtering-by-labels/
  */
- describe('Image filtering by labels', () => {
+describe('Image filtering by labels', () => {
     const imageEnv = Cypress.env('image');
     // has only one label
     const IMAGE_NAME_1 = generateName('auto-image-suse');
@@ -411,7 +411,7 @@ describe('Create a ISO image via upload', () => {
     const IMAGE_NAME_3 = generateName('auto-image-both');
     const IMAGE_URL = imageEnv.url;
     const namespace = 'default';
-    let IMAGE_REAL_NAME_1:string, IMAGE_REAL_NAME_2:string, IMAGE_REAL_NAME_3:string;
+    let IMAGE_REAL_NAME_1: string, IMAGE_REAL_NAME_2: string, IMAGE_REAL_NAME_3: string;
 
     it('Upload several images and add related label, add filter according to test plan 1', () => {
         cy.login();
@@ -422,11 +422,11 @@ describe('Create a ISO image via upload', () => {
         image.setLabels({
             labels: { suse_group: '1', harvester_e2e_test: 'harvester' }
         });
-        image.setBasics({url: IMAGE_URL});
+        image.setBasics({ url: IMAGE_URL });
         cy.wrap(image.save()).then((realName) => {
             IMAGE_REAL_NAME_1 = realName as string
         })
-        image.checkState({name: IMAGE_NAME_1});
+        image.checkState({ name: IMAGE_NAME_1 });
 
         // create the second one
         image.goToCreate();
@@ -434,22 +434,22 @@ describe('Create a ISO image via upload', () => {
         image.setLabels({
             labels: { ubuntu_group: '1', harvester_e2e_test: 'harvester' }
         });
-        image.setBasics({url: IMAGE_URL});
+        image.setBasics({ url: IMAGE_URL });
         cy.wrap(image.save()).then((realName) => {
             IMAGE_REAL_NAME_2 = realName as string
         })
-        image.checkState({name: IMAGE_NAME_2});
+        image.checkState({ name: IMAGE_NAME_2 });
 
         image.goToCreate();
         image.setNameNsDescription(IMAGE_NAME_3, namespace);
         image.setLabels({
             labels: { suse_group: '1', ubuntu_group: '1', harvester_e2e_test: 'harvester' }
         });
-        image.setBasics({url: IMAGE_URL});
+        image.setBasics({ url: IMAGE_URL });
         cy.wrap(image.save()).then((realName) => {
             IMAGE_REAL_NAME_3 = realName as string
         })
-        image.checkState({name: IMAGE_NAME_3});
+        image.checkState({ name: IMAGE_NAME_3 });
 
         // Can search specific image by name in the Harvester VM creation page
         vms.goToCreate();
@@ -466,14 +466,14 @@ describe('Create a ISO image via upload', () => {
         })
         cy.get('tbody').should('contain', IMAGE_NAME_1);
         cy.get('tbody').should('contain', IMAGE_NAME_3);
-        
+
         // Can filter using One key with value
         image.filterByLabels({
             suse_group: '1',
         })
         cy.get('tbody').should('contain', IMAGE_NAME_1);
         cy.get('tbody').should('contain', IMAGE_NAME_3);
-        
+
         // Can filter using Two keys without value
         image.filterByLabels({
             suse_group: null,
@@ -481,7 +481,7 @@ describe('Create a ISO image via upload', () => {
         })
         cy.get('tbody').should('contain', IMAGE_NAME_2);
         cy.get('tbody').should('contain', IMAGE_NAME_3);
-        
+
         // Can filter using using Two keys and one key without value
         image.filterByLabels({
             suse_group: '1',
@@ -489,7 +489,7 @@ describe('Create a ISO image via upload', () => {
         })
         cy.get('tbody').should('contain', IMAGE_NAME_2);
         cy.get('tbody').should('contain', IMAGE_NAME_3);
-        
+
         // Can filter using Two keys both have values
         image.filterByLabels({
             suse_group: '1',
@@ -513,11 +513,11 @@ describe('Create a ISO image via upload', () => {
 /**
  * https://harvester.github.io/tests/manual/_incoming/2563-image-naming-inline-css/
  */
- describe('Image naming with inline CSS', () => {
+describe('Image naming with inline CSS', () => {
     const imageEnv = Cypress.env('image');
     const IMAGE_NAME = '<strong><em>something_interesting</em></strong>';
     const IMAGE_URL = imageEnv.url;
-    let name:string;
+    let name: string;
 
     it('Create an image with valid image URL', () => {
         cy.login();
@@ -527,17 +527,17 @@ describe('Create a ISO image via upload', () => {
 
         image.goToCreate();
         image.setNameNsDescription(IMAGE_NAME, namespace);
-        image.setBasics({url: IMAGE_URL});
-        
+        image.setBasics({ url: IMAGE_URL });
+
         cy.wrap(image.save()).then((realName) => {
             name = realName as string;
         })
 
         // check IMAGE state
-        image.checkState({name: IMAGE_NAME});
+        image.checkState({ name: IMAGE_NAME });
 
         // edit IMAGE
-        image.goToDetail({name: IMAGE_NAME, ns: namespace});
+        image.goToDetail({ name: IMAGE_NAME, ns: namespace });
         cy.get('.primaryheader').should('contain', IMAGE_NAME)
 
         // delete IMAGE

--- a/cypress/testcases/networks/network.spec.ts
+++ b/cypress/testcases/networks/network.spec.ts
@@ -19,7 +19,7 @@ interface Vlan {
  * Expected Results
  * 1. create/delete network success
 */
-export function CheckCreateNetwork() {}
+export function CheckCreateNetwork() { }
 describe('Check create/delete network', () => {
   it('Check create/delete network', () => {
     cy.login();
@@ -45,7 +45,7 @@ describe('Check create/delete network', () => {
  * Expected Results
  * 1. Create network with DHCP server IP success
 */
-export function CheckDHCP() {}
+export function CheckDHCP() { }
 describe('Check network with DHCP', () => {
   it('Check network with DHCP', () => {
     cy.login();
@@ -61,7 +61,7 @@ describe('Check network with DHCP', () => {
       namespace,
       vlan: '234',
       clusterNetwork: 'mgmt',
-      mode: 'Auto(DHCP)',
+      mode: 'Auto (DHCP)',
       dhcp,
     })
 
@@ -88,7 +88,7 @@ describe('Check network with DHCP', () => {
  * Expected Results
  * 1. Create network with manual mode success
 */
-export function CheckManualMode() {}
+export function CheckManualMode() { }
 describe('Check network with Manual Mode', () => {
   it('Check network with Manual Mode', () => {
     cy.login();
@@ -125,7 +125,7 @@ describe('Check network with Manual Mode', () => {
 });
 
 
-export function CreateVlan1() {}
+export function CreateVlan1() { }
 describe('Preset Vlans', () => {
   function createVlan(vlan: Vlan) {
     cy.intercept('POST', `/v1/harvester/k8s.cni.cncf.io.network-attachment-definitions`).as('create');
@@ -157,7 +157,7 @@ describe('Preset Vlans', () => {
     const vlan = vlans[0].vlan
 
     cy.login();
-    
+
     createVlan({
       name: `vlan${vlan}`,
       namespace: 'default',
@@ -171,7 +171,7 @@ describe('Preset Vlans', () => {
     const vlan = vlans[1].vlan
 
     cy.login();
-    
+
     createVlan({
       name: `vlan${vlan}`,
       namespace: 'default',

--- a/cypress/testcases/settings/settings.spec.ts
+++ b/cypress/testcases/settings/settings.spec.ts
@@ -5,8 +5,8 @@ const settings = new SettingsPagePo();
 
 describe('Setting Page', () => {
     beforeEach(() => {
-       cy.login({url: PageUrl.setting});
-       settings.checkIsCurrentPage();
+        cy.login({ url: PageUrl.setting });
+        settings.checkIsCurrentPage();
     })
 
     /**
@@ -18,11 +18,11 @@ describe('Setting Page', () => {
      */
     it('change UI source type to Bundled, Check whether the configuration takes effect', () => {
         const address = `${Cypress.env('baseUrl')}/dashboard/js/**`;
-        settings.clickMenu('ui-source', 'Edit Setting', 'ui-source', undefined,'UI')
+        settings.clickMenu('ui-source', 'Edit Setting', 'ui-source', undefined, 'UI')
         settings.checkUiSource('Bundled', address);
     });
 
-    
+
     it('change UI source type to external, Check whether the configuration takes effect', () => {
         const address = 'https://releases.rancher.com/harvester-ui/dashboard/**';
         settings.clickMenu('ui-source', 'Edit Setting', 'ui-source', undefined, 'UI')
@@ -58,7 +58,7 @@ describe('Setting Page', () => {
  */
 describe('Set backup target S3', () => {
     beforeEach(() => {
-        cy.login({url: PageUrl.setting});
+        cy.login({ url: PageUrl.setting });
         settings.checkIsCurrentPage(false);
     })
 
@@ -67,8 +67,8 @@ describe('Set backup target S3', () => {
 
         const backupTarget = Cypress.env('backupTarget');
         settings.setS3BackupTarget({
-            type: 'S3', 
-            endpoint: backupTarget.endpoint, 
+            type: 'S3',
+            endpoint: backupTarget.endpoint,
             bucketName: backupTarget.bucketName,
             bucketRegion: backupTarget.bucketRegion,
             accessKeyId: backupTarget.accessKey,

--- a/cypress/testcases/storageclasses/storageclasses.spec.ts
+++ b/cypress/testcases/storageclasses/storageclasses.spec.ts
@@ -42,7 +42,7 @@ describe('Create a storage class with all the required values', () => {
       migratable: 'No',
       reclaimPolicy: 'Retain the volume for manual cleanup',
       allowVolumeExpansion: 'Disabled',
-      volumeBindingMode: 'Bind and provision a persistent volume once a VM using the PersistentVolumeClaim is created',
+      volumeBindingMode: 'Bind and provision a persistent volume once a virtual machine using the PersistentVolumeClaim is created',
     }
 
     storageClasses.create(value);
@@ -54,7 +54,7 @@ describe('Create a storage class with all the required values', () => {
       migratable: 'false',
       reclaimPolicy: 'Retain',
       allowVolumeExpansion: false,
-      volumeBindingMode: 'WaitForFirstConsumer', 
+      volumeBindingMode: 'WaitForFirstConsumer',
     });
 
     storageClasses.delete({ name: NAME })

--- a/cypress/testcases/virtualmachines/virtual-machine.spec.ts
+++ b/cypress/testcases/virtualmachines/virtual-machine.spec.ts
@@ -14,7 +14,7 @@ const imagePO = new ImagePage();
 
 describe('VM Form Validation', () => {
   beforeEach(() => {
-    cy.login({url: PageUrl.virtualMachine});
+    cy.login({ url: PageUrl.virtualMachine });
   });
 
   /**
@@ -50,11 +50,11 @@ describe('VM Form Validation', () => {
   /**
    * https://harvester.github.io/tests/manual/virtual-machines/1283-vm-creation-required-fields/
    */
-   it('Check VM creation without required-fields', () => {
+  it('Check VM creation without required-fields', () => {
     vms.goToCreatePage();
     vms.clickFooterBtn();
     cy.get('#cru-errors').contains('"Name" is required').should('exist');
-    cy.get('#cru-errors').contains('"Cpu" is required').should('exist');
+    cy.get('#cru-errors').contains('"CPU" is required').should('exist');
     cy.get('#cru-errors').contains('"Memory" is required').should('exist');
     cy.get('#cru-errors').contains('"Image" is required').should('exist');
   })
@@ -68,21 +68,21 @@ describe('VM Form Validation', () => {
   it('Create VM without memory provided', () => {
     const VM_NAME = 'test-memory-required';
     const namespace = 'default'
-  
+
     const imageEnv = Cypress.env('image');
-  
+
     const value = {
       name: VM_NAME,
       cpu: '2',
       image: Cypress._.toLower(imageEnv.name),
       namespace,
     }
-  
+
     vms.goToCreate();
     vms.setValue(value);
-  
+
     vms.clickFooterBtn();
-  
+
     cy.contains('"Memory" is required').should('exist')
   });
 });
@@ -95,7 +95,7 @@ describe('VM Form Validation', () => {
  * 1. vm assignment to different nodes
  * @notImplemented
  */
-export function CheckMultiVMScheduler() {}
+export function CheckMultiVMScheduler() { }
 describe("automatic assignment to different nodes when creating multiple vm's", () => {
   it("automatic assignment to different nodes when creating multiple vm's", () => {
 
@@ -104,7 +104,7 @@ describe("automatic assignment to different nodes when creating multiple vm's", 
 
 describe('VM clone Validation', () => {
   beforeEach(() => {
-    cy.login({url: PageUrl.virtualMachine});
+    cy.login({ url: PageUrl.virtualMachine });
   });
 
   /**
@@ -129,7 +129,7 @@ describe('VM clone Validation', () => {
     vms.goToCreate();
 
     const imageEnv = Cypress.env('image');
-    
+
     const volume = [{
       buttonText: 'Add Volume',
       create: false,
@@ -161,7 +161,7 @@ describe('VM clone Validation', () => {
 
 describe('VM runStategy Validation (Halted)', () => {
   beforeEach(() => {
-    cy.login({url: PageUrl.virtualMachine});
+    cy.login({ url: PageUrl.virtualMachine });
   });
 
   const namespace = 'default'
@@ -170,7 +170,7 @@ describe('VM runStategy Validation (Halted)', () => {
     vms.goToCreate();
 
     const imageEnv = Cypress.env('image');
-    
+
     const VM_NAME = 'vm-halted';
     const volume = [{
       buttonText: 'Add Volume',
@@ -202,16 +202,16 @@ describe('VM runStategy Validation (Halted)', () => {
  * Expected Results
  * 1. Image “img-1” will be deleted
  */
-export function DeleteVMWithImage() {}
+export function DeleteVMWithImage() { }
 describe("Delete VM with exported image", () => {
   it("Delete VM with exported image", () => {
     const VM_NAME = generateName('vm-1');
     const namespace = 'default'
-  
+
     cy.login();
-  
+
     const imageEnv = Cypress.env('image');
-  
+
     const value = {
       name: VM_NAME,
       cpu: '1',
@@ -219,10 +219,10 @@ describe("Delete VM with exported image", () => {
       image: Cypress._.toLower(imageEnv.name),
       namespace,
     }
-  
+
     vms.goToCreate();
     vms.setValue(value);
-  
+
     cy.intercept('POST', '/v1/harvester/kubevirt.io.virtualmachines/*').as('createVM');
     cy.get('.cru-resource-footer').contains('Create').click()
     cy.wait('@createVM').then(res => {
@@ -231,22 +231,22 @@ describe("Delete VM with exported image", () => {
       const volumeClaimTemplates = body?.metadata?.annotations?.['harvesterhci.io/volumeClaimTemplates']
       const volumes = JSON.parse(volumeClaimTemplates || '{}')
 
-      const imageName = generateName('img-1'); 
-      
+      const imageName = generateName('img-1');
+
       volumePO.goToList()
       volumePO.exportImage(volumes[0].metadata.name, imageName)
       cy.intercept('DELETE', `/v1/harvester/kubevirt.io.virtualmachines/${namespace}/${VM_NAME}*`).as('deleteVM');
       vms.delete(namespace, VM_NAME)
       cy.wait('@deleteVM').then(res => {
         expect(res.response?.statusCode, 'Delete VM').to.be.oneOf([200, 204]);
-        
+
         imagePO.goToList()
 
         cy.intercept('DELETE', `/v1/harvester/harvesterhci.io.virtualmachineimages/${namespace}/*`).as('deleteImage');
         imagePO.clickAction(imageName, 'Delete')
         cy.get('[data-testid="prompt-remove-confirm-button"]').click()
         cy.wait('@deleteImage').then(res => {
-          expect(res.response?.statusCode, 'Delete Image').to.be.oneOf([200, 204]); 
+          expect(res.response?.statusCode, 'Delete Image').to.be.oneOf([200, 204]);
         })
       })
     })
@@ -287,7 +287,7 @@ describe('Edit vm and insert ssh and check the ssh key is accepted for the login
       network: NETWORK_1,
     }])
 
-    vms.save(); 
+    vms.save();
 
     vms.censorInColumn(VM_NAME, 3, namespace, 4, 'Running', 2, { timeout: constants.timeout.maxTimeout, nameSelector: '.name-console a' });
     // Wait for IP address show in table
@@ -304,16 +304,16 @@ describe('Edit vm and insert ssh and check the ssh key is accepted for the login
           host: address,
           remoteCommand: 'ls',
         })
-        .then(result => {
-          vms.delete(namespace, VM_NAME)
-        })
+          .then(result => {
+            vms.delete(namespace, VM_NAME)
+          })
       })
   })
 })
 
 describe('All Namespace filtering in VM list', () => {
   beforeEach(() => {
-    cy.login({url: PageUrl.namespace});
+    cy.login({ url: PageUrl.namespace });
   });
 
   // https://harvester.github.io/tests/manual/_incoming/2578-all-namespace-filtering/  
@@ -329,7 +329,7 @@ describe('All Namespace filtering in VM list', () => {
 
     // create vm in test namespace
     const imageEnv = Cypress.env('image');
-    
+
     const VM_NAME = 'namespace-test';
     const volume = [{
       buttonText: 'Add Volume',

--- a/cypress/testcases/volume/volumes.spec.ts
+++ b/cypress/testcases/volume/volumes.spec.ts
@@ -44,7 +44,7 @@ describe("Create image from Volume", () => {
     vms.save();
 
     // check VM state
-    vms.checkState({name: VM_NAME});
+    vms.checkState({ name: VM_NAME });
 
     // // export IMAGE
     image.exportImage(VM_NAME, IMAGE_NAME, namespace);
@@ -63,7 +63,7 @@ describe("Create image from Volume", () => {
     vms.save();
 
     // check VM state
-    vms.checkState({name: ANOTHER_VM_NAME});
+    vms.checkState({ name: ANOTHER_VM_NAME });
 
     // delete VM
     vms.delete(namespace, ANOTHER_VM_NAME);
@@ -104,7 +104,7 @@ describe("Create volume root disk VM Image Form", () => {
     // create VOLUME
     volumes.goToCreate();
     volumes.setNameNsDescription(VOLUME_NAME, namespace);
-    volumes.setBasics({source: 'VM Image', image: imageEnv.name, size: '10'});
+    volumes.setBasics({ source: 'Virtual Machine Image', image: imageEnv.name, size: '10' });
     volumes.save();
 
     // check state
@@ -156,7 +156,7 @@ describe("Delete volume that was attached to VM but now is not", () => {
       const volumeName = vm.spec?.template?.spec?.volumes?.[0]?.persistentVolumeClaim?.claimName || '';
 
       // check VM state
-      vms.checkState({name: VM_NAME});
+      vms.checkState({ name: VM_NAME });
 
       // delete VM
       vms.delete(namespace, VM_NAME, VM_NAME, { removeRootDisk: false });
@@ -202,13 +202,13 @@ describe("Support Volume Hot Unplug", () => {
     // create VOLUME
     volumes.goToCreate();
     volumes.setNameNsDescription(VOLUME_NAME_1, namespace);
-    volumes.setBasics({size: '4'});
+    volumes.setBasics({ size: '4' });
     volumes.save();
     volumes.censorInColumn(VOLUME_NAME_1, 3, namespace, 4, 'Ready');
 
     volumes.goToCreate();
     volumes.setNameNsDescription(VOLUME_NAME_2, namespace);
-    volumes.setBasics({size: '4'});
+    volumes.setBasics({ size: '4' });
     volumes.save();
     volumes.censorInColumn(VOLUME_NAME_2, 3, namespace, 4, 'Ready');
 
@@ -221,10 +221,10 @@ describe("Support Volume Hot Unplug", () => {
     vms.save();
 
     // check VM state
-    vms.checkState({name: VM_NAME});
+    vms.checkState({ name: VM_NAME });
 
     vms.plugVolume(VM_NAME, [VOLUME_NAME_1, VOLUME_NAME_2], namespace);
-    vms.unplugVolume(VM_NAME, [1,2], namespace);
+    vms.unplugVolume(VM_NAME, [1, 2], namespace);
     vms.plugVolume(VM_NAME, [VOLUME_NAME_1, VOLUME_NAME_2], namespace);
 
     // delete VM
@@ -245,7 +245,7 @@ describe("Support Volume Hot Unplug", () => {
   * Expected Results
   * 1. Disk should be resized
   */
- describe("Edit volume increase size via form", () => {
+describe("Edit volume increase size via form", () => {
   const VM_NAME = generateName("vm-e2e-1");
 
   it("Edit volume increase size via form", () => {
@@ -277,12 +277,12 @@ describe("Support Volume Hot Unplug", () => {
       // check VM state
       vms.clickAction(VM_NAME, 'Stop');
       vms.searchClear();
-      vms.checkState({name: VM_NAME, state: 'Off'});
+      vms.checkState({ name: VM_NAME, state: 'Off' });
 
       volumes.goToEdit(volumeName);
-      volumes.setBasics({size: '5'});
+      volumes.setBasics({ size: '5' });
       volumes.update(`${namespace}/${volumeName}`);
-      
+
       // check VOLUME state
       volumes.censorInColumn(volumeName, 3, namespace, 4, 'In-use', 2);
 

--- a/cypress/utils/components/labeled-input.po.ts
+++ b/cypress/utils/components/labeled-input.po.ts
@@ -3,8 +3,8 @@ import ComponentPo from './component.po';
 export default class LabeledInputPo extends ComponentPo {
   input(string: string | undefined) {
     if (string) {
-      this.self().find('input').clear({force: true})
-      this.self().type(string)
+      this.self().find('input').clear({ force: true })
+      this.self().first().type(string)
     }
 
     return


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

Harvester issue: https://github.com/harvester/harvester/issues/6407
Test sssue: https://github.com/harvester/tests/issues/1535


#### What this PR does / why we need it:
* Starting with v1.4.0, we have made some dashboard string changes in issue https://github.com/harvester/harvester/issues/6407

* This change would cause cypress test to have around `46` failure result job [#110](http://172.19.99.74/job/harvester-cypress-test/110/)

* The corresponding [test result](https://minio.provo.rancherlabs.com:31524/cypress-test-report/cypress/results/20240917-145232-4d4d22b/index.html):

  ![image](https://github.com/user-attachments/assets/236e5d60-9247-4abe-ac41-24dd4c874fe2)


#### Special notes for your reviewer:
* Tested on the latest `v1.4.0-rc1` cypress test result on Jenkins Harvester cypress test job [# 114](http://172.19.99.74/job/harvester-cypress-test/114/)

* According to the corresponding [cypress test report](https://minio.provo.rancherlabs.com:31524/cypress-test-report/cypress/results/20241005-121123-a22ae3d/index.html)

* After the fix, the failed test reduced from `46` to `9`
  ![image](https://github.com/user-attachments/assets/ef7fef3a-574e-4b0f-9d9c-ab4d63758aed)


