### PR TITLE
Support new annotation behavior on storage network

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -8,8 +8,8 @@ host-private-key: ''
 
 # VLAN ID, will invoke the tests depended on external networking if not set to -1.
 vlan-id: 1
-# Physical NIC for VLAN. Default is "harvester-mgmt"
-vlan-nic: 'harvester-mgmt'
+# Physical NIC for VLAN. Default is "mgmt"
+vlan-nic: 'mgmt'
 ip-pool-subnet: '192.168.0.0/24'
 ip-pool-start: ''
 ip-pool-end: ''
@@ -22,15 +22,12 @@ sleep-timeout: 3
 # script location to manipulate node power cycle
 node-scripts-location: 'scripts/vagrant'
 
+# Images and its sha512sum
 opensuse-image-url: https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.5/images/openSUSE-Leap-15.5.x86_64-NoCloud.qcow2
-# sha512sum for opensuse image-url
 opensuse-checksum: ''
-
 ubuntu-image-url: https://cloud-images.ubuntu.com/releases/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img
-# sha512sum for ubuntu image-url
 ubuntu-checksum: ''
-
-# URL to download all images
+# cache URL, convert image-url to <image-cache-url>/<filename>
 image-cache-url: ''
 
 # script location for terraform related test cases
@@ -51,7 +48,7 @@ accessKeyId: ''
 secretAccessKey: ''
 bucketName: ''
 
-# Backup Targer NFS
+# Backup Target NFS
 nfs-endpoint: ''
 nfs-mount-dir: 'nfsshare'
 


### PR DESCRIPTION
### Which issue(s) this PR fixes
Issue #1566 

### Why we need it
1. Compare to _longhorn-v1.6.2_, _longhorn-v1.7.1_ behaves a bit different about the instance-manager's annotation when storage-network is disabled. 
1. This behavior change breaks some test cases includes:
   * `test_0_storage_network.py::test_storage_network`
   * `TestImageWithStorageNetwork::test_delete_image::teardown`
   * `TestVMWithStorageNetwork::test_enable_storage_network_with_api_stopped_vm::teardown`
   * `TestVMWithStorageNetwork::test_enable_storage_network_with_cli_stopped_vm::teardown`
1. Longhorn mainly controls `k8s.v1.cni.cncf.io/networks` but not `k8s.v1.cni.cncf.io/network-status`. However we still need to check the latter for address.

### What this PR does
1. Add checking on `k8s.v1.cni.cncf.io/networks` annotation for storage-network enable/disable status.
2. Keep existed checking on `k8s.v1.cni.cncf.io/network-status` but only for address and name validation when enabling storage-network.
3. This fix is compatible with _longhorn-v1.6.2_ (_harvester-v1.3.2_).

### Special notes for your reviewer
#### Validation
* _harvester-install-and-test/72_
  > 3 fails are due to single node cluster does not support VM migration.

  ![image](https://github.com/user-attachments/assets/cb676c34-e6b3-4969-983c-bc1a98d15f8a)

* local ipxe-example
  ![image](https://github.com/user-attachments/assets/dd2f6cd1-d553-4467-a3df-7fa913a9708a)
 
### Additional documentation or context
n/a
