### PR TITLE
Wip/fix get harvester kubeconfig

### DIFF
--- a/apiclient/rancher_api/api.py
+++ b/apiclient/rancher_api/api.py
@@ -67,19 +67,27 @@ class RancherAPI:
 
     def _get(self, path, **kwargs):
         url = urljoin(self.endpoint, path)
-        return self.session.get(url, **kwargs)
+        resp = self.session.get(url, **kwargs)
+        print(f"{resp.request.method} {resp.request.url}")
+        return resp
 
     def _post(self, path, **kwargs):
         url = urljoin(self.endpoint, path)
-        return self.session.post(url, **kwargs)
+        resp = self.session.post(url, **kwargs)
+        print(f"{resp.request.method} {resp.request.url}")
+        return resp
 
     def _put(self, path, **kwargs):
         url = urljoin(self.endpoint, path)
-        return self.session.put(url, **kwargs)
+        resp = self.session.put(url, **kwargs)
+        print(f"{resp.request.method} {resp.request.url}")
+        return resp
 
     def _delete(self, path, **kwargs):
         url = urljoin(self.endpoint, path)
-        return self.session.delete(url, **kwargs)
+        resp = self.session.delete(url, **kwargs)
+        print(f"{resp.request.method} {resp.request.url}")
+        return resp
 
     def authenticate(self, user, passwd, **kwargs):
         path = "v3-public/localProviders/local?action=login"

--- a/apiclient/rancher_api/managers.py
+++ b/apiclient/rancher_api/managers.py
@@ -31,7 +31,7 @@ class BaseManager:
             raise ReferenceError("API object no longer exists")
         return self._api()
 
-    def _delegate(self, meth, path, params, *, raw=False, **kwargs):
+    def _delegate(self, meth, path, *, raw=False, **kwargs):
         func = getattr(self.api, meth)
         resp = func(path, **kwargs)
 
@@ -46,22 +46,22 @@ class BaseManager:
         except json.decoder.JSONDecodeError as e:
             return resp.status_code, dict(error=e, response=resp)
 
-    def _get(self, path, params={}, *, raw=False, **kwargs):
-        return self._delegate("_get", path, params=params, raw=raw, **kwargs)
+    def _get(self, path, *, raw=False, **kwargs):
+        return self._delegate("_get", path, raw=raw, **kwargs)
 
-    def _create(self, path, params={}, *, raw=False, **kwargs):
-        return self._delegate("_post", path, params=params, raw=raw, **kwargs)
+    def _create(self, path, *, raw=False, **kwargs):
+        return self._delegate("_post", path, raw=raw, **kwargs)
 
-    def _update(self, path, data, *, params={}, raw=False, as_json=True, **kwargs):
+    def _update(self, path, data, *, raw=False, as_json=True, **kwargs):
         if as_json:
             kwargs.update(json=data)
         else:
             kwargs.update(data=data)
 
-        return self._delegate("_put", path, params=params, raw=raw, **kwargs)
+        return self._delegate("_put", path, raw=raw, **kwargs)
 
-    def _delete(self, path, params={}, *, raw=False, **kwargs):
-        return self._delegate("_delete", path, params=params, raw=raw, **kwargs)
+    def _delete(self, path, *, raw=False, **kwargs):
+        return self._delegate("_delete", path, raw=raw, **kwargs)
 
 
 class UserManager(BaseManager):
@@ -811,7 +811,7 @@ class ClusterManager(BaseManager):
 
     def generate_kubeconfig(self, name, *, raw=False):
         params = {'action': 'generateKubeconfig'}
-        return self._create(f"v3/clusters/{name}", params=params, raw=raw)
+        return self._create(f"v3/clusters/{name}", raw=raw, params=params)
 
     def explore(self, name):
         from .cluster_api import ClusterExploreAPI  # circular dependency

--- a/apiclient/rancher_api/managers.py
+++ b/apiclient/rancher_api/managers.py
@@ -31,7 +31,7 @@ class BaseManager:
             raise ReferenceError("API object no longer exists")
         return self._api()
 
-    def _delegate(self, meth, path, *, raw=False, **kwargs):
+    def _delegate(self, meth, path, params, *, raw=False, **kwargs):
         func = getattr(self.api, meth)
         resp = func(path, **kwargs)
 
@@ -46,22 +46,22 @@ class BaseManager:
         except json.decoder.JSONDecodeError as e:
             return resp.status_code, dict(error=e, response=resp)
 
-    def _get(self, path, *, raw=False, **kwargs):
-        return self._delegate("_get", path, raw=raw, **kwargs)
+    def _get(self, path, params={}, *, raw=False, **kwargs):
+        return self._delegate("_get", path, params=params, raw=raw, **kwargs)
 
-    def _create(self, path, *, raw=False, **kwargs):
-        return self._delegate("_post", path, raw=raw, **kwargs)
+    def _create(self, path, params={}, *, raw=False, **kwargs):
+        return self._delegate("_post", path, params=params, raw=raw, **kwargs)
 
-    def _update(self, path, data, *, raw=False, as_json=True, **kwargs):
+    def _update(self, path, data, *, params={}, raw=False, as_json=True, **kwargs):
         if as_json:
             kwargs.update(json=data)
         else:
             kwargs.update(data=data)
 
-        return self._delegate("_put", path, raw=raw, **kwargs)
+        return self._delegate("_put", path, params=params, raw=raw, **kwargs)
 
-    def _delete(self, path, *, raw=False, **kwargs):
-        return self._delegate("_delete", path, raw=raw, **kwargs)
+    def _delete(self, path, params={}, *, raw=False, **kwargs):
+        return self._delegate("_delete", path, params=params, raw=raw, **kwargs)
 
 
 class UserManager(BaseManager):
@@ -678,6 +678,7 @@ class NodeTemplateManager(BaseManager):
 
 class ClusterManager(BaseManager):
     PATH_fmt = "v3/cluster/{uid}"
+    PATH1_fmt = "v3/clusters/{uid}"
 
     def create_data(self, name, k8s_version, kubeconfig):
 
@@ -807,6 +808,10 @@ class ClusterManager(BaseManager):
 
     def delete(self, name, *, raw=False):
         return self._delete(self.PATH_fmt.format(uid=name), raw=raw)
+
+    def generate_kubeconfig(self, name, *, raw=False):
+        params = {'action': 'generateKubeconfig'}
+        return self._create(f"v3/clusters/{name}", params=params, raw=raw)
 
     def explore(self, name):
         from .cluster_api import ClusterExploreAPI  # circular dependency

--- a/harvester_e2e_tests/fixtures/settings.py
+++ b/harvester_e2e_tests/fixtures/settings.py
@@ -15,7 +15,9 @@ def setting_checker(api_client, wait_timeout, sleep_timeout):
 
         def _storage_net_configured(self):
             code, data = self.settings.get('storage-network')
-            if (cs := data.get('status', {}).get('conditions')):
+
+            cs = data.get('status', {}).get('conditions')
+            if cs:
                 if 'True' == cs[-1].get('status') and 'Completed' == cs[-1].get('reason'):
                     return True, (code, data)
             return False, (code, data)

--- a/harvester_e2e_tests/integrations/test_9_rancher_integration.py
+++ b/harvester_e2e_tests/integrations/test_9_rancher_integration.py
@@ -130,7 +130,14 @@ def harvester_mgmt_cluster(api_client, rancher_api_client, unique_name, polling_
 @pytest.fixture(scope='module')
 def harvester_cloud_credential(api_client, rancher_api_client,
                                harvester_mgmt_cluster, unique_name):
-    harvester_kubeconfig = api_client.generate_kubeconfig()
+    code, data = rancher_api_client.clusters.generate_kubeconfig(
+        harvester_mgmt_cluster['id']
+    )
+    assert 200 == code, (
+        f"Failed to create kubconfig with error: {code}, {data}"
+    )
+    harvester_kubeconfig = data['config']
+
     code, data = rancher_api_client.cloud_credentials.create(
         unique_name,
         harvester_kubeconfig,

--- a/harvester_e2e_tests/integrations/test_upgrade.py
+++ b/harvester_e2e_tests/integrations/test_upgrade.py
@@ -507,7 +507,8 @@ class TestInvalidUpgrade:
         # https://github.com/harvester/harvester/issues/6425
         code, data = api_client.hosts.get()
         assert 200 == code, (code, data)
-        if (cluster_size := len(data['data'])) < 3:
+        cluster_size = len(data['data'])
+        if cluster_size < 3:
             pytest.skip(
                 f"Degraded volumes only checked on 3+ nodes cluster, skip on {cluster_size}."
             )


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue # https://github.com/harvester/tests/issues/1627

#### What this PR does / why we need it:

Creating a cloud credential from a kubeconfig file that has not been created through Rancher is wrong, because then Rancher can't determine the expiration date of that kubeconfig and will return an error.
To fix this, the test suite needs to create the kubeconfig file through Rancher

#### Special notes for your reviewer:

#### Additional documentation or context
