### PR TITLE
Fixups and Python 3.11 Environment

### DIFF
--- a/apiclient/rancher_api/api.py
+++ b/apiclient/rancher_api/api.py
@@ -68,25 +68,21 @@ class RancherAPI:
     def _get(self, path, **kwargs):
         url = urljoin(self.endpoint, path)
         resp = self.session.get(url, **kwargs)
-        print(f"{resp.request.method} {resp.request.url}")
         return resp
 
     def _post(self, path, **kwargs):
         url = urljoin(self.endpoint, path)
         resp = self.session.post(url, **kwargs)
-        print(f"{resp.request.method} {resp.request.url}")
         return resp
 
     def _put(self, path, **kwargs):
         url = urljoin(self.endpoint, path)
         resp = self.session.put(url, **kwargs)
-        print(f"{resp.request.method} {resp.request.url}")
         return resp
 
     def _delete(self, path, **kwargs):
         url = urljoin(self.endpoint, path)
         resp = self.session.delete(url, **kwargs)
-        print(f"{resp.request.method} {resp.request.url}")
         return resp
 
     def authenticate(self, user, passwd, **kwargs):

--- a/apiclient/rancher_api/managers.py
+++ b/apiclient/rancher_api/managers.py
@@ -810,8 +810,11 @@ class ClusterManager(BaseManager):
         return self._delete(self.PATH_fmt.format(uid=name), raw=raw)
 
     def generate_kubeconfig(self, name, *, raw=False):
-        params = {'action': 'generateKubeconfig'}
-        return self._create(f"v3/clusters/{name}", raw=raw, params=params)
+        return self._create(
+            self.PATH1_fmt.format(uid=name),
+            raw=raw,
+            params={'action': 'generateKubeconfig'}
+        )
 
     def explore(self, name):
         from .cluster_api import ClusterExploreAPI  # circular dependency

--- a/harvester_e2e_tests/fixtures/settings.py
+++ b/harvester_e2e_tests/fixtures/settings.py
@@ -16,8 +16,7 @@ def setting_checker(api_client, wait_timeout, sleep_timeout):
         def _storage_net_configured(self):
             code, data = self.settings.get('storage-network')
 
-            cs = data.get('status', {}).get('conditions')
-            if cs:
+            if (cs := data.get('status', {}).get('conditions')):
                 if 'True' == cs[-1].get('status') and 'Completed' == cs[-1].get('reason'):
                     return True, (code, data)
             return False, (code, data)

--- a/harvester_e2e_tests/integrations/test_upgrade.py
+++ b/harvester_e2e_tests/integrations/test_upgrade.py
@@ -507,8 +507,7 @@ class TestInvalidUpgrade:
         # https://github.com/harvester/harvester/issues/6425
         code, data = api_client.hosts.get()
         assert 200 == code, (code, data)
-        cluster_size = len(data['data'])
-        if cluster_size < 3:
+        if (cluster_size := len(data['data'])) < 3:
             pytest.skip(
                 f"Degraded volumes only checked on 3+ nodes cluster, skip on {cluster_size}."
             )

--- a/py36_pytest.ini
+++ b/py36_pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-render_collapsed = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py38,pep8,testenv
+envlist = py38,py311,pep8,testenv
 # TODO(gyee): we are not distributing the test code right now. Will need
 # to revisit this once we have majority of the tests developed.
 skipsdist = True
@@ -20,6 +20,9 @@ commands =
   pytest -c {env:PYTEST_CONFIG:{toxinidir}/tox.ini} {posargs}
 passenv = http_proxy,HTTP_PROXY,https_proxy,HTTPS_PROXY,no_proxy,NO_PROXY,PBR_VERSION
 
+[testenv:py311]
+basepython = python3.11
+
 [testenv:pep8]
 deps = flake8
 commands =
@@ -31,7 +34,3 @@ max-line-length = 99
 [pytest]
 initial_sort = original
 render_collapsed = all
-
-[testenv:py36]
-setenv =
-    PYTEST_CONFIG = {toxinidir}/py36_pytest.ini


### PR DESCRIPTION
Fixups:
 - Remove debug output
 - Cleanup format strings in ClusterManager class

Tox:
 - Add Python 3.11 environment
 - Drop Python 3.6 environment

Revert change to two assignment expressions. Without the need to further support Python 3.6 assignment expressions can be used in conditionals, i.e. `if (cs := data.get(...)):`.

#### Which issue(s) this PR fixes:
This PR addresses suggestions on [a previous PR](https://github.com/harvester/tests/pull/1628).

#### What this PR does / why we need it:

Following the suggestions on [PR1628](https://github.com/harvester/tests/pull/1628) that were made after that PR had already been merged, this PR is a simple clean up.

#### Special notes for your reviewer:

There are no new tests, no removed tests and no changes to functionality. However support for Python 3.6 has been dropped and as replacement support for Python 3.11 has been added to the tox config.
