### PR TITLE
[e2e] add python3.10 to tox env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py311,pep8,testenv
+envlist = py38,python3.10,py311,pep8,testenv
 # TODO(gyee): we are not distributing the test code right now. Will need
 # to revisit this once we have majority of the tests developed.
 skipsdist = True


### PR DESCRIPTION
## Changes
- Add `python3.10` to `tox.ini` which was injected from ansible.
```ansible
  - name: Add a tox environment for python 3.10
    replace:
      path: "{{ test_workspace }}/tox.ini"
      regexp: "py36,py38"
      replace: "py36,py38,python3.10"
```

ref: https://github.com/harvester/harvester-baremetal-ansible/blob/afe8affb7364e51b4430046ca6aefbbd72aa494c/ansible/roles/tests/tasks/run_tests_seeder.yml#L148-L160