### PR TITLE
Conform new upgradelog naming and check before create upgrade

### DIFF
--- a/harvester_e2e_tests/fixtures/upgrades.py
+++ b/harvester_e2e_tests/fixtures/upgrades.py
@@ -1,0 +1,47 @@
+import pytest
+from .base import wait_until
+
+pytest_plugins = ["harvester_e2e_tests.fixtures.api_client"]
+
+
+@pytest.fixture(scope="session")
+def upgrade_checker(api_client, wait_timeout, sleep_timeout):
+    class UpgradeChecker:
+        def __init__(self):
+            self.versions = api_client.versions
+            self.upgrades = api_client.upgrades
+
+        @wait_until(wait_timeout, sleep_timeout)
+        def wait_upgrade_version_created(self, version):
+            code, data = self.versions.get(version)
+            if code == 200:
+                return True, (code, data)
+            return False, (code, data)
+
+        @wait_until(wait_timeout, sleep_timeout)
+        def wait_upgrade_fail_by_invalid_iso_url(self, upgrade_name):
+            code, data = self.upgrades.get(upgrade_name)
+            conds = dict((c['type'], c) for c in data.get('status', {}).get('conditions', []))
+            verified = [
+                "False" == conds.get('Completed', {}).get('status'),
+                "False" == conds.get('ImageReady', {}).get('status'),
+                "no such host" in conds.get('ImageReady', {}).get('message', "")
+            ]
+            if all(verified):
+                return True, (code, data)
+            return False, (code, data)
+
+        @wait_until(wait_timeout, sleep_timeout)
+        def wait_upgrade_fail_by_invalid_checksum(self, upgrade_name):
+            code, data = self.upgrades.get(upgrade_name)
+            conds = dict((c['type'], c) for c in data.get('status', {}).get('conditions', []))
+            verified = [
+                "False" == conds.get('Completed', {}).get('status'),
+                "False" == conds.get('ImageReady', {}).get('status'),
+                "n't match the file actual check" in conds.get('ImageReady', {}).get('message', "")
+            ]
+            if all(verified):
+                return True, (code, data)
+            return False, (code, data)
+
+    return UpgradeChecker()

--- a/harvester_e2e_tests/fixtures/volumes.py
+++ b/harvester_e2e_tests/fixtures/volumes.py
@@ -23,7 +23,13 @@ def volume_checker(api_client, wait_timeout, sleep_timeout):
                 code, data = self.lhvolumes.get(pvc_name)
                 if not (200 == code and "detached" == data['status']['state']):
                     return False, (code, data)
-
             return True, (code, data)
+
+        @wait_until(wait_timeout, sleep_timeout)
+        def wait_lhvolume_degraded(self, pv_name):
+            code, data = api_client.lhvolumes.get(pv_name)
+            if 200 == code and "degraded" == data['status']['robustness']:
+                return True, (code, data)
+            return False, (code, data)
 
     return VolumeChecker()


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
1. Fix harvester/tests/issues/1448
   * Add test case _test_upgrade.py::TestAnyNodesUpgrade::test_verify_upgradelog_
   * Enhance upgradelog pod naming check
1. Check upgrade version do created before create upgrade job
   * Refactoring an `upgrade_check` fixture


#### What this PR does / why we need it:
Fix failed upgrade test cases and enhance stability


#### Special notes for your reviewer:


#### Additional documentation or context
1. Verification
   ![image](https://github.com/user-attachments/assets/d69cd546-7975-4568-bc0a-17d35a887fa7)
