### PR TITLE
Gracefully setup/teardown network configs and sanitize ISO URL

### DIFF
--- a/harvester_e2e_tests/fixtures/networks.py
+++ b/harvester_e2e_tests/fixtures/networks.py
@@ -23,6 +23,7 @@ def network_checker(api_client, wait_timeout, sleep_timeout):
     class NetworkChecker:
         def __init__(self):
             self.networks = api_client.networks
+            self.clusternetworks = api_client.clusternetworks
 
         @wait_until(wait_timeout, sleep_timeout)
         def wait_routed(self, vnet_name):
@@ -30,6 +31,13 @@ def network_checker(api_client, wait_timeout, sleep_timeout):
             annotations = data['metadata'].get('annotations', {})
             route = json.loads(annotations.get('network.harvesterhci.io/route', '{}'))
             if code == 200 and route.get('connectivity') == 'true':
+                return True, (code, data)
+            return False, (code, data)
+
+        @wait_until(wait_timeout, sleep_timeout)
+        def wait_cnet_config_created(self, cnet_config_name):
+            code, data = api_client.clusternetworks.get_config(cnet_config_name)
+            if code == 200:
                 return True, (code, data)
             return False, (code, data)
 

--- a/harvester_e2e_tests/fixtures/upgrades.py
+++ b/harvester_e2e_tests/fixtures/upgrades.py
@@ -12,7 +12,7 @@ def upgrade_checker(api_client, wait_timeout, sleep_timeout):
             self.upgrades = api_client.upgrades
 
         @wait_until(wait_timeout, sleep_timeout)
-        def wait_upgrade_version_created(self, version):
+        def wait_version_created(self, version):
             code, data = self.versions.get(version)
             if code == 200:
                 return True, (code, data)
@@ -25,7 +25,10 @@ def upgrade_checker(api_client, wait_timeout, sleep_timeout):
             verified = [
                 "False" == conds.get('Completed', {}).get('status'),
                 "False" == conds.get('ImageReady', {}).get('status'),
-                "no such host" in conds.get('ImageReady', {}).get('message', "")
+                any([
+                    "no such host" in conds.get('ImageReady', {}).get('message', ""),  # >= v1.4.0
+                    "retry limit" in conds.get('ImageReady', {}).get('message', "")    # < v1.4.0
+                ])
             ]
             if all(verified):
                 return True, (code, data)
@@ -38,7 +41,10 @@ def upgrade_checker(api_client, wait_timeout, sleep_timeout):
             verified = [
                 "False" == conds.get('Completed', {}).get('status'),
                 "False" == conds.get('ImageReady', {}).get('status'),
-                "n't match the file actual check" in conds.get('ImageReady', {}).get('message', "")
+                any([
+                    "actual check" in conds.get('ImageReady', {}).get('message', ""),  # >= v1.4.0
+                    "retry limit" in conds.get('ImageReady', {}).get('message', "")    # < v1.4.0
+                ])
             ]
             if all(verified):
                 return True, (code, data)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
#### What this PR does / why we need it:
1. Erro message backward compatibility of expected isourl/checksum in upgrade creation before `v1.4.0`
   <details>
   <summary> screenshot
   </summary>
   
   ![image](https://github.com/user-attachments/assets/5b3b1946-0ce0-476c-823a-7889e6f55276)
   </details>

1. Fix flaky test
   * Gracefully teardown network config on each nodes thus confirm not to affect next multistage upgrade.
   * Confirm version is created before perform upgrade.

Ref. [[TEST] v1.4.1 Release Testing - Automation - Two stage upgrade](https://github.com/harvester/tests/issues/1774)

#### Verification
* `v1.3.2` -> `v1.4.0`
  harvester-upgrade-test#135
  ![Image](https://github.com/user-attachments/assets/d842de8e-c15f-4a49-96aa-3f9826d3a9e6)
* `v1.4.0` -> `v1.4.1-rc1`
  harvester-upgrade-test#136
  ![Image](https://github.com/user-attachments/assets/20284f17-95ce-47dd-b5e6-0c9b5548c06d)

