### PR TITLE
Fix non-exited while loop in teardown

### DIFF
--- a/apiclient/harvester_api/api.py
+++ b/apiclient/harvester_api/api.py
@@ -140,8 +140,13 @@ class HarvesterAPI:
         resp = self._get(path)
         return resp.status_code, resp.json()
 
-    def get_apps_catalog(self, name="", namespace=DEFAULT_NAMESPACE):
-        path = f"v1/catalog.cattle.io.apps/{namespace}/{name}"
+    def get_apps_deployments(self, name="", namespace=DEFAULT_NAMESPACE):
+        path = f"v1/apps.deployments/{namespace}/{name}"
+        resp = self._get(path)
+        return resp.status_code, resp.json()
+
+    def get_apps_controllerrevisions(self, namespace=""):
+        path = f"v1/apps.controllerrevisions/{namespace}"
         resp = self._get(path)
         return resp.status_code, resp.json()
 

--- a/harvester_e2e_tests/integrations/test_upgrade.py
+++ b/harvester_e2e_tests/integrations/test_upgrade.py
@@ -166,11 +166,13 @@ def cluster_network(vlan_nic, api_client, unique_name, network_checker, wait_tim
 
     # Teardown
     endtime = datetime.now() + timedelta(seconds=wait_timeout)
-    while endtime > datetime.now() and created:
+    while endtime > datetime.now():
         name = created.pop(0)
         code, data = api_client.clusternetworks.delete_config(name)
         if code != 404:
             created.append(name)
+        if not created:
+            break
         sleep(1)
     else:
         raise AssertionError(


### PR DESCRIPTION
### Which issue(s) this PR fixes:
* https://github.com/harvester/harvester/pull/7479

### What this PR does / why we need it:
1. Fix non-exited while loop in upgrade teardown.
2. Conform test case to https://github.com/harvester/harvester/pull/7479
   * Use `v1/apps.deployments` and `apps.controllerrevisions` to get app image instead of previous `v1/catalog.cattle.io.apps`.

### Special notes for your reviewer:
Verifed
![Image](https://github.com/user-attachments/assets/cb23f40a-852f-4de1-ae1e-a7395590b06b)

### Additional documentation or context
1. Comparism
   * `v1/catalog.cattle.io.apps`
     ![image](https://github.com/user-attachments/assets/a629f040-b228-4caa-abe3-43bcdf85ddee)
   * `v1/apps.deployments`
     ![image](https://github.com/user-attachments/assets/c1db727f-557f-4512-a1f4-c4cf65f014e7)
