### PR TITLE
chore: bump python version in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Setting Up Default Dockerfile For Backend E2E Tests For CI
-FROM python:3.8.13-buster
+FROM python:3.10.16-bookworm
 RUN apt-get update && \
     apt-get install -y --no-install-recommends build-essential findutils wget && \
     apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
An error occurred while building the image. So, I bump the python version.

```
9.977   × python setup.py egg_info did not run successfully.
9.977   │ exit code: 1
9.977   ╰─> [71 lines of output]
9.977       /usr/local/lib/python3.8/distutils/dist.py:274: UserWarning: Unknown distribution option: 'test_suite'
9.977         warnings.warn(msg)
9.977       /tmp/pip-install-0k00_782/pdoc3_a66b6f4c43b24b9ea0681bfacb3a1ae2/.eggs/setuptools_scm-8.2.0-py3.8.egg/setuptools_scm/_integration/setuptools.py:31: RuntimeWarning:
9.977       ERROR: setuptools==57.5.0 is used in combination with setuptools-scm>=8.x
9.977
9.977       Your build configuration is incomplete and previously worked by accident!
9.977       setuptools-scm requires setuptools>=61
9.977
9.977       Suggested workaround if applicable:
9.977        - migrating from the deprecated setup_requires mechanism to pep517/518
9.977          and using a pyproject.toml to declare build dependencies
9.977          which are reliably pre-installed before running the build tools
9.977
9.977         warnings.warn(
9.977       WARNING setuptools_scm.pyproject_reading toml section missing 'pyproject.toml does not contain a tool.setuptools_scm section'
9.977       Traceback (most recent call last):
9.977         File "/tmp/pip-install-0k00_782/pdoc3_a66b6f4c43b24b9ea0681bfacb3a1ae2/.eggs/setuptools_scm-8.2.0-py3.8.egg/setuptools_scm/_integration/pyproject_reading.py", line 36, in read_pyproject
9.977           section = defn.get("tool", {})[tool_name]
9.977       KeyError: 'setuptools_scm'
9.977       running egg_info
9.977       creating /tmp/pip-pip-egg-info-tn2ujkhz/pdoc3.egg-info
9.977       writing /tmp/pip-pip-egg-info-tn2ujkhz/pdoc3.egg-info/PKG-INFO
9.977       writing dependency_links to /tmp/pip-pip-egg-info-tn2ujkhz/pdoc3.egg-info/dependency_links.txt
9.977       writing entry points to /tmp/pip-pip-egg-info-tn2ujkhz/pdoc3.egg-info/entry_points.txt
9.977       writing requirements to /tmp/pip-pip-egg-info-tn2ujkhz/pdoc3.egg-info/requires.txt
9.977       writing top-level names to /tmp/pip-pip-egg-info-tn2ujkhz/pdoc3.egg-info/top_level.txt
9.977       writing manifest file '/tmp/pip-pip-egg-info-tn2ujkhz/pdoc3.egg-info/SOURCES.txt'
9.977       Traceback (most recent call last):
9.977         File "<string>", line 2, in <module>
9.977         File "<pip-setuptools-caller>", line 34, in <module>
9.977         File "/tmp/pip-install-0k00_782/pdoc3_a66b6f4c43b24b9ea0681bfacb3a1ae2/setup.py", line 15, in <module>
9.977           setup(
9.977         File "/usr/local/lib/python3.8/site-packages/setuptools/__init__.py", line 153, in setup
9.977           return distutils.core.setup(**attrs)
9.977         File "/usr/local/lib/python3.8/distutils/core.py", line 148, in setup
9.977           dist.run_commands()
9.977         File "/usr/local/lib/python3.8/distutils/dist.py", line 966, in run_commands
9.977           self.run_command(cmd)
9.977         File "/usr/local/lib/python3.8/distutils/dist.py", line 985, in run_command
9.977           cmd_obj.run()
9.977         File "/usr/local/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 299, in run
9.977           self.find_sources()
9.977         File "/usr/local/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 306, in find_sources
9.977           mm.run()
9.977         File "/usr/local/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 541, in run
9.977           self.add_defaults()
9.977         File "/usr/local/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 578, in add_defaults
9.977           sdist.add_defaults(self)
9.977         File "/usr/local/lib/python3.8/distutils/command/sdist.py", line 226, in add_defaults
9.977           self._add_defaults_python()
9.977         File "/usr/local/lib/python3.8/site-packages/setuptools/command/sdist.py", line 107, in _add_defaults_python
9.977           build_py = self.get_finalized_command('build_py')
9.977         File "/usr/local/lib/python3.8/distutils/cmd.py", line 299, in get_finalized_command
9.977           cmd_obj.ensure_finalized()
9.977         File "/usr/local/lib/python3.8/distutils/cmd.py", line 107, in ensure_finalized
9.977           self.finalize_options()
9.977         File "/usr/local/lib/python3.8/site-packages/setuptools/command/build_py.py", line 37, in finalize_options
9.977           orig.build_py.finalize_options(self)
9.977         File "/usr/local/lib/python3.8/distutils/command/build_py.py", line 43, in finalize_options
9.977           self.set_undefined_options('build',
9.977         File "/usr/local/lib/python3.8/distutils/cmd.py", line 286, in set_undefined_options
9.977           src_cmd_obj = self.distribution.get_command_obj(src_cmd)
9.977         File "/usr/local/lib/python3.8/distutils/dist.py", line 857, in get_command_obj
9.977           klass = self.get_command_class(command)
9.977         File "/usr/local/lib/python3.8/site-packages/setuptools/dist.py", line 854, in get_command_class
9.977           self.cmdclass[command] = cmdclass = ep.load()
9.977         File "/usr/local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2450, in load
9.977           return self.resolve()
9.977         File "/usr/local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2456, in resolve
9.977           module = __import__(self.module_name, fromlist=['__name__'], level=0)
9.977       ModuleNotFoundError: No module named 'setuptools.command.build'
9.977       [end of output]
9.977
9.977   note: This error originates from a subprocess, and is likely not a problem with pip.
9.978 error: metadata-generation-failed
9.978
9.978 × Encountered error while generating package metadata.
9.978 ╰─> See above for output.
9.978
9.978 note: This is an issue with the package mentioned above, not pip.
9.978 hint: See above for details.
10.17 WARNING: You are using pip version 22.0.4; however, version 25.0.1 is available.
10.17 You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
```