### PR TITLE
Refactor test case teardown

### DIFF
--- a/harvester_e2e_tests/fixtures/networks.py
+++ b/harvester_e2e_tests/fixtures/networks.py
@@ -41,4 +41,11 @@ def network_checker(api_client, wait_timeout, sleep_timeout):
                 return True, (code, data)
             return False, (code, data)
 
+        @wait_until(wait_timeout, sleep_timeout)
+        def wait_cnet_config_deleted(self, cnet_config_name):
+            code, data = api_client.clusternetworks.get_config(cnet_config_name)
+            if code == 404:
+                return True, (code, data)
+            return False, (code, data)
+
     return NetworkChecker()

--- a/harvester_e2e_tests/fixtures/networks.py
+++ b/harvester_e2e_tests/fixtures/networks.py
@@ -26,11 +26,18 @@ def network_checker(api_client, wait_timeout, sleep_timeout):
             self.clusternetworks = api_client.clusternetworks
 
         @wait_until(wait_timeout, sleep_timeout)
-        def wait_routed(self, vnet_name):
+        def wait_vnet_routed(self, vnet_name):
             code, data = self.networks.get(vnet_name)
             annotations = data['metadata'].get('annotations', {})
             route = json.loads(annotations.get('network.harvesterhci.io/route', '{}'))
             if code == 200 and route.get('connectivity') == 'true':
+                return True, (code, data)
+            return False, (code, data)
+
+        @wait_until(wait_timeout, sleep_timeout)
+        def wait_vnet_deleted(self, vnet_name):
+            code, data = api_client.networks.get(vnet_name)
+            if code == 404:
                 return True, (code, data)
             return False, (code, data)
 
@@ -44,6 +51,13 @@ def network_checker(api_client, wait_timeout, sleep_timeout):
         @wait_until(wait_timeout, sleep_timeout)
         def wait_cnet_config_deleted(self, cnet_config_name):
             code, data = api_client.clusternetworks.get_config(cnet_config_name)
+            if code == 404:
+                return True, (code, data)
+            return False, (code, data)
+
+        @wait_until(wait_timeout, sleep_timeout)
+        def wait_cnet_deleted(self, cnet_name):
+            code, data = api_client.clusternetworks.get(cnet_name)
             if code == 404:
                 return True, (code, data)
             return False, (code, data)

--- a/harvester_e2e_tests/fixtures/volumes.py
+++ b/harvester_e2e_tests/fixtures/volumes.py
@@ -13,6 +13,13 @@ def volume_checker(api_client, wait_timeout, sleep_timeout):
             self.lhvolumes = api_client.lhvolumes
 
         @wait_until(wait_timeout, sleep_timeout)
+        def wait_volume_deleted(self, vol_name):
+            code, data = self.volumes.get(vol_name)
+            if code == 404:
+                return True, (code, data)
+            return False, (code, data)
+
+        @wait_until(wait_timeout, sleep_timeout)
         def wait_volumes_detached(self, vol_names):
             for vol_name in vol_names:
                 code, data = self.volumes.get(name=vol_name)

--- a/harvester_e2e_tests/integrations/test_0_storage_network.py
+++ b/harvester_e2e_tests/integrations/test_0_storage_network.py
@@ -70,13 +70,17 @@ def cluster_network(request, api_client, unique_name, setting_checker, network_c
     assert snet_disabled, (code, data)
     snet_disabled, (code, data) = setting_checker.wait_storage_net_disabled_on_longhorn()
     assert snet_disabled, (code, data)
-    # cluster network
+    # cluster network config
     for cnet_cfg_name in created:
         code, data = api_client.clusternetworks.delete_config(cnet_cfg_name)
+        assert 200 == code, (code, data)
         cnet_cfg_deleted, (code, data) = network_checker.wait_cnet_config_deleted(cnet_cfg_name)
         assert cnet_cfg_deleted, (code, data)
+    # cluster network
     code, data = api_client.clusternetworks.delete(cnet)
     assert 200 == code, (code, data)
+    cnet_deleted, (code, data) = network_checker.wait_cnet_deleted(cnet)
+    assert cnet_deleted, (code, data)
 
 
 @pytest.mark.p0
@@ -145,4 +149,3 @@ def test_storage_network(
     assert snet_enabled, (code, data)
     snet_enabled, (code, data) = setting_checker.wait_storage_net_enabled_on_longhorn(vlan_cidr)
     assert snet_enabled, (code, data)
-

--- a/harvester_e2e_tests/integrations/test_1_volumes.py
+++ b/harvester_e2e_tests/integrations/test_1_volumes.py
@@ -88,14 +88,11 @@ def ubuntu_vm(api_client, unique_name, ubuntu_image, vm_checker, volume_checker)
     volumes = list(filter(lambda vol: "persistentVolumeClaim" in vol,
                           data["spec"]["template"]["spec"]["volumes"]))
     assert len(volumes) == 1
+
     yield data
 
-    code, data = api_client.vms.get(vm_name)
-    if 200 == code:
-        code, data = api_client.vms.delete(vm_name)
-        assert 200 == code, f"Fail to cleanup VM\n{code}, {data}"
-        vm_checker.wait_deleted(vm_name)
-
+    # teardown
+    _ = vm_checker.wait_deleted(vm_name)
     vol_name = volumes[0]['persistentVolumeClaim']['claimName']
     code, data = api_client.volumes.get(vol_name)
     if 200 == code:

--- a/harvester_e2e_tests/integrations/test_3_vm.py
+++ b/harvester_e2e_tests/integrations/test_3_vm.py
@@ -87,7 +87,7 @@ def vm_network(api_client, unique_name, cluster_network, vlan_id, network_checke
     code, data = api_client.networks.create(name, vlan_id, cluster_network=cluster_network)
     assert 201 == code, (code, data)
 
-    vnet_routed, (code, data) = network_checker.wait_routed(name)
+    vnet_routed, (code, data) = network_checker.wait_vnet_routed(name)
     assert vnet_routed, (code, data)
     route = json.loads(data['metadata'].get('annotations').get('network.harvesterhci.io/route'))
 


### PR DESCRIPTION
### Which issue(s) this PR fixes:
Issue #2028

### What this PR does / why we need it:
Sometimes unteardowned fixtures (vm network, cluster network, ...) will affect following test case running. To let each test suite is self-consistent we need to actively check teardown is successful before get into next case.

 
### Special notes for your reviewer:
Idealy, teardown should only be handle in fixture cuz
  * Test case self does not guarantee PASS
  * Teardowns in test case will not be execute as long as test fail.

### Additional documentation or context
1. _harvester_e2e_tests/integrations/test*.py_
   - [x] _test_0_storage_network.py_
   - [x] _test_1_images.py_
   - [x] _test_1_volumes.py_
   - [x] _test_3_vm_functions.py_
   - [ ] _test_3_vm.py_
   - [ ] _test_4_vm_backup_restore.py_
   - [ ] _test_4_vm_host_powercycle.py_
   - [ ] _test_4_vm_snapshot.py_
   - [ ] _test_4_vm_template.py_
   - [ ] _test_5_vm_networks_interact.py_
   - [ ] _test_5_vm_networks.py_
   - [ ] _test_9_rancher_integration.py_
   - [ ] _test_z_terraform_rancher.py_
   - [ ] _test_z_terraform.py_

1. _harvester_e2e_tests/apis/test*.py_

