### PR TITLE
Refactor to not ignoring teardown on test_0

### DIFF
--- a/harvester_e2e_tests/fixtures/networks.py
+++ b/harvester_e2e_tests/fixtures/networks.py
@@ -41,4 +41,11 @@ def network_checker(api_client, wait_timeout, sleep_timeout):
                 return True, (code, data)
             return False, (code, data)
 
+        @wait_until(wait_timeout, sleep_timeout)
+        def wait_vnet_deleted(self, vnet_name):
+            code, data = api_client.networks.get(vnet_name)
+            if code == 404:
+                return True, (code, data)
+            return False, (code, data)
+
     return NetworkChecker()


### PR DESCRIPTION
### Source Issue
* https://github.com/harvester/tests/issues/2028

### Implementation
Because storage network enable and disable are independent.
By separate single TC into enable and disable TCs we can ensure disable will still execute even enable is FAIL.

### Verification
![image](https://github.com/user-attachments/assets/bc43fbc0-79b1-47d4-88d8-581d25fa2f31)
