### PR TITLE
[e2e] add smoke/sanity markers

### DIFF
--- a/apiclient/harvester_api/api.py
+++ b/apiclient/harvester_api/api.py
@@ -45,6 +45,9 @@ class HarvesterAPI:
                 # Fixed as:
                 # 1. va.b-xxx-head => va.b.99
                 # 2. master-xxx-head => v8.8.99
+                # release-1.3-1bda61b3-head => v1.3-1bda61b3-head
+                if ver.startswith('release-'):
+                    ver = ver.replace('release-', 'v')
                 cur, _, _ = ver.split('-')
                 cur = "v8.8" if "master" in cur else cur
                 self._version = parse_version(f"{cur}.99")

--- a/harvester_e2e_tests/apis/test_addons.py
+++ b/harvester_e2e_tests/apis/test_addons.py
@@ -5,6 +5,7 @@ import pytest
 
 
 @pytest.mark.p0
+@pytest.mark.smoke
 @pytest.mark.parametrize("addon", [
     'cattle-logging-system/rancher-logging',
     'cattle-monitoring-system/rancher-monitoring',

--- a/harvester_e2e_tests/apis/test_hosts.py
+++ b/harvester_e2e_tests/apis/test_hosts.py
@@ -29,6 +29,7 @@ pytest_plugins = [
 @pytest.mark.dependency(name="get_host")
 @pytest.mark.hosts
 @pytest.mark.p0
+@pytest.mark.smoke
 def test_get_host(api_client):
     # Case 1: Get all nodes
     status_code, nodes_info = api_client.hosts.get()
@@ -48,6 +49,7 @@ def test_get_host(api_client):
 @pytest.mark.dependency(depends=["get_host"])
 @pytest.mark.hosts
 @pytest.mark.p0
+@pytest.mark.smoke
 def test_update_node(api_client):
     """
     Test the hosts are the nodes which make the cluster
@@ -92,6 +94,7 @@ def test_update_node(api_client):
 @pytest.mark.dependency(depends=["get_host"])
 @pytest.mark.hosts
 @pytest.mark.p2
+@pytest.mark.sanity
 def test_update_using_yaml(api_client):
     """
     Test the hosts are the nodes which make the cluster
@@ -137,7 +140,8 @@ def test_update_using_yaml(api_client):
 
 @pytest.mark.dependency(depends=["get_host"], name="enable_maintenance_mode")
 @pytest.mark.hosts
-@pytest.mark.p2
+@pytest.mark.p0
+@pytest.mark.smoke
 def test_maintenance_mode(api_client, wait_timeout):
     """
     Test the hosts are the nodes which make the cluster
@@ -188,8 +192,9 @@ def test_maintenance_mode(api_client, wait_timeout):
 
 
 @pytest.mark.dependency(depends=["get_host"], name="delete_host")
-@pytest.mark.p0
+@pytest.mark.p1
 @pytest.mark.hosts
+@pytest.mark.sanity
 @pytest.mark.delete_host
 def test_delete_host(api_client, wait_timeout):
     """

--- a/harvester_e2e_tests/apis/test_images.py
+++ b/harvester_e2e_tests/apis/test_images.py
@@ -82,6 +82,7 @@ class CasesImages:
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.negative
 @pytest.mark.images
 class TestImagesNegative:
@@ -117,6 +118,7 @@ class TestImagesNegative:
 
 
 @pytest.mark.p0
+@pytest.mark.smoke
 @pytest.mark.images
 class TestImages:
 
@@ -223,6 +225,7 @@ class TestImages:
 
 @pytest.mark.dependency(depends=["create_image", "get_image", "delete_image"])
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.negative
 @pytest.mark.images
 @parametrize_with_cases("gen_unique_name", cases=CasesImages, has_tag='gen-unique-name')

--- a/harvester_e2e_tests/apis/test_keypairs.py
+++ b/harvester_e2e_tests/apis/test_keypairs.py
@@ -27,6 +27,7 @@ pytest_plugins = [
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.negative
 @pytest.mark.keypairs
 class TestKeypairsNegative:
@@ -63,6 +64,7 @@ class TestKeypairsNegative:
 
 
 @pytest.mark.p0
+@pytest.mark.smoke
 @pytest.mark.keypairs
 class TestKeypairs:
     @pytest.mark.dependency(depends=["delete_keypair_negative", "create_keypair_negative"],

--- a/harvester_e2e_tests/apis/test_networks.py
+++ b/harvester_e2e_tests/apis/test_networks.py
@@ -28,6 +28,7 @@ VLAN_ID = 4000
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.negative
 @pytest.mark.networks
 class TestNetworksNegative:
@@ -68,6 +69,7 @@ class TestNetworksNegative:
 
 
 @pytest.mark.p0
+@pytest.mark.smoke
 @pytest.mark.networks
 class TestNetworks:
 

--- a/harvester_e2e_tests/apis/test_settings.py
+++ b/harvester_e2e_tests/apis/test_settings.py
@@ -24,6 +24,7 @@ pytest_plugins = [
 
 
 @pytest.mark.p0
+@pytest.mark.smoke
 @pytest.mark.settings
 def test_get_all_settings(api_client, expected_settings):
     expected_settings = expected_settings['default']
@@ -63,6 +64,7 @@ def test_get_all_settings_v110(api_client, expected_settings):
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.settings
 def test_update_log_level(api_client):
     code, data = api_client.settings.get("log-level")
@@ -80,6 +82,7 @@ def test_update_log_level(api_client):
 
 
 @pytest.mark.p0
+@pytest.mark.smoke
 @pytest.mark.settings
 def test_get_storage_network(api_client):
     code, data = api_client.settings.get("storage-network")
@@ -87,6 +90,7 @@ def test_get_storage_network(api_client):
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.negative
 @pytest.mark.settings
 class TestUpdateInvalidStorageNetwork:
@@ -119,6 +123,7 @@ class TestUpdateInvalidStorageNetwork:
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.negative
 @pytest.mark.settings
 class TestUpdateInvalidBackupTarget:
@@ -165,6 +170,7 @@ class TestUpdateInvalidBackupTarget:
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.settings
 class TestUpdateKubeconfigDefaultToken:
     @pytest.mark.skip_version_before("v1.3.2", reason="Issue#5891 fixed after v1.3.2")

--- a/harvester_e2e_tests/apis/test_support_bundle.py
+++ b/harvester_e2e_tests/apis/test_support_bundle.py
@@ -29,6 +29,7 @@ pytest_plugins = [
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.negative
 @pytest.mark.support_bundle
 class TestSupportBundleNegative:
@@ -46,6 +47,7 @@ class TestSupportBundleNegative:
 
 
 @pytest.mark.p0
+@pytest.mark.smoke
 @pytest.mark.support_bundle
 class TestSupportBundle:
     @pytest.mark.dependency(name="create support bundle")

--- a/harvester_e2e_tests/apis/test_vm_templates.py
+++ b/harvester_e2e_tests/apis/test_vm_templates.py
@@ -29,6 +29,7 @@ DEFAULT_TEMPLATES_NAMESPACE = 'harvester-public'
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.templates
 @pytest.mark.negative
 class TestVMTemplateNegative:
@@ -52,6 +53,7 @@ class TestVMTemplateNegative:
 
 
 @pytest.mark.p0
+@pytest.mark.smoke
 @pytest.mark.templates
 class TestVMTemplate:
     def test_create(self, api_client, unique_name):

--- a/harvester_e2e_tests/apis/test_vms.py
+++ b/harvester_e2e_tests/apis/test_vms.py
@@ -6,6 +6,7 @@ pytest_plugins = [
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.negative
 @pytest.mark.virtualmachines
 class TestVMNegative:

--- a/harvester_e2e_tests/apis/test_volumes.py
+++ b/harvester_e2e_tests/apis/test_volumes.py
@@ -27,6 +27,7 @@ pytest_plugins = [
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.negative
 @pytest.mark.volumes
 class TestVolumesNegative:
@@ -74,6 +75,7 @@ class TestVolumesNegative:
 
 
 @pytest.mark.p0
+@pytest.mark.smoke
 @pytest.mark.volumes
 class TestVolumes:
     def test_create(self, api_client, unique_name):

--- a/harvester_e2e_tests/apis/test_volumes.py
+++ b/harvester_e2e_tests/apis/test_volumes.py
@@ -62,6 +62,7 @@ class TestVolumesNegative:
         assert 422 == code, (code, data)
         assert "Invalid" == data.get("code"), (code, data)
 
+    @pytest.mark.skip_version_if(">= v1.4.0", reason="issue#7030, breaking changes")
     def test_create_without_name(self, api_client):
         """
         1. Tries to create a volume without a name

--- a/harvester_e2e_tests/conftest.py
+++ b/harvester_e2e_tests/conftest.py
@@ -296,6 +296,8 @@ def pytest_configure(config):
             "mark test skipped when cluster version < provided version")),
         ("skip_version_after", (
             "mark test skipped when cluster version >= provided version")),
+        ("smoke", "{_r} smoke testing"),
+        ("sanity", "{_r} sanity testing"),
         ('p0', ("mark the test's priority is p0")),
         ('p1', ("mark the test's priority is p1")),
         ('p2', ("mark the test's priority is p2")),
@@ -326,7 +328,7 @@ def pytest_configure(config):
 
     for m, msg in markers:
         related = 'mark the test is related to'
-        config.addinivalue_line("markers", f"{m}:{msg.format(_r=related)}")
+        config.addinivalue_line("markers", f"{m}: {msg.format(_r=related)}")
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/harvester_e2e_tests/integrations/test_0_storage_network.py
+++ b/harvester_e2e_tests/integrations/test_0_storage_network.py
@@ -75,6 +75,7 @@ def cluster_network(request, api_client, unique_name):
 
 
 @pytest.mark.p0
+@pytest.mark.smoke
 @pytest.mark.settings
 @pytest.mark.networks
 @pytest.mark.skip_version_before('v1.0.3')
@@ -147,6 +148,7 @@ def test_enable_storage_network(
 
 
 @pytest.mark.p0
+@pytest.mark.smoke
 @pytest.mark.settings
 @pytest.mark.networks
 @pytest.mark.skip_version_before('v1.0.3')

--- a/harvester_e2e_tests/integrations/test_1_images.py
+++ b/harvester_e2e_tests/integrations/test_1_images.py
@@ -189,8 +189,9 @@ def storage_network(api_client, cluster_network, vlan_id, vlan_cidr, setting_che
 
 
 @pytest.mark.p0
+@pytest.mark.images
 class TestBackendImages:
-    @pytest.mark.p0
+    @pytest.mark.smoke
     @pytest.mark.dependency(name="create_image_from_volume")
     def test_create_image_from_volume(
         self, api_client, unique_name, export_storage_class, wait_timeout
@@ -252,7 +253,7 @@ class TestBackendImages:
         delete_volume(api_client, volume_name, wait_timeout)
         delete_image(api_client, image_id, wait_timeout)
 
-    @pytest.mark.p0
+    @pytest.mark.smoke
     @pytest.mark.dependency(name="create_image_url")
     def test_create_image_url(self, image_info, unique_name, api_client, wait_timeout):
         """
@@ -270,8 +271,8 @@ class TestBackendImages:
         create_image_url(api_client, image_name, image_url,
                          image_info.image_checksum, wait_timeout)
 
+    @pytest.mark.sanity
     @pytest.mark.skip_version_if("> v1.2.0", "<= v1.4.0", reason="Issue#4293 fix after `v1.4.0`")
-    @pytest.mark.p0
     @pytest.mark.dependency(name="delete_image_recreate", depends=["create_image_url"])
     def test_delete_image_recreate(
         self,
@@ -321,7 +322,8 @@ class TestBackendImages:
         get_image(api_client, unique_name)
         delete_image(api_client, unique_name, wait_timeout)
 
-    @pytest.mark.p0
+    @pytest.mark.sanity
+    @pytest.mark.negative
     def test_create_invalid_file(
         self, api_client, gen_unique_name, fake_invalid_image_file, wait_timeout
     ):
@@ -341,7 +343,8 @@ class TestBackendImages:
         ), f"File size correct, it's a multiple of 512 bytes:{resp.status_code}, {resp.content}"
         delete_image(api_client, unique_name, wait_timeout)
 
-    @pytest.mark.p0
+    @pytest.mark.sanity
+    @pytest.mark.negative
     @pytest.mark.dependency(name="edit_image_in_use", depends=["create_image_url"])
     def test_edit_image_in_use(self, api_client, unique_name, image_info, wait_timeout):
         """
@@ -407,6 +410,10 @@ class TestBackendImages:
 
 
 @pytest.mark.p0
+@pytest.mark.smoke
+@pytest.mark.images
+@pytest.mark.settings
+@pytest.mark.networks
 @pytest.mark.skip_version_if("< v1.0.3")
 @pytest.mark.usefixtures("storage_network")
 class TestImageWithStorageNetwork:

--- a/harvester_e2e_tests/integrations/test_1_volumes.py
+++ b/harvester_e2e_tests/integrations/test_1_volumes.py
@@ -114,6 +114,7 @@ def ubuntu_vm(api_client, unique_name, ubuntu_image, polling_for):
 
 
 @pytest.mark.p0
+@pytest.mark.smoke
 @pytest.mark.volumes
 @pytest.mark.parametrize("create_as", ["json", "yaml"])
 @pytest.mark.parametrize("source_type", ["New", "VM Image"])
@@ -171,6 +172,7 @@ def test_create_volume(api_client, unique_name, ubuntu_image, create_as, source_
 
 
 @pytest.mark.p1
+@pytest.mark.sanity
 @pytest.mark.volumes
 @pytest.mark.negative
 @pytest.mark.parametrize("create_as", ["json", "yaml"])
@@ -221,7 +223,9 @@ def test_create_volume_bad_checksum(api_client, unique_name, ubuntu_image_bad_ch
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.volumes
+@pytest.mark.virtualmachines
 class TestVolumeWithVM:
     def pause_vm(self, api_client, ubuntu_vm, polling_for):
         vm_name = ubuntu_vm['metadata']['name']

--- a/harvester_e2e_tests/integrations/test_3_vm.py
+++ b/harvester_e2e_tests/integrations/test_3_vm.py
@@ -169,6 +169,7 @@ def storage_network(api_client, cluster_network, vm_network, setting_checker):
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.virtualmachines
 def test_multiple_migrations(
     api_client, unique_name, ubuntu_image, wait_timeout, available_node_names
@@ -266,6 +267,7 @@ def test_multiple_migrations(
 
 
 @pytest.mark.p0
+@pytest.mark.smoke
 @pytest.mark.virtualmachines
 def test_migrate_vm_with_user_data(
     api_client, unique_name, ubuntu_image, wait_timeout, available_node_names, vm_checker
@@ -335,6 +337,7 @@ def test_migrate_vm_with_user_data(
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.virtualmachines
 def test_migrate_vm_with_multiple_volumes(
     api_client, unique_name, ubuntu_image, wait_timeout, available_node_names, vm_checker
@@ -398,7 +401,8 @@ def test_migrate_vm_with_multiple_volumes(
             api_client.volumes.delete(vol['volume']['persistentVolumeClaim']['claimName'])
 
 
-@pytest.mark.p0
+@pytest.mark.p1
+@pytest.mark.sanity
 @pytest.mark.networks
 @pytest.mark.settings
 @pytest.mark.virtualmachines

--- a/harvester_e2e_tests/integrations/test_3_vm_functions.py
+++ b/harvester_e2e_tests/integrations/test_3_vm_functions.py
@@ -175,6 +175,7 @@ def unset_cpu_memory_overcommit(api_client):
 
 
 @pytest.mark.p0
+@pytest.mark.smoke
 @pytest.mark.virtualmachines
 @pytest.mark.dependency(name="minimal_vm")
 def test_minimal_vm(api_client, image, unique_vm_name, wait_timeout):
@@ -212,6 +213,7 @@ def test_minimal_vm(api_client, image, unique_vm_name, wait_timeout):
 
 
 @pytest.mark.p0
+@pytest.mark.smoke
 @pytest.mark.virtualmachines
 @pytest.mark.dependency(depends=["minimal_vm"])
 class TestVMOperations:
@@ -584,6 +586,7 @@ class TestVMOperations:
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.virtualmachines
 def test_create_stopped_vm(api_client, stopped_vm, wait_timeout):
     """
@@ -618,6 +621,7 @@ def test_create_stopped_vm(api_client, stopped_vm, wait_timeout):
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.virtualmachines
 class TestVMResource:
     @pytest.mark.parametrize("res_type", ["cpu", "memory"])
@@ -921,6 +925,7 @@ class TestVMResource:
 
 
 @pytest.mark.p0
+@pytest.mark.smoke
 @pytest.mark.virtualmachines
 class TestVMClone:
     def test_clone_running_vm(
@@ -1245,6 +1250,8 @@ class TestVMClone:
 
 
 @pytest.mark.p0
+@pytest.mark.smoke
+@pytest.mark.volumes
 @pytest.mark.virtualmachines
 class TestVMWithVolumes:
     def test_create_with_two_volumes(
@@ -1515,6 +1522,7 @@ class TestVMWithVolumes:
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.virtualmachines
 @pytest.mark.negative
 @pytest.mark.parametrize("resource", [dict(cpu=MAX), dict(mem=MAX), dict(disk=MAX),
@@ -1635,6 +1643,7 @@ def test_create_vm_no_available_resources(resource, api_client, image,
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.virtualmachines
 @pytest.mark.skip_version_if(
     "> v1.3.0", reason="`pc type removed, ref: https://github.com/harvester/harvester/issues/5437"
@@ -1793,6 +1802,7 @@ def test_update_vm_machine_type(
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.negative
 @pytest.mark.virtualmachines
 def test_vm_with_bogus_vlan(api_client, image, unique_vm_name,
@@ -1909,6 +1919,8 @@ def test_vm_with_bogus_vlan(api_client, image, unique_vm_name,
 
 
 @pytest.mark.p0
+@pytest.mark.smoke
+@pytest.mark.wait_volumes_detached
 @pytest.mark.virtualmachines
 class TestHotPlugVolume:
     """

--- a/harvester_e2e_tests/integrations/test_4_vm_backup_restore.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_backup_restore.py
@@ -313,6 +313,7 @@ def base_vm_with_data(
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.backup_target
 @pytest.mark.parametrize(
     "backup_config", [
@@ -640,6 +641,7 @@ class TestBackupRestore:
 
 @pytest.mark.skip("https://github.com/harvester/harvester/issues/1473")
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.backup_target
 @pytest.mark.parametrize(
     "backup_config", [
@@ -745,6 +747,7 @@ class TestBackupRestoreOnMigration:
 
 
 @pytest.mark.p1
+@pytest.mark.sanity
 @pytest.mark.backup_target
 @pytest.mark.parametrize(
     "backup_config", [

--- a/harvester_e2e_tests/integrations/test_4_vm_host_powercycle.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_host_powercycle.py
@@ -117,6 +117,7 @@ def vm_force_reset_policy(api_client):
 
 
 @pytest.mark.hosts
+@pytest.mark.sanity
 @pytest.mark.p1
 class TestHostState:
     @pytest.mark.dependency(name="host_poweroff")
@@ -192,6 +193,7 @@ class TestHostState:
 
 
 @pytest.mark.hosts
+@pytest.mark.smoke
 @pytest.mark.p0
 def test_verify_host_info(api_client):
     status_code, nodes_info = api_client.hosts.get()
@@ -221,7 +223,9 @@ def test_verify_host_info(api_client):
 
 
 @pytest.mark.hosts
+@pytest.mark.smoke
 @pytest.mark.p0
+@pytest.mark.virtualmachines
 def test_maintenance_mode_trigger_vm_migrate(
     api_client, focal_vm, wait_timeout, available_node_names
 ):
@@ -277,7 +281,9 @@ def test_maintenance_mode_trigger_vm_migrate(
 
 
 @pytest.mark.hosts
+@pytest.mark.sanity
 @pytest.mark.p0
+@pytest.mark.virtualmachines
 @pytest.mark.dependency(depends=["host_poweroff", "host_poweron"])
 def test_poweroff_node_trigger_vm_reschedule(
     api_client, host_state, focal_vm, wait_timeout, available_node_names, vm_force_reset_policy
@@ -365,7 +371,9 @@ def test_poweroff_node_trigger_vm_reschedule(
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.hosts
+@pytest.mark.virtualmachines
 @pytest.mark.dependency(depends=["host_poweroff", "host_poweron"])
 def test_delete_vm_after_host_shutdown(
     api_client, host_state, wait_timeout, focal_vm, available_node_names
@@ -479,7 +487,9 @@ def test_delete_vm_after_host_shutdown(
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
 @pytest.mark.hosts
+@pytest.mark.virtualmachines
 @pytest.mark.dependency(depends=["host_poweroff", "host_poweron"])
 def test_vm_restarted_after_host_reboot(
     api_client, host_state, wait_timeout, focal_vm, available_node_names

--- a/harvester_e2e_tests/integrations/test_4_vm_snapshot.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_snapshot.py
@@ -273,6 +273,7 @@ def vm_shell_do(name, api_client, host_shell, vm_shell, user, ssh_keypair, actio
 @pytest.mark.p0
 @pytest.mark.virtualmachines
 class TestVMSnapshot:
+    @pytest.mark.smoke
     @pytest.mark.dependency(name="source_vm_snapshot")
     def test_vm_snapshot_create(self, api_client,
                                 source_vm, vm_snapshot_name,
@@ -315,6 +316,7 @@ class TestVMSnapshot:
         assert 200 == code
         assert data.get("status", {}).get("readyToUse") is True
 
+    @pytest.mark.negative
     @pytest.mark.dependency(depends=["source_vm_snapshot"])
     def test_volume_snapshot_not_exist(self, api_client):
         ''' ref: https://github.com/harvester/tests/issues/524 '''
@@ -323,6 +325,7 @@ class TestVMSnapshot:
         assert 200 == code, (code, data)
         assert not data['data'], (code, data)
 
+    @pytest.mark.smoke
     @pytest.mark.dependency(depends=["source_vm_snapshot"])
     def test_restore_into_new_vm_from_vm_snapshot(self, api_client,
                                                   restored_from_snapshot_vm,
@@ -350,6 +353,7 @@ class TestVMSnapshot:
                     ssh_user, ssh_keypair,
                     actassert, wait_timeout)
 
+    @pytest.mark.negative
     @pytest.mark.dependency(depends=["source_vm_snapshot"])
     def test_replace_is_rejected_when_deletepolicy_is_retain(self, api_client,
                                                              source_vm, vm_snapshot_name,
@@ -378,6 +382,7 @@ class TestVMSnapshot:
         assert wantmsg in reason
         assert 422 == code
 
+    @pytest.mark.smoke
     @pytest.mark.dependency(name="replaced_source_vm", depends=["source_vm_snapshot"])
     def test_replace_vm_with_vm_snapshot(self, api_client,
                                          source_vm, vm_snapshot_name,
@@ -429,6 +434,7 @@ class TestVMSnapshot:
                     ssh_user, ssh_keypair,
                     actassert, wait_timeout)
 
+    @pytest.mark.sanity
     @pytest.mark.dependency(name="detached_source_vm_pvc", depends=["replaced_source_vm"])
     def test_restore_from_vm_snapshot_while_pvc_detached_from_source(self,
                                                                      api_client,
@@ -460,6 +466,7 @@ class TestVMSnapshot:
                     ssh_user, ssh_keypair,
                     actassert, wait_timeout)
 
+    @pytest.mark.sanity
     @pytest.mark.dependency(name="snapshot_created_from_detached_source_vm_pvc",
                             depends=["detached_source_vm_pvc"])
     def test_create_vm_snapshot_while_pvc_detached(self, api_client,
@@ -494,6 +501,7 @@ class TestVMSnapshot:
         assert 200 == code
         assert data.get("status", {}).get("readyToUse") is True
 
+    @pytest.mark.sanity
     @pytest.mark.dependency(name="cleaned_up_after_vm_delete")
     def test_vm_snapshots_are_cleaned_up_after_source_vm_deleted(self, api_client,
                                                                  source_vm, vm_snapshot_name,
@@ -531,6 +539,7 @@ class TestVMSnapshot:
 
         wait_for_snapshot_to_disappear(vm_snapshot_name)
 
+    @pytest.mark.sanity
     @pytest.mark.dependency(depends=["snapshot_created_from_detached_source_vm_pvc",
                                      "cleaned_up_after_vm_delete"])
     def test_volume_snapshots_are_cleaned_up_after_source_volume_deleted(self, api_client,

--- a/harvester_e2e_tests/integrations/test_4_vm_template.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_template.py
@@ -71,6 +71,10 @@ def stopped_vm(api_client, ssh_keypair, wait_timeout, image, unique_name):
         api_client.volumes.delete(vol_name)
 
 
+@pytest.mark.p0
+@pytest.mark.smoke
+@pytest.mark.templates
+@pytest.mark.virtualmachines
 class TestVMTemplate:
     def test_create_template_with_data(
         self, api_client, vm_shell_from_host, vm_checker, ssh_keypair, wait_timeout, stopped_vm

--- a/harvester_e2e_tests/integrations/test_5_vm_networks.py
+++ b/harvester_e2e_tests/integrations/test_5_vm_networks.py
@@ -215,6 +215,7 @@ def two_mirror_vms(api_client, ssh_keypair, unique_name, vm_checker, image, vm_n
 @pytest.mark.networks
 @pytest.mark.virtualmachines
 class TestVMNetwork:
+    @pytest.mark.sanity
     @pytest.mark.dependency(name="add_vlan")
     def test_add_vlan(
         self, api_client, ssh_keypair, vm_mgmt_static, vm_checker, vm_shell_from_host, vm_network,
@@ -292,6 +293,7 @@ class TestVMNetwork:
                           if iface['name'] != 'default')
         assert ip_address(vm_vlan_ip) in vlan_ip_range and vm_vlan_ip in ips
 
+    @pytest.mark.smoke
     @pytest.mark.dependency(depends=["add_vlan"])
     def test_ssh_connection(
         self, api_client, ssh_keypair, vm_checker, vm_network, minimal_vm
@@ -316,6 +318,7 @@ class TestVMNetwork:
                 f"Unable to login to VM via VLAN IP {vm_ip}"
             ) from ex
 
+    @pytest.mark.sanity
     def test_vms_on_same_vlan(
         self, api_client, ssh_keypair, vm_checker, vm_network, two_mirror_vms
     ):

--- a/harvester_e2e_tests/integrations/test_5_vm_networks_interact.py
+++ b/harvester_e2e_tests/integrations/test_5_vm_networks_interact.py
@@ -209,11 +209,10 @@ def check_vm_ip_exists(api_client, vm_name, wait_timeout):
 
 
 @pytest.mark.p0
+@pytest.mark.sanity
+@pytest.mark.virtualmachines
 @pytest.mark.networks
 class TestBackendNetwork:
-
-    @pytest.mark.p0
-    @pytest.mark.networks
     def test_mgmt_network_connection(
         self, api_client, request, client, image_opensuse, unique_name, wait_timeout,
         host_shell, vm_shell_from_host, vm_checker
@@ -309,8 +308,6 @@ class TestBackendNetwork:
             vol_name = vol['volume']['persistentVolumeClaim']['claimName']
             api_client.volumes.delete(vol_name)
 
-    @pytest.mark.p0
-    @pytest.mark.networks
     @pytest.mark.dependency(name="vlan_network_connection")
     def test_vlan_network_connection(self, api_client, request, client, unique_name,
                                      image_opensuse, vm_network, wait_timeout, vm_checker):
@@ -393,8 +390,6 @@ class TestBackendNetwork:
             vol_name = vol['volume']['persistentVolumeClaim']['claimName']
             api_client.volumes.delete(vol_name)
 
-    @pytest.mark.p0
-    @pytest.mark.networks
     @pytest.mark.dependency(name="reboot_vlan_connection",
                             depends=["vlan_network_connection"])
     def test_reboot_vlan_connection(self, api_client, request, unique_name,
@@ -540,8 +535,6 @@ class TestBackendNetwork:
             vol_name = vol['volume']['persistentVolumeClaim']['claimName']
             api_client.volumes.delete(vol_name)
 
-    @pytest.mark.p0
-    @pytest.mark.networks
     def test_mgmt_to_vlan_connection(self, api_client, request, client, unique_name,
                                      image_opensuse, vm_network, wait_timeout, vm_checker):
         """
@@ -672,8 +665,6 @@ class TestBackendNetwork:
             vol_name = vol['volume']['persistentVolumeClaim']['claimName']
             api_client.volumes.delete(vol_name)
 
-    @pytest.mark.p0
-    @pytest.mark.networks
     def test_vlan_to_mgmt_connection(
         self, api_client, request, client, unique_name, image_opensuse, vm_network, wait_timeout,
         host_shell, vm_shell_from_host, vm_checker
@@ -803,8 +794,6 @@ class TestBackendNetwork:
             vol_name = vol['volume']['persistentVolumeClaim']['claimName']
             api_client.volumes.delete(vol_name)
 
-    @pytest.mark.p0
-    @pytest.mark.networks
     def test_delete_vlan_from_multiple(
         self, api_client, request, client, unique_name, image_opensuse, vm_network, wait_timeout,
         host_shell, vm_checker


### PR DESCRIPTION
## Changes
- **Add** new marker: smoke, sanity
- **Update** existing test cases to add smoke/sanity marker
- **Update** some test cases' priority
- **Remove** unnecessary markers
- **Update** HarvesterAPI to support sprint release version
- **Update** volume test case `test_create_without_name` to skip after `v1.4`

#### Which issue(s) this PR fixes:
Issue #2016

#### What this PR does / why we need it:
To improve release testing
