### PR TITLE
feat: add harvester-version for self built Harvester testing

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2,6 +2,10 @@
 endpoint: 'https://localhost'
 username: 'admin'
 password: 'password1234'
+# Default is empty because released Harvester version always has a version.
+# In self built Harvester, you can set this to the specific version to skip the test cases.
+# Otherwise, in self built Harvester, it's a dirty commit (like <commit_hash>) which the `skip_version_if` check will fail to check.
+harvester-version: ''
 # Be used to access Harvester node, fill in one of following is enough.
 host-password: ''
 host-private-key: ''

--- a/harvester_e2e_tests/conftest.py
+++ b/harvester_e2e_tests/conftest.py
@@ -71,6 +71,12 @@ def pytest_addoption(parser):
         help='Harvester password'
     )
     parser.addoption(
+        '--harvester-version',
+        action='store',
+        default=config_data['harvester-version'],
+        help='Harvester version to run tests against'
+    )
+    parser.addoption(
         '--host-password',
         action='store',
         default=config_data['host-password'],

--- a/harvester_e2e_tests/fixtures/api_client.py
+++ b/harvester_e2e_tests/fixtures/api_client.py
@@ -38,14 +38,15 @@ def api_client(request, harvester_metadata):
     username = request.config.getoption("--username")
     password = request.config.getoption("--password")
     ssl_verify = request.config.getoption("--ssl_verify", False)
+    harvester_version = request.config.getoption("--harvester-version", "")
 
-    api = HarvesterAPI(endpoint)
+    api = HarvesterAPI(endpoint, version=harvester_version)
     api.authenticate(username, password, verify=ssl_verify)
-
     api.session.verify = ssl_verify
 
     harvester_metadata['Cluster Endpoint'] = endpoint
     harvester_metadata['Cluster Version'] = api.cluster_version.raw
+    harvester_metadata['Harvester Version (config)'] = harvester_version
 
     return api
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue https://github.com/harvester/harvester/issues/6558

#### What this PR does / why we need it:

When testing self built Harvester, `skip_version_if` will fail to check. Hence, I add a new config to fake it for convenience.

For example, because self built Harvester has dirty commit which is just a commit hash, not a version `v1.x.x`, we can give a custom version.

#### Special notes for your reviewer:

#### Additional documentation or context
