### PR TITLE
[apiclient] add customized build version detection

### DIFF
--- a/apiclient/harvester_api/api.py
+++ b/apiclient/harvester_api/api.py
@@ -52,7 +52,12 @@ class HarvesterAPI:
                 cur = "v8.8" if "master" in cur else cur
                 self._version = parse_version(f"{cur}.99")
             except ValueError:
-                self._version = parse_version(ver)
+                # 1. va.b.c => valid version
+                # 2. 3874194f-dirty (customized build)
+                #   Use KubeVirt version as the customized version
+                data = self._get('apis/kubevirt.io/v1/kubevirts').json()
+                kube_ver = data['items'][0]['status'].get('operatorVersion')
+                self._version = parse_version(kube_ver if '-' in ver else ver)
             # store the raw version returns from `server-version` for reference
             self._version.raw = ver
         return self._version


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue #2064

#### What this PR does / why we need it:
let KubeVirt's version be the customized build's version, it might not be 100% correct, but close to.

this would fix #2064 directly.