### PR TITLE
[e2e] fix bugs appeared when testing on arm environment

### DIFF
--- a/harvester_e2e_tests/fixtures/virtualmachines.py
+++ b/harvester_e2e_tests/fixtures/virtualmachines.py
@@ -307,7 +307,8 @@ def vm_checker(api_client, wait_timeout, sleep_timeout, vm_shell):
             def cb(ctx):
                 if ctx.callee == 'vm.start':
                     return callback(ctx)
-                ifaces = {d['name']: d for d in ctx.data.get('status', {}).get('interfaces', {})}
+                ifaces = {d['name']: d for d in ctx.data.get('status', {}).get('interfaces', {})
+                          if 'name' in d}
                 return (
                     all(ifaces.get(name, {}).get('ipAddress') for name in ifnames)
                     and callback(ctx)

--- a/harvester_e2e_tests/integrations/test_1_images.py
+++ b/harvester_e2e_tests/integrations/test_1_images.py
@@ -113,7 +113,7 @@ def get_image(api_client, image_name):
 @pytest.fixture(scope="class")
 def cluster_network(api_client, vlan_nic):
     # We should change this at some point. It fails if the total cnet name is over 12 chars
-    cnet = f"cnet-{vlan_nic}"
+    cnet = f"cnet-{vlan_nic.lower()}"[:12]  # ???: RFC1123 and length limits
     code, data = api_client.clusternetworks.get(cnet)
     if code != 200:
         code, data = api_client.clusternetworks.create(cnet)

--- a/harvester_e2e_tests/integrations/test_3_vm.py
+++ b/harvester_e2e_tests/integrations/test_3_vm.py
@@ -66,7 +66,7 @@ def available_node_names(api_client):
 
 @pytest.fixture(scope="class")
 def cluster_network(api_client, vlan_nic):
-    name = f"cnet-{vlan_nic}"
+    name = f"cnet-{vlan_nic.lower()}"[:12]  # ???: RFC1123 and length limits
     code, data = api_client.clusternetworks.create(name)
     assert 201 == code, (code, data)
     code, data = api_client.clusternetworks.create_config(name, name, vlan_nic)

--- a/harvester_e2e_tests/integrations/test_4_vm_snapshot.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_snapshot.py
@@ -376,8 +376,7 @@ class TestVMSnapshot:
 
         reason = data.get("message")
 
-        wantmsg = "Delete policy with backup type snapshot"
-        " for replacing VM is not supported"
+        wantmsg = "policy with backup type snapshot for replacing VM is not supported"
 
         assert wantmsg in reason
         assert 422 == code


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
1. interface naming: `name` field might not available for the interface that connect as `guest agent`
<img width="1149" height="238" alt="image" src="https://github.com/user-attachments/assets/819dbafb-0071-4c86-87b8-c809d4010d16" />
<img width="1149" height="303" alt="image" src="https://github.com/user-attachments/assets/9a524f05-4e14-4ba6-ac9d-9b02fc3d6c6c" />

2. naming of VLAN nic might hit the RFC1123
<img width="1337" height="316" alt="image" src="https://github.com/user-attachments/assets/165cfce7-eee2-4762-ab3c-63b117059c56" />

3. Error message of snapshot been changed to use lower case
<img width="1611" height="316" alt="image" src="https://github.com/user-attachments/assets/61048c1c-410c-4c96-80dd-c9c9b6f90248" />

