### PR TITLE
[e2e] fix test_update_schedule_on_maximum[cpu] fails due to 409 case

### DIFF
--- a/harvester_e2e_tests/integrations/test_3_vm_functions.py
+++ b/harvester_e2e_tests/integrations/test_3_vm_functions.py
@@ -698,6 +698,7 @@ class TestVMResource:
         code, data = api_client.vms.get(unique_vm_name)
         vm_spec = api_client.vms.Spec.from_dict(data)
         vm_spec.cpu_cores, vm_spec.memory = 1, 2
+        sleep(1) # to prevent update too fast cause code 409 conflict: 'object has been modified'
         code, data = api_client.vms.update(unique_vm_name, vm_spec)
         assert 200 == code, (code, data)
 

--- a/harvester_e2e_tests/integrations/test_3_vm_functions.py
+++ b/harvester_e2e_tests/integrations/test_3_vm_functions.py
@@ -698,7 +698,7 @@ class TestVMResource:
         code, data = api_client.vms.get(unique_vm_name)
         vm_spec = api_client.vms.Spec.from_dict(data)
         vm_spec.cpu_cores, vm_spec.memory = 1, 2
-        sleep(1) # to prevent update too fast cause code 409 conflict: 'object has been modified'
+        sleep(1)  # to prevent update too fast cause code 409 conflict: 'object has been modified'
         code, data = api_client.vms.update(unique_vm_name, vm_spec)
         assert 200 == code, (code, data)
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
No issue id, but the [test_update_schedule_on_maximum[cpu]](http://10.115.1.7/job/harvester-runtests/84/TestReport/) failed due to `AssertionError: (409, {'code': 'Conflict', 'links': {}, 'message': 'Operation cannot be fulfilled on virtualmachines.kubevirt.io "stop...05": the object has been modified; please apply your changes to the latest version and try again', 'status': 409, ...})`, which can be avoid by add sleep.

#### What this PR does / why we need it:
* To prevent update too fast cause code 409 conflict: `object has been modified`

