### PR TITLE
[e2e]: fix support bundle testing dependency

### DIFF
--- a/harvester_e2e_tests/apis/test_support_bundle.py
+++ b/harvester_e2e_tests/apis/test_support_bundle.py
@@ -155,7 +155,7 @@ class TestSupportBundle:
         finally:
             support_bundle_state.fio.seek(0)
 
-    @pytest.mark.dependency(depends=["donwnload support bundle"])
+    @pytest.mark.dependency(depends=["download support bundle"])
     def test_secret_file_exists(self, support_bundle_state):
         ''' ref: https://github.com/harvester/tests/issues/603 '''
         pattern = r"^.*/yamls/namespaced/fleet-local/v1/secrets\.yaml"
@@ -184,7 +184,7 @@ class TestSupportBundle:
             f"{fails}"
         )
 
-    @pytest.mark.dependency(depends=["donwnload support bundle"])
+    @pytest.mark.dependency(depends=["download support bundle"])
     def test_hardware_info_exists(self, support_bundle_state):
         ''' ref: https://github.com/harvester/tests/issues/569 '''
         nodes, pattern = [], r"^.*/nodes/.*.zip"


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue #2177

#### What this PR does / why we need it:

I found out that we actually have tests to check support config file, but we used wrong keyword. So, it has been skipping those two test cases.

#### Special notes for your reviewer:

Before:
```sh
collected 8 items

harvester_e2e_tests/apis/test_support_bundle.py::TestSupportBundle::test_create PASSED
harvester_e2e_tests/apis/test_support_bundle.py::TestSupportBundle::test_get PASSED
harvester_e2e_tests/apis/test_support_bundle.py::TestSupportBundle::test_download PASSED
harvester_e2e_tests/apis/test_support_bundle.py::TestSupportBundle::test_logfile_exists PASSED
harvester_e2e_tests/apis/test_support_bundle.py::TestSupportBundle::test_plan_secrets_exists PASSED
harvester_e2e_tests/apis/test_support_bundle.py::TestSupportBundle::test_secret_file_exists SKIPPED
harvester_e2e_tests/apis/test_support_bundle.py::TestSupportBundle::test_hardware_info_exists SKIPPED
harvester_e2e_tests/apis/test_support_bundle.py::TestSupportBundle::test_delete PASSED
===================== 6 passed, 2 skipped, 4 warnings in 81.47s (0:01:21) =====================
```

After:
```sh
collected 8 items

harvester_e2e_tests/apis/test_support_bundle.py::TestSupportBundle::test_create PASSED
harvester_e2e_tests/apis/test_support_bundle.py::TestSupportBundle::test_get PASSED
harvester_e2e_tests/apis/test_support_bundle.py::TestSupportBundle::test_download PASSED
harvester_e2e_tests/apis/test_support_bundle.py::TestSupportBundle::test_logfile_exists PASSED
harvester_e2e_tests/apis/test_support_bundle.py::TestSupportBundle::test_plan_secrets_exists PASSED
harvester_e2e_tests/apis/test_support_bundle.py::TestSupportBundle::test_secret_file_exists PASSED
harvester_e2e_tests/apis/test_support_bundle.py::TestSupportBundle::test_hardware_info_exists PASSED
harvester_e2e_tests/apis/test_support_bundle.py::TestSupportBundle::test_delete PASSED
========================== 8 passed, 4 warnings in 81.18s (0:01:21) ===========================
```

#### Additional documentation or context

