### PR TITLE
Revert "DHCP addon test fixes" the CRDs 

### DIFF
--- a/harvester_e2e_tests/integrations/test_9_rancher_integration.py
+++ b/harvester_e2e_tests/integrations/test_9_rancher_integration.py
@@ -421,7 +421,7 @@ class TestResourceQuota:
         assert 200 == code, (code, data)
 
         ns_quota = loads(data['metadata']['annotations']['field.cattle.io/resourceQuota'])['limit']
-        ns_quota['limitsCpu'] = f"{(cpu - 1) * 1000}m"
+        ns_quota['limitsCpu'] = f"{(cpu -1) * 1000}m"
         anno = {'field.cattle.io/resourceQuota': dumps({"limit": ns_quota})}
         rancher_api_client.set_retries(status_forcelist=(502, 504))
         code, data = ns_mgr.update(unique_name, dict(annotations=anno))


### PR DESCRIPTION
Reverts harvester/tests#2310

It turns out that there were two CRDs that were named IPPool. Also the vmdhcp server logic doesn't have any UI yet so that was why the original CRDs weren't showing up in the IPPool UI section on Harvester. Reverting back and we can validate this later with the environment.