### PR TITLE
Use wait_status_stopped to avoid race condition

### DIFF
--- a/harvester_e2e_tests/integrations/test_3_vm_functions.py
+++ b/harvester_e2e_tests/integrations/test_3_vm_functions.py
@@ -699,12 +699,12 @@ class TestVMResource:
         unique_vm_name, ssh_user = stopped_vm
 
         # make sure VM stopped and configure as minimal resource
-        vm_stopped, (code, data) = vm_checker.wait_stopped(unique_vm_name)
+        vm_stopped, (code, data) = vm_checker.wait_status_stopped(unique_vm_name)
         assert vm_stopped, (code, data)
+        sleep(1)  # to avoid code 409 conflict: 'object has been modified'
         code, data = api_client.vms.get(unique_vm_name)
         vm_spec = api_client.vms.Spec.from_dict(data)
         vm_spec.cpu_cores, vm_spec.memory = 1, 2
-        sleep(1)  # to prevent update too fast cause code 409 conflict: 'object has been modified'
         code, data = api_client.vms.update(unique_vm_name, vm_spec)
         assert 200 == code, (code, data)
 


### PR DESCRIPTION
1. Use wait_status_stopped to avoid race condition
2. Move sleep before vms.get, which is the correct location to avoid 409 conflict

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #2285

#### What this PR does / why we need it:
To avoid test cases fail due to the race condition

#### Special notes for your reviewer:

#### Additional documentation or context
