### PR TITLE
Add dependency info of cleaned_up_after_vm_delete

### DIFF
--- a/harvester_e2e_tests/integrations/test_4_vm_snapshot.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_snapshot.py
@@ -501,7 +501,8 @@ class TestVMSnapshot:
         assert data.get("status", {}).get("readyToUse") is True
 
     @pytest.mark.sanity
-    @pytest.mark.dependency(name="cleaned_up_after_vm_delete")
+    @pytest.mark.dependency(name="cleaned_up_after_vm_delete",
+                            depends=["source_vm_snapshot"])
     def test_vm_snapshots_are_cleaned_up_after_source_vm_deleted(self, api_client,
                                                                  source_vm, vm_snapshot_name,
                                                                  wait_timeout):


### PR DESCRIPTION
Add the dependency info of cleaned_up_after_vm_delete, to avoid unexpected failure in test reports

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
No Issue

#### What this PR does / why we need it:
With this PR, we won't see the test fail due to the dependency doesn't run
