### PR TITLE
Modify key size to 4096 to fix auth issue

### DIFF
--- a/harvester_e2e_tests/fixtures/api_client.py
+++ b/harvester_e2e_tests/fixtures/api_client.py
@@ -122,7 +122,7 @@ def gen_unique_name():
 def ssh_keypair():
     private_key = asymmetric.rsa.generate_private_key(
         public_exponent=65537,
-        key_size=1024,
+        key_size=4096,
         backend=backends.default_backend()
     )
     private_key_pem = private_key.private_bytes(


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
No issue

#### What this PR does / why we need it:
Run the automation in local with key size 1024, the test will fail due to Authentication failed.
<img width="1187" height="424" alt="image" src="https://github.com/user-attachments/assets/c3a6e4f9-3e22-4aa0-99d7-9cab47cb2042" />

After change the key size to 4096, the issue is gone.
<img width="1187" height="424" alt="image" src="https://github.com/user-attachments/assets/b9af2b4b-4d29-43c5-b436-b208c0450ac5" />


