### PR TITLE
Show extra info for Skipped (include XFailed) cases

### DIFF
--- a/harvester_e2e_tests/apis/test_images.py
+++ b/harvester_e2e_tests/apis/test_images.py
@@ -192,7 +192,9 @@ class TestImages:
                 f"Still got {code} with {data}"
             )
 
-    @pytest.mark.skip_version_if("> v1.2.0", "<= v1.4.0", reason="Issue#4293 fix after `v1.4.0`")
+    @pytest.mark.skip_version_if(
+            "> v1.2.0", "<= v1.4.0",
+            reason="https://github.com/harvester/harvester/issues/4293 fix after `v1.4.0`")
     @pytest.mark.dependency(depends=["create_image", "get_image", "delete_image"])
     @parametrize_with_cases("unique_name", cases=CasesImages, has_tag='unique-name')
     def test_create_with_reuse_display_name(

--- a/harvester_e2e_tests/apis/test_networks.py
+++ b/harvester_e2e_tests/apis/test_networks.py
@@ -46,7 +46,8 @@ class TestNetworksNegative:
         assert "NotFound" == data.get("reason"), (code, data)
 
     @pytest.mark.parametrize("vlan_id", [0, 4095])
-    @pytest.mark.skip_version_after("v1.0.3")  # ref to harvester/issues/3151
+    @pytest.mark.skip_version_if(
+            ">= v1.0.3", reason="https://github.com/harvester/harvester/issues/3151")
     def test_create_with_invalid_id_103(self, api_client, unique_name, vlan_id):
         code, data = api_client.networks.create(unique_name, vlan_id)
 
@@ -60,7 +61,8 @@ class TestNetworksNegative:
         assert "Invalid" == data.get("reason"), (code, data)
 
     @pytest.mark.parametrize("vlan_id", [4095])
-    @pytest.mark.skip_version_before("v1.1.0")  # ref to harvester/issues/3151
+    @pytest.mark.skip_version_if(
+            "< v1.1.0", reason="https://github.com/harvester/harvester/issues/3151")
     def test_create_with_invalid_id(self, api_client, unique_name, vlan_id):
         code, data = api_client.networks.create(unique_name, vlan_id)
 
@@ -74,13 +76,14 @@ class TestNetworksNegative:
 class TestNetworks:
 
     @pytest.mark.dependency(name="create_network_103")
-    @pytest.mark.skip_version_after("v1.0.3")
+    @pytest.mark.skip_version_if(">= v1.0.3")
     def test_create_103(self, api_client, unique_name):
         code, data = api_client.networks.create(unique_name, VLAN_ID)
         assert 201 == code, (code, data)
 
     @pytest.mark.dependency(name="create_network")
-    @pytest.mark.skip_version_before("v1.1.0")
+    @pytest.mark.skip_version_if(
+            "< v1.1.0", reason="https://github.com/harvester/harvester/issues/3151")
     def test_create(self, api_client, unique_name):
         code, data = api_client.networks.create(unique_name, VLAN_ID, cluster_network='mgmt')
         assert 201 == code, (code, data)

--- a/harvester_e2e_tests/apis/test_settings.py
+++ b/harvester_e2e_tests/apis/test_settings.py
@@ -41,7 +41,7 @@ def test_get_all_settings(api_client, expected_settings):
 
 @pytest.mark.p0
 @pytest.mark.settings
-@pytest.mark.skip_version_before('v1.1.0')
+@pytest.mark.skip_version_if("< v1.1.0")
 def test_get_all_settings_v110(api_client, expected_settings):
     expected_settings = expected_settings['default'] | expected_settings['1.1.0']
     code, data = api_client.settings.get()
@@ -173,7 +173,9 @@ class TestUpdateInvalidBackupTarget:
 @pytest.mark.sanity
 @pytest.mark.settings
 class TestUpdateKubeconfigDefaultToken:
-    @pytest.mark.skip_version_before("v1.3.2", reason="Issue#5891 fixed after v1.3.2")
+    @pytest.mark.skip_version_if(
+            "< v1.3.2",
+            reason="https://github.com/harvester/harvester/issues/5891 fixed after v1.3.2")
     def test_invalid_kubeconfig_ttl_min(self, api_client):
         KubeconfigTTLMinSpec = api_client.settings.KubeconfigDefaultTokenTTLSpec.TTL
         spec = KubeconfigTTLMinSpec(99999999999999)
@@ -183,7 +185,7 @@ class TestUpdateKubeconfigDefaultToken:
             f"API Status({code}): {data}"
         )
 
-    @pytest.mark.skip_version_before('v1.3.1')
+    @pytest.mark.skip_version_if("< v1.3.1")
     def test_valid_kubeconfig_ttl_min(self, api_client):
         KubeconfigTTLMinSpec = api_client.settings.KubeconfigDefaultTokenTTLSpec.TTL
         spec = KubeconfigTTLMinSpec(172800)

--- a/harvester_e2e_tests/apis/test_support_bundle.py
+++ b/harvester_e2e_tests/apis/test_support_bundle.py
@@ -239,7 +239,8 @@ class TestSupportBundle:
 @pytest.mark.sanity
 @pytest.mark.negative
 @pytest.mark.support_bundle
-@pytest.mark.skip_version_if("< v1.6.0", reason="Issue#7835 new feature in v1.6.0")
+@pytest.mark.skip_version_if(
+    "< v1.6.0", reason="https://github.com/harvester/harvester/issues/7835 new feature in v1.6.0")
 class TestSupportBundleInvalidExtraCollectionNamespaces:
     def test_create_invalid_extra_collection_namespaces(
         self, api_client, unique_name, support_bundle_state
@@ -275,7 +276,8 @@ class TestSupportBundleInvalidExtraCollectionNamespaces:
 @pytest.mark.p0
 @pytest.mark.smoke
 @pytest.mark.support_bundle
-@pytest.mark.skip_version_if("< v1.6.0", reason="Issue#7835 new feature in v1.6.0")
+@pytest.mark.skip_version_if(
+    "< v1.6.0", reason="https://github.com/harvester/harvester/issues/7835 new feature in v1.6.0")
 class TestSupportBundleTimeout:
     @pytest.mark.dependency(name="create support bundle")
     def test_create(self, api_client, unique_name, support_bundle_state):
@@ -308,7 +310,8 @@ class TestSupportBundleTimeout:
 @pytest.mark.p0
 @pytest.mark.smoke
 @pytest.mark.support_bundle
-@pytest.mark.skip_version_if("< v1.6.0", reason="Issue#7835 new feature in v1.6.0")
+@pytest.mark.skip_version_if(
+    "< v1.6.0", reason="https://github.com/harvester/harvester/issues/7835 new feature in v1.6.0")
 class TestSupportBundleExpiration:
     @pytest.mark.dependency(name="create support bundle")
     def test_create(self, api_client, unique_name, support_bundle_state):
@@ -341,7 +344,8 @@ class TestSupportBundleExpiration:
 @pytest.mark.p0
 @pytest.mark.smoke
 @pytest.mark.support_bundle
-@pytest.mark.skip_version_if("< v1.6.0", reason="Issue#7835 new feature in v1.6.0")
+@pytest.mark.skip_version_if(
+    "< v1.6.0", reason="https://github.com/harvester/harvester/issues/7835 new feature in v1.6.0")
 class TestSupportBundleExtraNamespaces:
     @pytest.mark.dependency(name="create support bundle")
     def test_create(self, api_client, unique_name, support_bundle_state):

--- a/harvester_e2e_tests/apis/test_volumes.py
+++ b/harvester_e2e_tests/apis/test_volumes.py
@@ -62,7 +62,9 @@ class TestVolumesNegative:
         assert 422 == code, (code, data)
         assert "Invalid" == data.get("code"), (code, data)
 
-    @pytest.mark.skip_version_if(">= v1.4.0", reason="issue#7030, breaking changes")
+    @pytest.mark.skip_version_if(
+            ">= v1.4.0",
+            reason="https://github.com/harvester/harvester/issues/7030, breaking changes")
     def test_create_without_name(self, api_client):
         """
         1. Tries to create a volume without a name

--- a/harvester_e2e_tests/integrations/test_0_storage_network.py
+++ b/harvester_e2e_tests/integrations/test_0_storage_network.py
@@ -78,7 +78,7 @@ def cluster_network(request, api_client, unique_name):
 @pytest.mark.smoke
 @pytest.mark.settings
 @pytest.mark.networks
-@pytest.mark.skip_version_before('v1.0.3')
+@pytest.mark.skip_version_if("< v1.0.3")
 def test_enable_storage_network(
     api_client, cluster_network, vlan_id, unique_name, wait_timeout,
     setting_checker, network_checker
@@ -151,7 +151,7 @@ def test_enable_storage_network(
 @pytest.mark.smoke
 @pytest.mark.settings
 @pytest.mark.networks
-@pytest.mark.skip_version_before('v1.0.3')
+@pytest.mark.skip_version_if("< v1.0.3")
 def test_disable_storage_network(api_client, setting_checker):
     disable_spec = api_client.settings.StorageNetworkSpec.disable()
     code, data = api_client.settings.update('storage-network', disable_spec)

--- a/harvester_e2e_tests/integrations/test_1_images.py
+++ b/harvester_e2e_tests/integrations/test_1_images.py
@@ -275,7 +275,9 @@ class TestBackendImages:
                          image_info.image_checksum, wait_timeout)
 
     @pytest.mark.sanity
-    @pytest.mark.skip_version_if("> v1.2.0", "<= v1.4.0", reason="Issue#4293 fix after `v1.4.0`")
+    @pytest.mark.skip_version_if(
+        "> v1.2.0", "<= v1.4.0",
+        reason="https://github.com/harvester/harvester/issues/4293 fix after `v1.4.0`")
     @pytest.mark.dependency(name="delete_image_recreate", depends=["create_image_url"])
     def test_delete_image_recreate(
         self,
@@ -877,6 +879,8 @@ class TestImageEnhancements:
         delete_image(api_client, original_image, wait_timeout)
         delete_image(api_client, exported_image_id, wait_timeout)
 
+    @pytest.mark.skip_version_if(
+            ">= v1.7.0", "< v1.9.0", reason="https://github.com/harvester/harvester/issues/9515")
     @pytest.mark.p1
     @pytest.mark.images
     @pytest.mark.negative

--- a/harvester_e2e_tests/integrations/test_1_volumes.py
+++ b/harvester_e2e_tests/integrations/test_1_volumes.py
@@ -266,8 +266,10 @@ def test_delete_volume_when_exporting(api_client, unique_name, ubuntu_image, pol
     {"size": "0Gi", "error_msg": "must be greater than zero"},
     {"size": "-5Gi", "error_msg": "must be greater than zero"},
     {"size": "invalid_size", "error_msg": "quantities must match"},
-    {"size": "999999Ti", "error_msg": "exceeds cluster capacity"},
-    ],
+    pytest.param(
+        {"size": "999999Ti", "error_msg": "exceeds cluster capacity"},
+        marks=pytest.mark.xfail(reason="https://github.com/harvester/harvester/issues/9268")
+    )],
     ids=['zero_size', 'negative_size', 'not_number', 'too_large_size'])
 def test_create_volume_invalid_specifications(api_client, gen_unique_name, invalid_spec):
     """

--- a/harvester_e2e_tests/integrations/test_3_vm_functions.py
+++ b/harvester_e2e_tests/integrations/test_3_vm_functions.py
@@ -1653,11 +1653,9 @@ def test_create_vm_no_available_resources(resource, api_client, image,
 @pytest.mark.sanity
 @pytest.mark.virtualmachines
 @pytest.mark.skip_version_if(
-    "> v1.3.0", reason="`pc type removed, ref: https://github.com/harvester/harvester/issues/5437"
-)
+    "> v1.3.0", reason="`pc type removed, ref: https://github.com/harvester/harvester/issues/5437")
 @pytest.mark.parametrize(
-    "machine_types", [("q35", "pc"), ("pc", "q35")], ids=['q35_to_pc', 'pc_to_q35']
-)
+    "machine_types", [("q35", "pc"), ("pc", "q35")], ids=['q35_to_pc', 'pc_to_q35'])
 def test_update_vm_machine_type(
     api_client, image, unique_vm_name, wait_timeout, machine_types, sleep_timeout
 ):

--- a/harvester_e2e_tests/integrations/test_4_vm_backup_restore.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_backup_restore.py
@@ -639,7 +639,7 @@ class TestBackupRestore:
         )
 
 
-@pytest.mark.skip("https://github.com/harvester/harvester/issues/1473")
+@pytest.mark.xfail(reason="https://github.com/harvester/harvester/issues/1473")
 @pytest.mark.p0
 @pytest.mark.sanity
 @pytest.mark.backup_target

--- a/harvester_e2e_tests/integrations/test_4_vm_host_cpu_pinning.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_host_cpu_pinning.py
@@ -240,6 +240,8 @@ class TestPinCPUonVM:
             f"API Status({code}): {data}"
         )
 
+    @pytest.mark.skip_version_if(
+            ">= v1.7.0", "< v1.8.0", reason="https://github.com/harvester/harvester/issues/9557")
     @pytest.mark.negative
     @pytest.mark.dependency(depends=["pin_cpu_on_vm"])
     def test_disable_cpu_manager_when_vm_on_it(self, api_client, unique_name, wait_timeout):

--- a/harvester_e2e_tests/integrations/test_4_vm_host_powercycle.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_host_powercycle.py
@@ -101,6 +101,8 @@ def vm_force_reset_policy(api_client):
 @pytest.mark.sanity
 @pytest.mark.p1
 class TestHostState:
+    @pytest.mark.skip_version_if(
+        ">= v1.7.0", "< v1.8.0", reason="https://github.com/harvester/harvester/issues/9759")
     @pytest.mark.dependency(name="host_poweroff")
     def test_poweroff_state(self, api_client, host_state, wait_timeout, available_node_names):
         """

--- a/harvester_e2e_tests/integrations/test_upgrade.py
+++ b/harvester_e2e_tests/integrations/test_upgrade.py
@@ -409,7 +409,9 @@ def stopped_vm(request, api_client, ssh_keypair, wait_timeout, unique_name, imag
 @pytest.mark.negative
 @pytest.mark.any_nodes
 class TestInvalidUpgrade:
-    @pytest.mark.skip_version_if("< v1.5.0", reason="Issue#7654 fix after `v1.5.0`")
+    @pytest.mark.skip_version_if(
+            "< v1.5.0",
+            reason="https://github.com/harvester/harvester/issues/7654 fix after `v1.5.0`")
     def test_iso_url(self, api_client, unique_name, upgrade_checker):
         """
         Steps:
@@ -439,10 +441,11 @@ class TestInvalidUpgrade:
         api_client.upgrades.delete(upgrade_name)
         api_client.versions.delete(version)
 
-    @pytest.mark.skip_version_if("< v1.5.0", reason="Issue#7654 fix after `v1.5.0`")
+    @pytest.mark.skip_version_if(
+            "< v1.5.0",
+            reason="https://github.com/harvester/harvester/issues/7654 fix after `v1.5.0`")
     @pytest.mark.parametrize(
-        "resort", [slice(None, None, -1), slice(None, None, 2)], ids=("mismatched", "invalid")
-    )
+        "resort", [slice(None, None, -1), slice(None, None, 2)], ids=("mismatched", "invalid"))
     def test_checksum(self, api_client, unique_name, upgrade_target, resort, upgrade_checker):
         version, url, checksum = upgrade_target
         version = f"{version}-{unique_name}"
@@ -472,7 +475,7 @@ class TestInvalidUpgrade:
         api_client.upgrades.delete(upgrade_name)
         api_client.versions.delete(version)
 
-    @pytest.mark.skip("https://github.com/harvester/harvester/issues/5494")
+    @pytest.mark.skip(reason="https://github.com/harvester/harvester/issues/5494")
     def test_version_compatibility(
         self, api_client, unique_name, upgrade_target, upgrade_timeout
     ):


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue #2373

#### What this PR does / why we need it:
1. Easier check test report to know corresponding issue/reason of skipped cases, e.g.
   * Known issues (with URL)
   * Skipped byVersion
   * Skipped byPriorCase (dependency)
3. Refactor to unify `pytest.mark.skip_version_*` marks to the more explicit `pytest.mark.skip_version_if`.
4. For known issues, first use `skip_version_if()` if the milestone is decided. For those still in `Planning`, may use `xfail` (expected fail) temporarily.

 
#### Special notes for your reviewer:
For known issue to leverage this enhancement, skip `reason` should contain URL.

#### Additional documentation or context
Verification (`harvester-install-and-test#9`)
<img width="1901" height="951" alt="image" src="https://github.com/user-attachments/assets/82214595-b99b-41aa-9d02-27be4fe88de4" />


