### PR TITLE
Add xfail_if_version and refactoring

### DIFF
--- a/harvester_e2e_tests/apis/test_images.py
+++ b/harvester_e2e_tests/apis/test_images.py
@@ -192,8 +192,8 @@ class TestImages:
                 f"Still got {code} with {data}"
             )
 
-    @pytest.mark.skip_version_if(
-            "> v1.2.0", "<= v1.4.0",
+    @pytest.mark.skip_if_version(
+            ">= v1.2.0", "< v1.4.0",
             reason="https://github.com/harvester/harvester/issues/4293 fix after `v1.4.0`")
     @pytest.mark.dependency(depends=["create_image", "get_image", "delete_image"])
     @parametrize_with_cases("unique_name", cases=CasesImages, has_tag='unique-name')

--- a/harvester_e2e_tests/apis/test_networks.py
+++ b/harvester_e2e_tests/apis/test_networks.py
@@ -46,7 +46,7 @@ class TestNetworksNegative:
         assert "NotFound" == data.get("reason"), (code, data)
 
     @pytest.mark.parametrize("vlan_id", [0, 4095])
-    @pytest.mark.skip_version_if(
+    @pytest.mark.skip_if_version(
             ">= v1.0.3", reason="https://github.com/harvester/harvester/issues/3151")
     def test_create_with_invalid_id_103(self, api_client, unique_name, vlan_id):
         code, data = api_client.networks.create(unique_name, vlan_id)
@@ -61,7 +61,7 @@ class TestNetworksNegative:
         assert "Invalid" == data.get("reason"), (code, data)
 
     @pytest.mark.parametrize("vlan_id", [4095])
-    @pytest.mark.skip_version_if(
+    @pytest.mark.skip_if_version(
             "< v1.1.0", reason="https://github.com/harvester/harvester/issues/3151")
     def test_create_with_invalid_id(self, api_client, unique_name, vlan_id):
         code, data = api_client.networks.create(unique_name, vlan_id)
@@ -76,13 +76,13 @@ class TestNetworksNegative:
 class TestNetworks:
 
     @pytest.mark.dependency(name="create_network_103")
-    @pytest.mark.skip_version_if(">= v1.0.3")
+    @pytest.mark.skip_if_version(">= v1.0.3")
     def test_create_103(self, api_client, unique_name):
         code, data = api_client.networks.create(unique_name, VLAN_ID)
         assert 201 == code, (code, data)
 
     @pytest.mark.dependency(name="create_network")
-    @pytest.mark.skip_version_if(
+    @pytest.mark.skip_if_version(
             "< v1.1.0", reason="https://github.com/harvester/harvester/issues/3151")
     def test_create(self, api_client, unique_name):
         code, data = api_client.networks.create(unique_name, VLAN_ID, cluster_network='mgmt')

--- a/harvester_e2e_tests/apis/test_settings.py
+++ b/harvester_e2e_tests/apis/test_settings.py
@@ -41,7 +41,7 @@ def test_get_all_settings(api_client, expected_settings):
 
 @pytest.mark.p0
 @pytest.mark.settings
-@pytest.mark.skip_version_if("< v1.1.0")
+@pytest.mark.skip_if_version("< v1.1.0")
 def test_get_all_settings_v110(api_client, expected_settings):
     expected_settings = expected_settings['default'] | expected_settings['1.1.0']
     code, data = api_client.settings.get()
@@ -173,9 +173,9 @@ class TestUpdateInvalidBackupTarget:
 @pytest.mark.sanity
 @pytest.mark.settings
 class TestUpdateKubeconfigDefaultToken:
-    @pytest.mark.skip_version_if(
-            "< v1.3.2",
-            reason="https://github.com/harvester/harvester/issues/5891 fixed after v1.3.2")
+    @pytest.mark.skip_if_version(
+            "< v1.3.1",
+            reason="https://github.com/harvester/harvester/issues/5891 fixed after v1.3.1")
     def test_invalid_kubeconfig_ttl_min(self, api_client):
         KubeconfigTTLMinSpec = api_client.settings.KubeconfigDefaultTokenTTLSpec.TTL
         spec = KubeconfigTTLMinSpec(99999999999999)
@@ -185,7 +185,7 @@ class TestUpdateKubeconfigDefaultToken:
             f"API Status({code}): {data}"
         )
 
-    @pytest.mark.skip_version_if("< v1.3.1")
+    @pytest.mark.skip_if_version("< v1.3.1")
     def test_valid_kubeconfig_ttl_min(self, api_client):
         KubeconfigTTLMinSpec = api_client.settings.KubeconfigDefaultTokenTTLSpec.TTL
         spec = KubeconfigTTLMinSpec(172800)

--- a/harvester_e2e_tests/apis/test_support_bundle.py
+++ b/harvester_e2e_tests/apis/test_support_bundle.py
@@ -239,7 +239,7 @@ class TestSupportBundle:
 @pytest.mark.sanity
 @pytest.mark.negative
 @pytest.mark.support_bundle
-@pytest.mark.skip_version_if(
+@pytest.mark.skip_if_version(
     "< v1.6.0", reason="https://github.com/harvester/harvester/issues/7835 new feature in v1.6.0")
 class TestSupportBundleInvalidExtraCollectionNamespaces:
     def test_create_invalid_extra_collection_namespaces(
@@ -276,7 +276,7 @@ class TestSupportBundleInvalidExtraCollectionNamespaces:
 @pytest.mark.p0
 @pytest.mark.smoke
 @pytest.mark.support_bundle
-@pytest.mark.skip_version_if(
+@pytest.mark.skip_if_version(
     "< v1.6.0", reason="https://github.com/harvester/harvester/issues/7835 new feature in v1.6.0")
 class TestSupportBundleTimeout:
     @pytest.mark.dependency(name="create support bundle")
@@ -310,7 +310,7 @@ class TestSupportBundleTimeout:
 @pytest.mark.p0
 @pytest.mark.smoke
 @pytest.mark.support_bundle
-@pytest.mark.skip_version_if(
+@pytest.mark.skip_if_version(
     "< v1.6.0", reason="https://github.com/harvester/harvester/issues/7835 new feature in v1.6.0")
 class TestSupportBundleExpiration:
     @pytest.mark.dependency(name="create support bundle")
@@ -344,7 +344,7 @@ class TestSupportBundleExpiration:
 @pytest.mark.p0
 @pytest.mark.smoke
 @pytest.mark.support_bundle
-@pytest.mark.skip_version_if(
+@pytest.mark.skip_if_version(
     "< v1.6.0", reason="https://github.com/harvester/harvester/issues/7835 new feature in v1.6.0")
 class TestSupportBundleExtraNamespaces:
     @pytest.mark.dependency(name="create support bundle")

--- a/harvester_e2e_tests/apis/test_volumes.py
+++ b/harvester_e2e_tests/apis/test_volumes.py
@@ -62,7 +62,7 @@ class TestVolumesNegative:
         assert 422 == code, (code, data)
         assert "Invalid" == data.get("code"), (code, data)
 
-    @pytest.mark.skip_version_if(
+    @pytest.mark.skip_if_version(
             ">= v1.4.0",
             reason="https://github.com/harvester/harvester/issues/7030, breaking changes")
     def test_create_without_name(self, api_client):

--- a/harvester_e2e_tests/conftest.py
+++ b/harvester_e2e_tests/conftest.py
@@ -292,7 +292,8 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     # Register marker as the format (marker, (description))
     markers = [
-        ("skip_version_if", "Mark test skipped when cluster version hit the condition"),
+        ("skip_if_version", "Mark test skip when cluster version hit the condition"),
+        ("xfail_if_version", "Mark test xfail when cluster version hit the condition"),
         ("smoke", "{_r} smoke testing"),
         ("sanity", "{_r} sanity testing"),
         ('p0', ("mark the test's priority is p0")),

--- a/harvester_e2e_tests/integrations/test_0_storage_network.py
+++ b/harvester_e2e_tests/integrations/test_0_storage_network.py
@@ -78,7 +78,7 @@ def cluster_network(request, api_client, unique_name):
 @pytest.mark.smoke
 @pytest.mark.settings
 @pytest.mark.networks
-@pytest.mark.skip_version_if("< v1.0.3")
+@pytest.mark.skip_if_version("< v1.0.3")
 def test_enable_storage_network(
     api_client, cluster_network, vlan_id, unique_name, wait_timeout,
     setting_checker, network_checker
@@ -151,7 +151,7 @@ def test_enable_storage_network(
 @pytest.mark.smoke
 @pytest.mark.settings
 @pytest.mark.networks
-@pytest.mark.skip_version_if("< v1.0.3")
+@pytest.mark.skip_if_version("< v1.0.3")
 def test_disable_storage_network(api_client, setting_checker):
     disable_spec = api_client.settings.StorageNetworkSpec.disable()
     code, data = api_client.settings.update('storage-network', disable_spec)

--- a/harvester_e2e_tests/integrations/test_1_images.py
+++ b/harvester_e2e_tests/integrations/test_1_images.py
@@ -275,8 +275,8 @@ class TestBackendImages:
                          image_info.image_checksum, wait_timeout)
 
     @pytest.mark.sanity
-    @pytest.mark.skip_version_if(
-        "> v1.2.0", "<= v1.4.0",
+    @pytest.mark.skip_if_version(
+        ">= v1.2.0", "< v1.4.0",
         reason="https://github.com/harvester/harvester/issues/4293 fix after `v1.4.0`")
     @pytest.mark.dependency(name="delete_image_recreate", depends=["create_image_url"])
     def test_delete_image_recreate(
@@ -419,7 +419,7 @@ class TestBackendImages:
 @pytest.mark.images
 @pytest.mark.settings
 @pytest.mark.networks
-@pytest.mark.skip_version_if("< v1.0.3")
+@pytest.mark.skip_if_version("< v1.0.3")
 @pytest.mark.usefixtures("storage_network")
 class TestImageWithStorageNetwork:
     @pytest.mark.dependency(name="create_image_by_file")
@@ -879,8 +879,8 @@ class TestImageEnhancements:
         delete_image(api_client, original_image, wait_timeout)
         delete_image(api_client, exported_image_id, wait_timeout)
 
-    @pytest.mark.skip_version_if(
-            ">= v1.7.0", "< v1.9.0", reason="https://github.com/harvester/harvester/issues/9515")
+    @pytest.mark.xfail_if_version(
+            ">= v1.7.0", reason="https://github.com/harvester/harvester/issues/9515 since v1.7.0")
     @pytest.mark.p1
     @pytest.mark.images
     @pytest.mark.negative

--- a/harvester_e2e_tests/integrations/test_1_volumes.py
+++ b/harvester_e2e_tests/integrations/test_1_volumes.py
@@ -268,7 +268,8 @@ def test_delete_volume_when_exporting(api_client, unique_name, ubuntu_image, pol
     {"size": "invalid_size", "error_msg": "quantities must match"},
     pytest.param(
         {"size": "999999Ti", "error_msg": "exceeds cluster capacity"},
-        marks=pytest.mark.xfail(reason="https://github.com/harvester/harvester/issues/9268")
+        marks=pytest.mark.xfail_if_version(
+            ">= v1.6.1", reason="https://github.com/harvester/harvester/issues/9268 since v1.6.1")
     )],
     ids=['zero_size', 'negative_size', 'not_number', 'too_large_size'])
 def test_create_volume_invalid_specifications(api_client, gen_unique_name, invalid_spec):

--- a/harvester_e2e_tests/integrations/test_2_security_images.py
+++ b/harvester_e2e_tests/integrations/test_2_security_images.py
@@ -162,7 +162,7 @@ def created_invalid_secret(
 
 
 @pytest.mark.p0
-@pytest.mark.skip_version_if("< v1.4.0", reason="New feature after v1.4.0")
+@pytest.mark.skip_if_version("< v1.4.0", reason="New feature after v1.4.0")
 class TestEncryptedBackingImage:
     """
     Integration tests for encrypted and decrypted backing images.
@@ -281,7 +281,7 @@ class TestEncryptedBackingImage:
 
 
 @pytest.mark.p0
-@pytest.mark.skip_version_if("< v1.4.0", reason="New feature after v1.4.0")
+@pytest.mark.skip_if_version("< v1.4.0", reason="New feature after v1.4.0")
 class TestInvalidEncryptionSecret:
     """
     Test creating invalid encryption secrets and verify error handling.

--- a/harvester_e2e_tests/integrations/test_3_vm.py
+++ b/harvester_e2e_tests/integrations/test_3_vm.py
@@ -393,7 +393,7 @@ def test_migrate_vm_with_multiple_volumes(
 @pytest.mark.networks
 @pytest.mark.settings
 @pytest.mark.virtualmachines
-@pytest.mark.skip_version_if("< v1.0.3")
+@pytest.mark.skip_if_version("< v1.0.3")
 class TestVMWithStorageNetwork:
     def test_enable_storage_network_with_api_stopped_vm(
         self, api_client, minimal_vm, storage_network, setting_checker, vm_checker, volume_checker

--- a/harvester_e2e_tests/integrations/test_3_vm_functions.py
+++ b/harvester_e2e_tests/integrations/test_3_vm_functions.py
@@ -1652,7 +1652,7 @@ def test_create_vm_no_available_resources(resource, api_client, image,
 @pytest.mark.p0
 @pytest.mark.sanity
 @pytest.mark.virtualmachines
-@pytest.mark.skip_version_if(
+@pytest.mark.skip_if_version(
     "> v1.3.0", reason="`pc type removed, ref: https://github.com/harvester/harvester/issues/5437")
 @pytest.mark.parametrize(
     "machine_types", [("q35", "pc"), ("pc", "q35")], ids=['q35_to_pc', 'pc_to_q35'])

--- a/harvester_e2e_tests/integrations/test_4_vm_backup_restore.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_backup_restore.py
@@ -527,7 +527,7 @@ class TestBackupRestore:
         assert 422 == code, (code, data)
 
     @pytest.mark.negative
-    @pytest.mark.skip_version_if('< v1.1.2', '< v1.2.1')
+    @pytest.mark.skip_if_version('< v1.1.2', '< v1.2.1')
     @pytest.mark.dependency(depends=["TestBackupRestore::tests_backup_vm"], param=True)
     def test_restore_with_invalid_name(self, api_client, backup_config, base_vm_with_data):
         # RFC1123 DNS Subdomain name rules:
@@ -562,7 +562,7 @@ class TestBackupRestore:
         code, data = api_client.backups.restore(unique_vm_name, spec)
         assert 422 == code, (code, data)
 
-    @pytest.mark.skip_version_if('< v1.2.2')
+    @pytest.mark.skip_if_version('< v1.2.2')
     @pytest.mark.dependency(depends=["TestBackupRestore::tests_backup_vm"], param=True)
     def test_restore_replace_with_vm_shutdown_command(
         self, api_client, vm_shell_from_host, ssh_keypair, wait_timeout, vm_checker,

--- a/harvester_e2e_tests/integrations/test_4_vm_host_cpu_pinning.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_host_cpu_pinning.py
@@ -240,7 +240,7 @@ class TestPinCPUonVM:
             f"API Status({code}): {data}"
         )
 
-    @pytest.mark.skip_version_if(
+    @pytest.mark.skip_if_version(
             ">= v1.7.0", "< v1.8.0", reason="https://github.com/harvester/harvester/issues/9557")
     @pytest.mark.negative
     @pytest.mark.dependency(depends=["pin_cpu_on_vm"])

--- a/harvester_e2e_tests/integrations/test_4_vm_host_powercycle.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_host_powercycle.py
@@ -101,7 +101,7 @@ def vm_force_reset_policy(api_client):
 @pytest.mark.sanity
 @pytest.mark.p1
 class TestHostState:
-    @pytest.mark.skip_version_if(
+    @pytest.mark.skip_if_version(
         ">= v1.7.0", "< v1.8.0", reason="https://github.com/harvester/harvester/issues/9759")
     @pytest.mark.dependency(name="host_poweroff")
     def test_poweroff_state(self, api_client, host_state, wait_timeout, available_node_names):

--- a/harvester_e2e_tests/integrations/test_upgrade.py
+++ b/harvester_e2e_tests/integrations/test_upgrade.py
@@ -409,7 +409,7 @@ def stopped_vm(request, api_client, ssh_keypair, wait_timeout, unique_name, imag
 @pytest.mark.negative
 @pytest.mark.any_nodes
 class TestInvalidUpgrade:
-    @pytest.mark.skip_version_if(
+    @pytest.mark.skip_if_version(
             "< v1.5.0",
             reason="https://github.com/harvester/harvester/issues/7654 fix after `v1.5.0`")
     def test_iso_url(self, api_client, unique_name, upgrade_checker):
@@ -441,7 +441,7 @@ class TestInvalidUpgrade:
         api_client.upgrades.delete(upgrade_name)
         api_client.versions.delete(version)
 
-    @pytest.mark.skip_version_if(
+    @pytest.mark.skip_if_version(
             "< v1.5.0",
             reason="https://github.com/harvester/harvester/issues/7654 fix after `v1.5.0`")
     @pytest.mark.parametrize(
@@ -1089,8 +1089,8 @@ class TestAnyNodesUpgrade:
           of kubevirt and longhorn
         """
 
-        def _check_image_version(old, new):
-            def _sanitized_ver(img: str):
+        def check_image_version(old, new):
+            def sanitized_ver(img: str):
                 try:
                     # PEP 440 compliant: N(.N)*[-+]?[{a|alpha|b|beta|c|rc}N][.postN][.devN]
                     ver_str = img.split(':', 1)[-1]
@@ -1105,7 +1105,7 @@ class TestAnyNodesUpgrade:
                         return ver_obj
                     raise e
 
-            old_le_new = (_sanitized_ver(old) <= _sanitized_ver(new))
+            old_le_new = (sanitized_ver(old) <= sanitized_ver(new))
             if not old_le_new:
                 logger.error(f"Old image {old} does not less or equal to the new {new}")
 
@@ -1143,7 +1143,7 @@ class TestAnyNodesUpgrade:
 
         for pod in pods['data']:
             if "virt-operator" in pod['metadata']['name']:
-                kubevirt_version_existed = _check_image_version(
+                kubevirt_version_existed = check_image_version(
                     kubevirt_operator_image, pod['spec']['containers'][0]['image']
                 )
 
@@ -1154,11 +1154,11 @@ class TestAnyNodesUpgrade:
 
         for pod in pods['data']:
             if "longhorn-manager" in pod['metadata']['name']:
-                longhorn_manager_version_existed = _check_image_version(
+                longhorn_manager_version_existed = check_image_version(
                   longhorn_images["longhorn-manager"], pod['spec']['containers'][0]['image']
                 )
             elif "engine-image" in pod['metadata']['name']:
-                engine_image_version_existed = _check_image_version(
+                engine_image_version_existed = check_image_version(
                     longhorn_images["engine-image"], pod['spec']['containers'][0]['image']
                 )
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue #2373 

#### What this PR does / why we need it:
1. Marking known issue by [^1]
   * `skip_if_version`: for issue has decided boundaries, e.g. resolved, breaking change, new feature
   * `xfail_if_version`: for ongoing known issue which has only left boundary which we not sure about the milestone (right boundary). Such case will show `XFail` and `XPass` when the issue is fixed so we can explicitly know it and update marker.


1. Use `cond.__name__` instead of `str(cond)` to fix potential exception in `api_client.py` [^2]

1. Refactoring
   * Renaming `skip_version_if` to `skip_if_version` to align pytest convention [^3]
   * Naming `test_upgrade.py::_check_image_version` back to `test_upgrade.py::check_image_version` cuz it's inner function [^4]
     
 
#### Special notes for your reviewer:
n/a

#### Additional documentation or context
Verification (`harvester-install-and-test#11`)
<img width="1564" height="1001" alt="image" src="https://github.com/user-attachments/assets/ab98cb95-0f05-40d8-99e7-89d5614b86aa" />


[^1]: https://github.com/harvester/tests/pull/2372#discussion_r2667744589
[^2]: https://github.com/harvester/tests/pull/2372#discussion_r2667727529
[^3]: https://docs.pytest.org/en/stable/reference/reference.html#pytest-mark-skipif-ref
[^4]: https://github.com/harvester/tests/pull/2369#pullrequestreview-3621053843