### PR TITLE
Add RKE1 deprecate condition to skip test cases

### DIFF
--- a/harvester_e2e_tests/fixtures/rancher_api_client.py
+++ b/harvester_e2e_tests/fixtures/rancher_api_client.py
@@ -47,7 +47,8 @@ def _pickup_k8s_version(versions, target_version):
 @pytest.fixture(scope='session')
 def rke1_version(request, rancher_api_client, harvester_metadata):
     if rancher_api_client.cluster_version >= parse_version("v2.12.0"):
-        pytest.skip(reason=f"Rancher version {rancher_api_client.cluster_version} matches RKE1 has reached EOL condition(s) in v2.12.0")
+        pytest.skip(reason=f"Rancher version {rancher_api_client.cluster_version} "
+                    "matches RKE1 has reached EOL condition(s) in v2.12.0")
 
     target_ver = request.config.getoption("--k8s-version")
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue #2400

#### What this PR does / why we need it:
Rancher version >= v2.12.0 is no longer support RKE1, add the condition to skip test cases and shows currect message on test report