### PR TITLE
Complement TemplateSpec140 to VMSpec140

### DIFF
--- a/apiclient/harvester_api/managers/templates.py
+++ b/apiclient/harvester_api/managers/templates.py
@@ -1,4 +1,4 @@
-from harvester_api.models.templates import TemplateSpec
+from harvester_api.models.templates import TemplateSpec, TemplateSpec140
 from .base import DEFAULT_NAMESPACE, BaseManager
 
 
@@ -49,3 +49,8 @@ class TemplateManager(BaseManager):
 
     def delete_version(self, name, namespace=DEFAULT_NAMESPACE, *, raw=False):
         return self._delete(self.VER_PATH_fmt.format(uid=name, ns=namespace), raw=raw)
+
+
+class TemplateManager140(TemplateManager):
+    support_to = "v1.4.0"
+    Spec = TemplateSpec140

--- a/apiclient/harvester_api/models/templates.py
+++ b/apiclient/harvester_api/models/templates.py
@@ -1,4 +1,4 @@
-from .virtualmachines import VMSpec
+from .virtualmachines import VMSpec, VMSpec140
 
 
 class TemplateSpec(VMSpec):
@@ -37,3 +37,7 @@ class TemplateSpec(VMSpec):
         vd['type'] = "kubevirt.io.virtualmachine"
         vd['spec']['template']['spec']['hostname'] = ""
         return super().from_dict(vd)
+
+
+class TemplateSpec140(TemplateSpec, VMSpec140):
+    pass

--- a/harvester_e2e_tests/integrations/test_4_vm_template.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_template.py
@@ -76,7 +76,6 @@ def stopped_vm(api_client, ssh_keypair, wait_timeout, image, unique_name):
 @pytest.mark.templates
 @pytest.mark.virtualmachines
 class TestVMTemplate:
-    @pytest.mark.xfail(reason="test issue https://github.com/harvester/tests/issues/2388")
     def test_create_template_with_data(
         self, api_client, vm_shell_from_host, vm_checker, ssh_keypair, wait_timeout, stopped_vm
     ):


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue #2371


#### What this PR does / why we need it:
* Why we need it
  `test_4_vm_template.py::TestVMTemplate::test_create_template_with_data` fails due to the `TemplateSpec` class is not inherited from corresponding `VMSpec`.
  Ref. https://github.com/harvester/tests/issues/2371#issuecomment-3748510208

* What this PR does
  Add `TemplateManager140` and `TemplateSpec140` inherited from `VMSpec140`


#### Verification
1. `TemplateSpec140` should has MRO `[TemplateSpec140, TemplateSpec, VMSpec140, VMSpec]`
   <img width="1555" height="283" alt="image" src="https://github.com/user-attachments/assets/7aa86b8b-d5a5-494d-97a2-019b945ceccc" />

2. Test case PASS
   <img width="1555" height="569" alt="image" src="https://github.com/user-attachments/assets/e3289fac-0f6b-467f-8fbd-78aacf7ec0a0" />
