### PR TITLE
Add retry to avoid race condition to fix 2376

### DIFF
--- a/harvester_e2e_tests/integrations/test_9_rancher_integration.py
+++ b/harvester_e2e_tests/integrations/test_9_rancher_integration.py
@@ -408,7 +408,7 @@ class TestResourceQuota:
         assert found_quota, (
             f"Timeout waiting for resourceQuota annotation "
             f"in namespace {unique_name}. Data: {data}")
-        
+
         ns_quota = loads(data['metadata']['annotations']['field.cattle.io/resourceQuota'])['limit']
         assert ns_quota['limitsCpu'] == proj_spec.namespace_quota.cpu_limit
         assert ns_quota['limitsMemory'] == proj_spec.namespace_quota.mem_limit


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #2376 

#### What this PR does / why we need it:
test_9_rancher_integration.py::TestResourceQuota::test_create_namespace_on_project will encounter race condition during test, which cause KeyError when attempting to get data['metadata']['annotations']['field.cattle.io/resourceQuota']
