### PR TITLE
fix: Issue 160

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,7 +7,6 @@ pytest-json-report
 pytest-dependency
 jinja2
 bcrypt
-requests
 paramiko
 pycryptodome
 sshpubkeys
@@ -19,8 +18,8 @@ scp
 requests
 urllib3
 lxml
-pyyaml
 pdoc3
+setuptools < 69
 tox
 dataclasses; python_version < '3.7'
 -e ./apiclient


### PR DESCRIPTION
* pin setuptools
* tests run but issue is `Refrain from using this package or pin to Setuptools<81` 

Resolves: fix/harvester-baremetal-ansible-issue-160 

Relates to: https://github.com/harvester/harvester-baremetal-ansible/issues/160

Signed-off-by: Mike Russell <michael.russell@suse.com>

#### Which issue(s) this PR fixes:
https://github.com/harvester/harvester-baremetal-ansible/issues/160

#### What this PR does / why we need it:
https://github.com/harvester/harvester-baremetal-ansible/issues/160

#### Special notes for your reviewer:
#### TEST:
1. `pip install -r test-requirements.txt`
2. `pip freeze --all | grep -ie "setuptools"` , should be less than 81

#### Additional documentation or context
https://github.com/harvester/harvester-baremetal-ansible/issues/160