### PR TITLE
Enhance the xfail info

### DIFF
--- a/harvester_e2e_tests/integrations/test_1_images.py
+++ b/harvester_e2e_tests/integrations/test_1_images.py
@@ -879,8 +879,8 @@ class TestImageEnhancements:
         delete_image(api_client, original_image, wait_timeout)
         delete_image(api_client, exported_image_id, wait_timeout)
 
-    @pytest.mark.xfail_if_version(
-            ">= v1.7.0", reason="https://github.com/harvester/harvester/issues/9515 since v1.7.0")
+    @pytest.mark.xfail(
+            reason="https://github.com/harvester/harvester/issues/9515")
     @pytest.mark.p1
     @pytest.mark.images
     @pytest.mark.negative

--- a/harvester_e2e_tests/integrations/test_1_volumes.py
+++ b/harvester_e2e_tests/integrations/test_1_volumes.py
@@ -268,8 +268,8 @@ def test_delete_volume_when_exporting(api_client, unique_name, ubuntu_image, pol
     {"size": "invalid_size", "error_msg": "quantities must match"},
     pytest.param(
         {"size": "999999Ti", "error_msg": "exceeds cluster capacity"},
-        marks=pytest.mark.xfail_if_version(
-            ">= v1.6.1", reason="https://github.com/harvester/harvester/issues/9268 since v1.6.1")
+        marks=pytest.mark.xfail(
+            reason="https://github.com/harvester/harvester/issues/9268")
     )],
     ids=['zero_size', 'negative_size', 'not_number', 'too_large_size'])
 def test_create_volume_invalid_specifications(api_client, gen_unique_name, invalid_spec):


### PR DESCRIPTION
Removes the version information of those fails, since the fails not related to the harvester version.

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
No issue ID, just quick enhancement of the test report.

#### What this PR does / why we need it:
To show xfail information correctly to enhance the test report

