### PR TITLE
Skip ISO checksum mismatched case

### DIFF
--- a/harvester_e2e_tests/integrations/test_upgrade.py
+++ b/harvester_e2e_tests/integrations/test_upgrade.py
@@ -444,8 +444,12 @@ class TestInvalidUpgrade:
     @pytest.mark.skip_if_version(
             "< v1.5.0",
             reason="https://github.com/harvester/harvester/issues/7654 fix after `v1.5.0`")
-    @pytest.mark.parametrize(
-        "resort", [slice(None, None, -1), slice(None, None, 2)], ids=("mismatched", "invalid"))
+    @pytest.mark.parametrize("resort", [
+        pytest.param(
+            slice(None, None, -1),
+            marks=pytest.mark.skip(reason="https://github.com/harvester/harvester/issues/9990")),
+        slice(None, None, 2)
+        ], ids=("mismatched", "invalid"))
     def test_checksum(self, api_client, unique_name, upgrade_target, resort, upgrade_checker):
         version, url, checksum = upgrade_target
         version = f"{version}-{unique_name}"


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Skip `TestInvalidUpgrade::test_checksum[mismatched]` due to harvester/harvester/issues/9990.

#### What this PR does / why we need it:
If not skip, the upgrade will not fail/blocked and affect following cases.

#### Special notes for your reviewer:

#### Additional documentation or context
Verification
<img width="1565" height="1033" alt="image" src="https://github.com/user-attachments/assets/0ac70888-a47e-4c8f-bee6-5f6da41b5d2c" />
