### PR TITLE
Enhance match method to support multiple logs case

### DIFF
--- a/harvester_e2e_tests/apis/test_support_bundle.py
+++ b/harvester_e2e_tests/apis/test_support_bundle.py
@@ -124,12 +124,12 @@ class TestSupportBundle:
         patterns = [r"^.*/logs/cattle-fleet-local-system/fleet-agent-.*/fleet-agent.log",
                     r"^.*/logs/cattle-fleet-system/fleet-controller-.*/fleet-controller.log",
                     r"^.*/logs/cattle-fleet-system/gitjob-.*/gitjob.log"]
-        matches = []
+        matches = [[]] * len(patterns)
         for f in support_bundle_state.files:
-            for pattern in patterns:
-                matches.extend([f] if re.match(pattern, f) else [])
+            for i in range(len(patterns)):
+                matches[i].extend([f] if re.match(patterns[i], f) else [])
 
-        assert len(matches) == len(patterns), (
+        assert [] not in matches, (
             f"Some file(s) not found, files: {matches}\npatterns: {patterns}"
         )
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #2447 

#### What this PR does / why we need it:
To support there are multiple log case.

```
E       AssertionError: Some file(s) not found, files: ['supportbundle_fbb53002-0beb-45b5-b955-7d5c8c7929b2_2026-02-01T12-46-45Z/logs/cattle-fleet-local-system/fleet-agent-5d4fcff575-d4zpg/fleet-agent.log', 'supportbundle_fbb53002-0beb-45b5-b955-7d5c8c7929b2_2026-02-01T12-46-45Z/logs/cattle-fleet-system/gitjob-6c89b7ddf5-b6ljn/gitjob.log.1', 'supportbundle_fbb53002-0beb-45b5-b955-7d5c8c7929b2_2026-02-01T12-46-45Z/logs/cattle-fleet-system/gitjob-6c89b7ddf5-b6ljn/gitjob.log', 'supportbundle_fbb53002-0beb-45b5-b955-7d5c8c7929b2_2026-02-01T12-46-45Z/logs/cattle-fleet-system/fleet-controller-7644cc7974-6fgcf/fleet-controller.log']
E         patterns: ['^.*/logs/cattle-fleet-local-system/fleet-agent-.*/fleet-agent.log', '^.*/logs/cattle-fleet-system/fleet-controller-.*/fleet-controller.log', '^.*/logs/cattle-fleet-system/gitjob-.*/gitjob.log']
E       assert 4 == 3
E        +  where 4 = len(['supportbundle_fbb53002-0beb-45b5-b955-7d5c8c7929b2_2026-02-01T12-46-45Z/logs/cattle-fleet-local-system/fleet-agent-5d4fcff575-d4zpg/fleet-agent.log', 'supportbundle_fbb53002-0beb-45b5-b955-7d5c8c7929b2_2026-02-01T12-46-45Z/logs/cattle-fleet-system/gitjob-6c89b7ddf5-b6ljn/gitjob.log.1', 'supportbundle_fbb53002-0beb-45b5-b955-7d5c8c7929b2_2026-02-01T12-46-45Z/logs/cattle-fleet-system/gitjob-6c89b7ddf5-b6ljn/gitjob.log', 'supportbundle_fbb53002-0beb-45b5-b955-7d5c8c7929b2_2026-02-01T12-46-45Z/logs/cattle-fleet-system/fleet-controller-7644cc7974-6fgcf/fleet-controller.log'])
E        +  and   3 = len(['^.*/logs/cattle-fleet-local-system/fleet-agent-.*/fleet-agent.log', '^.*/logs/cattle-fleet-system/fleet-controller-.*/fleet-controller.log', '^.*/logs/cattle-fleet-system/gitjob-.*/gitjob.log'])
```
