### PR TITLE
Use MAC as dhcp-identifier for restored VMs

### DIFF
--- a/harvester_e2e_tests/fixtures/images.py
+++ b/harvester_e2e_tests/fixtures/images.py
@@ -23,7 +23,7 @@ def image_opensuse(request, api_client):
         *_, image_name = url.path.rsplit("/", 1)
         url = urlparse(urljoin(f"{image_server}/", image_name))
 
-    return ImageInfo(url, image_checksum, name="opensuse", ssh_user="opensuse")
+    return ImageInfo(url, image_checksum, name="opensuse", ssh_user="opensuse", first_nic="eth0")
 
 
 @pytest.fixture(scope="session")
@@ -38,7 +38,7 @@ def image_ubuntu(request):
         *_, image_name = url.path.rsplit("/", 1)
         url = urlparse(urljoin(f"{image_server}/", image_name))
 
-    return ImageInfo(url, image_checksum, name="ubuntu", ssh_user="ubuntu")
+    return ImageInfo(url, image_checksum, name="ubuntu", ssh_user="ubuntu", first_nic="enp1s0")
 
 
 @pytest.fixture(scope="session")
@@ -51,7 +51,7 @@ def image_k3s(request):
 
 
 class ImageInfo:
-    def __init__(self, url_result, image_checksum=None, name="", ssh_user=None):
+    def __init__(self, url_result, image_checksum=None, name="", ssh_user=None, first_nic=None):
         self.url_result = url_result
         if name:
             self.name = name
@@ -59,6 +59,7 @@ class ImageInfo:
             self.name = self.url.rsplit("/", 1)[-1]
         self.ssh_user = ssh_user
         self.image_checksum = image_checksum
+        self.first_nic = first_nic
 
     def __repr__(self):
         return f"{__class__.__name__}({self.url_result})"


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Apply network data on restored VM in upgrade suite thus VMs can get IP via DHCP without problem.
Ref. https://docs.harvesterhci.io/v1.7/vm/backup-restore#create-a-vm-backup

#### What this PR does / why we need it:
`test_preq_setup_vms` may fail due to restored VM can not get IP
<img width="1565" height="199" alt="image" src="https://github.com/user-attachments/assets/930e515d-b045-438b-8011-b6dd83208a2b" />
<img width="1565" height="456" alt="image" src="https://github.com/user-attachments/assets/9445d518-1c14-4b78-8450-8a4b4a2411d1" />

#### Special notes for your reviewer:

#### Verification
<img width="1565" height="424" alt="image" src="https://github.com/user-attachments/assets/a0b5a576-7363-4198-91d0-a2fc1ade3d38" />
<img width="1565" height="424" alt="image" src="https://github.com/user-attachments/assets/40ea4579-8b22-4b3e-9e51-74bd6e4a6306" />
