### PR TITLE
Fix cpu_manager teardown does not revert change

### DIFF
--- a/harvester_e2e_tests/integrations/test_4_vm_host_cpu_pinning.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_host_cpu_pinning.py
@@ -137,7 +137,8 @@ def cpu_managers(api_client, wait_timeout):
         name = node['metadata']['name']
         status = json.loads(node['metadata']['labels'].get("cpumanager", 'false'))
         if status != origin[name]:
-            wait_applied(name, origin[name])
+            api_client.hosts.cpu_manager(name, enable=origin[name])
+            wait_applied(name, json.dumps(origin[name]))
 
 
 @pytest.mark.p0


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #2487

#### What this PR does / why we need it:
Fix cpu_manager teardown doesn't revert change issue

