### PR TITLE
Change skip to xfail to run test case in rc build

### DIFF
--- a/harvester_e2e_tests/integrations/test_4_vm_host_powercycle.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_host_powercycle.py
@@ -101,7 +101,7 @@ def vm_force_reset_policy(api_client):
 @pytest.mark.sanity
 @pytest.mark.p1
 class TestHostState:
-    @pytest.mark.skip_if_version(
+    @pytest.mark.xfail_if_version(
         ">= v1.7.0", "< v1.8.0", reason="https://github.com/harvester/harvester/issues/9759")
     @pytest.mark.dependency(name="host_poweroff")
     def test_poweroff_state(self, api_client, host_state, wait_timeout, available_node_names):


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
No issue

#### What this PR does / why we need it:
In current test case, we use `skip_if_version` since the test case `test_poweroff_state` will find the issue https://github.com/harvester/harvester/issues/9759, which cause the test case fail.
In this purpose, I woud like to change `skip_if_version` to `xfail_if_version` to run the test case to verify if the origin issue fix in the range `v1.7.0` ~ `v1.8.0` without changing test script.
