### PR TITLE
Skip negative upgrade cases which affects logging addon

### DIFF
--- a/harvester_e2e_tests/integrations/test_upgrade.py
+++ b/harvester_e2e_tests/integrations/test_upgrade.py
@@ -410,6 +410,7 @@ def stopped_vm(request, api_client, ssh_keypair, wait_timeout, unique_name, imag
 @pytest.mark.negative
 @pytest.mark.any_nodes
 class TestInvalidUpgrade:
+    @pytest.mark.skip(reason="https://github.com/harvester/harvester/issues/10220")
     @pytest.mark.skip_if_version(
             "< v1.5.0",
             reason="https://github.com/harvester/harvester/issues/7654 fix after `v1.5.0`")
@@ -442,6 +443,7 @@ class TestInvalidUpgrade:
         api_client.upgrades.delete(upgrade_name)
         api_client.versions.delete(version)
 
+    @pytest.mark.skip(reason="https://github.com/harvester/harvester/issues/10220")
     @pytest.mark.skip_if_version(
             "< v1.5.0",
             reason="https://github.com/harvester/harvester/issues/7654 fix after `v1.5.0`")


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
n/a

#### What this PR does / why we need it:
We found following issue which caused by side effects of invalid upgrade, see
* https://github.com/harvester/harvester/issues/10220

Consider the priority, this PR is going to temprarily skip those negative cases thus the main positives upgrade cases (`TestAnyNodesUpgrade`) can execute.

#### Special notes for your reviewer:

#### Additional documentation or context
* Verification
  <img width="1563" height="350" alt="image" src="https://github.com/user-attachments/assets/aefe261e-8ed8-4b88-8e03-ca9ad1466df7" />
