### PR TITLE
Use wait_stopped to ensure the vm stopped

### DIFF
--- a/harvester_e2e_tests/integrations/test_4_vm_snapshot.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_snapshot.py
@@ -383,10 +383,12 @@ class TestVMSnapshot:
 
     @pytest.mark.smoke
     @pytest.mark.dependency(name="replaced_source_vm", depends=["source_vm_snapshot"])
+    @pytest.mark.xfail_if_version(
+        ">= v1.7.0", "< v1.7.1", reason="https://github.com/harvester/harvester/issues/10012")
     def test_replace_vm_with_vm_snapshot(self, api_client,
                                          source_vm, vm_snapshot_name,
                                          ssh_keypair, host_shell,
-                                         vm_shell, wait_timeout):
+                                         vm_shell, wait_timeout, vm_checker):
         """
         Test that the original virtual machine can be replaced
         from its original snapshot (`vm-snapshot`) and that
@@ -410,7 +412,7 @@ class TestVMSnapshot:
         # Just to wait for `sync`
         sleep(2)
 
-        stop_vm(name, api_client, wait_timeout)
+        vm_checker.wait_stopped(name)
 
         spec = api_client.backups.RestoreSpec.for_existing(delete_volumes=False)
         code, data = api_client.vm_snapshots.restore(vm_snapshot_name, spec)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #2459

#### What this PR does / why we need it:
In current test_replace_vm_with_vm_snapshot, it trigger restore right after it stops the vm, which hit a race condition.
<img width="1913" height="1000" alt="Image" src="https://github.com/user-attachments/assets/30d32e96-04f2-41a9-8401-de78ca44e5d3" />
In this situation, automation won't hit the issue https://github.com/harvester/harvester/issues/10012.
Uses wait_stopped to ensure the vm stopped, then trigger the restore action.
More detail: https://github.com/harvester/tests/issues/2459#issuecomment-4073565235