### PR TITLE
Backward compatibilty for image_uid

### DIFF
--- a/apiclient/harvester_api/models/virtualmachines.py
+++ b/apiclient/harvester_api/models/virtualmachines.py
@@ -140,7 +140,7 @@ class VMSpec:
     def network_data(self, val):
         self._cloudinit_vol['volume']['cloudInitNoCloud']['networkData'] = val
 
-    def add_cd_rom(self, name, image_id, size=10, bus="SATA"):
+    def add_cd_rom(self, name, image_id, size=10, bus="SATA", image_uid=None):
         vol_spec = VolumeSpec(size, storage_cls=f"longhorn-{image_id.split('/')[1]}",
                               annotations={"harvesterhci.io/imageId": image_id})
 
@@ -160,7 +160,7 @@ class VMSpec:
         self.volumes.append(vol)
         return vol
 
-    def add_image(self, name, image_id, size=10, bus="virtio", type="disk"):
+    def add_image(self, name, image_id, size=10, bus="virtio", type="disk", image_uid=None):
         vol_spec = VolumeSpec(size, storage_cls=f"longhorn-{image_id.split('/')[1]}",
                               annotations={"harvesterhci.io/imageId": image_id})
 

--- a/apiclient/harvester_api/models/virtualmachines.pyi
+++ b/apiclient/harvester_api/models/virtualmachines.pyi
@@ -96,7 +96,8 @@ class VMSpec:
         name: str,
         image_id: str,
         size: int | float | United_S = ...,
-        bus: str = ...
+        bus: str = ...,
+        image_uid: Optional[str] = ...
     ) -> dict:
         """
         """
@@ -106,7 +107,8 @@ class VMSpec:
         image_id: str,
         size: int | float | United_S = ...,
         bus: str = ...,
-        type: str = ...
+        type: str = ...,
+        image_uid: Optional[str] = ...
     ) -> dict:
         """
         """


### PR DESCRIPTION
With https://github.com/harvester/tests/pull/2527 change, add the compatibility with <1.8.0. 