### PR TITLE
Skip tests related to version compatibility and volume

### DIFF
--- a/harvester_e2e_tests/integrations/test_upgrade.py
+++ b/harvester_e2e_tests/integrations/test_upgrade.py
@@ -483,6 +483,7 @@ class TestInvalidUpgrade:
         api_client.upgrades.delete(upgrade_name)
         api_client.versions.delete(version)
 
+    @pytest.mark.skip(reason="https://github.com/harvester/harvester/issues/10220")
     def test_version_compatibility(
         self, api_client, unique_name, upgrade_target, upgrade_timeout
     ):
@@ -508,6 +509,7 @@ class TestInvalidUpgrade:
         api_client.upgrades.delete(data['metadata']['name'])
         api_client.versions.delete(version)
 
+    @pytest.mark.skip(reason="https://github.com/harvester/harvester/issues/10220")
     def test_degraded_volume(
         self, api_client, unique_name, vm_shell_from_host, upgrade_target, stopped_vm,
         vm_checker, volume_checker, upgrade_checker


### PR DESCRIPTION
Follow-up to: https://github.com/harvester/tests/pull/2510

Skipping tests again due to https://github.com/harvester/harvester/issues/10220. They were  briefly re-enabled as https://github.com/harvester/harvester/issues/5494 was resolved, but must be disabled  until the new regression https://github.com/harvester/harvester/issues/10220 is fixed.

