### PR TITLE
[apiclient] update logic of cluster_version

### DIFF
--- a/apiclient/harvester_api/api.py
+++ b/apiclient/harvester_api/api.py
@@ -1,11 +1,23 @@
 from urllib.parse import urljoin
 
+import re
 import requests
 from pkg_resources import parse_version
 from requests.packages.urllib3.util.retry import Retry
 
 from . import managers as mgrs
 from .managers.base import DEFAULT_NAMESPACE
+
+
+def _normalize_version(version):
+    # XXX: https://github.com/harvester/harvester/issues/3137
+    # release-[any]-head => [any]-head
+    # master-SHA-head => v8.8-SHA-head
+    # [version]-SHA-head => [version]+SHA-head
+    ver = re.sub(r"^(?:release-v?(.+head))$", r"v\1", version)
+    ver = re.sub(r"^master(-.+)$", r"v8.8\1", ver)
+    ver = re.sub(r"(.+)-([^-]+?-head)$", r"\1+\2", ver)
+    return ver
 
 
 class HarvesterAPI:
@@ -42,24 +54,17 @@ class HarvesterAPI:
             resp = self._get("apis/{API_VERSION}/settings/server-version")
             ver = resp.json()['value']
             try:
-                # XXX: https://github.com/harvester/harvester/issues/3137
-                # Fixed as:
-                # 1. va.b-xxx-head => va.b.99
-                # 2. master-xxx-head => v8.8.99
-                # release-1.3-1bda61b3-head => v1.3-1bda61b3-head
-                if ver.startswith('release-'):
-                    ver = ver.replace('release-', 'v')
-                cur, _, _ = ver.split('-')
-                cur = "v8.8" if "master" in cur else cur
-                self._version = parse_version(f"{cur}.99")
-            except ValueError:
-                # TL;DR: use KubeVirt version if '-' in ver and '-rc' not in ver
-                # 1. va.b.c[-rc?] => valid version
-                # 2. 3874194f-dirty (customized build)
-                #    Use KubeVirt version as the customized version
+                version = parse_version(_normalize_version(ver))
+                assert version.major
+                self._version = version
+            except AttributeError:
+                # Use KubeVirt version as the customized version
+                # Set the invalid version for local version
+                # Final format: <KubeVirt_Ver>+<normalized_Ver>
                 data = self._get('apis/kubevirt.io/v1/kubevirts').json()
                 kube_ver = data['items'][0]['status'].get('operatorVersion')
-                self._version = parse_version(kube_ver if '-' in ver and '-rc' not in ver else ver)
+                self._version = parse_version(f"{kube_ver}+{version}")
+
             # store the raw version returns from `server-version` for reference
             self.raw_version = ver
         return self._version

--- a/apiclient/tests/test_api.py
+++ b/apiclient/tests/test_api.py
@@ -1,8 +1,63 @@
 from unittest import TestCase, mock
+from unittest.mock import PropertyMock
 
 import requests
+from pkg_resources import parse_version
 
-from harvester_api.api import HarvesterAPI
+from harvester_api.api import HarvesterAPI, _normalize_version
+
+
+class TestNomalizeVersion(TestCase):
+    valid_ver = parse_version("9.9.9").__class__
+    invalid_ver = parse_version("dirty").__class__
+
+    def test_general_version(self):
+        valid_form = [
+            "v1.0.0",
+            "1.0.0",
+            "1.0.0-alpha",
+            "1.0.0-alpha.1",
+            "1.0.0-beta",
+            "1.0.0-beta.2",
+            "1.0.0-rc1",
+            "1.0.0-rc.1",
+            "1.0.0-preview",
+            "1.0.0-pre.1",
+            "1.0.0-dev.20260331",
+        ]
+
+        for ver in valid_form:
+            with self.subTest(ver=ver):
+                out = parse_version(_normalize_version(ver))
+                self.assertIsInstance(out, self.valid_ver)
+
+    def test_master_build_version(self):
+        version = "master-1bda61b3-head"
+        out = parse_version(_normalize_version(version))
+
+        self.assertIsInstance(out, self.valid_ver)
+
+    def test_release_build_version(self):
+        expected_form = [
+            "release-1.3-1bda61b3-head",
+            "release-v1.8-1bda61b3-head",
+            "release-v1.8.0-rc3-b82-head",
+        ]
+
+        for ver in expected_form:
+            with self.subTest(ver=ver):
+                out = parse_version(_normalize_version(ver))
+                self.assertIsInstance(out, self.valid_ver)
+
+    def test_customized_build_version(self):
+        expected_form = [
+            "3874194f-dirty"
+        ]
+
+        for ver in expected_form:
+            with self.subTest(ver=ver):
+                out = parse_version(_normalize_version(ver))
+                self.assertIsInstance(out, self.invalid_ver)
 
 
 class TestHarvesterAPI(TestCase):
@@ -71,11 +126,11 @@ class TestHarvesterAPI(TestCase):
                     self.assertEqual(getattr(retries, attr), val)
 
     def test_load_managers(self):
-        default_ver, base_ver, new_ver = "", "0.0.0", "v1.1.0"
+        base_ver, new_ver = "0.0.0", "v1.1.0"
         api = HarvesterAPI("https://endpoint")
 
         self.assertEqual(api.hosts.support_to, base_ver)
-        self.assertEqual(api.hosts._ver, default_ver)
+        self.assertEqual(api.hosts._ver, base_ver)
 
         api.load_managers(new_ver)
         self.assertTrue(api.hosts.is_support(new_ver))
@@ -110,21 +165,27 @@ class TestHarvesterAPI(TestCase):
 
     def test_login(self):
         endpoint, user, pwd = "https://endpoint", "testuser", "testpasswd"
-        fake_version = "8.8.8"
+        fake_version = parse_version("8.8.8")
 
         with mock.patch.object(HarvesterAPI, 'authenticate') as m_auth, \
-             mock.patch.object(HarvesterAPI, 'cluster_version') as m_cluster_version:
+             mock.patch.object(
+                HarvesterAPI, 'cluster_version', new_callable=PropertyMock) as m_cluster_version:
             m_cluster_version.return_value = fake_version
 
             api = HarvesterAPI.login(endpoint, user, pwd)
 
-            m_auth.assert_called_once_with(user, pwd, verify=True)
-            self.assertEqual(api.vms._ver, m_cluster_version)
+            m_auth.assert_called_once_with(user, pwd)
+            self.assertTrue(api.session.verify)
+            self.assertEqual(api.vms._ver, fake_version)
 
         m_session, ssl_verify = mock.MagicMock(), False
         with mock.patch.object(HarvesterAPI, 'authenticate') as m_auth, \
-             mock.patch.object(HarvesterAPI, 'cluster_version') as m_cluster_version:
+             mock.patch.object(
+                HarvesterAPI, 'cluster_version', new_callable=PropertyMock) as m_cluster_version:
+            m_cluster_version.return_value = fake_version
+
             api = HarvesterAPI.login(endpoint, user, pwd, m_session, ssl_verify=ssl_verify)
 
             self.assertEqual(api.session, m_session)
-            m_auth.assert_called_once_with(user, pwd, verify=ssl_verify)
+            m_auth.assert_called_once_with(user, pwd)
+            self.assertEqual(m_session.verify, ssl_verify)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:
Engineer team have new logic for cluster version, we need to handle those.
(discussion thread in slack.)

#### Special notes for your reviewer:
1. Move parse logic to `_normalize_version`
2. Change to use regex for most case
3. store SHA info as local version as `<VersionInstance>.local`
4. add unittest for `_normalize_version`
5. update legacy unttest cases of `test_api.py`

#### Additional documentation or context
1. For *invalid* version, add new version item in `test_customized_build_version` and run unittest to make sure it will pass.
2. For *valid* version, add new version item to relevant test case and run unittest to make sure it will pass.

Run the command like `python -m unittest apiclient/tests/test_api.py`

<img width="1100" height="492" alt="image" src="https://github.com/user-attachments/assets/ebd35e66-504b-4711-87e1-b4b0ccd765ea" />