### PR TITLE
added in python dependency versions via pip freeze after 

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -20,3 +20,4 @@ scp==0.15.0
 sshpubkeys==3.3.1
 tox==4.50.3
 urllib3==2.6.3
+-e ./apiclient


### PR DESCRIPTION
pip install -r test-requirements

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # [2539](https://github.com/harvester/tests/issues/2539)

#### What this PR does / why we need it:
This is pinning the versions of our python test dependencies as well as adding explicit installs for the packages which allows us to check if versions changed
#### Special notes for your reviewer:
This was done via `pip3 install -r test-requirements` and `pip freeze` so it adds in all of the dependencies that weren't specifically pinned in the `test-requirements.txt`.

#### Additional documentation or context
