### PR TITLE
Check source_pod status in wait_migrated

### DIFF
--- a/harvester_e2e_tests/fixtures/virtualmachines.py
+++ b/harvester_e2e_tests/fixtures/virtualmachines.py
@@ -332,7 +332,6 @@ def vm_checker(api_client, wait_timeout, sleep_timeout, vm_shell):
             return True, (ctx.stdout, ctx.stderr)
 
         def wait_migrated(self, vm_name, new_host, endtime=None, callback=default_cb, **kws):
-            # ref: https://github.com/harvester/tests/pull/2582
             ctx = ResponseContext('vm.migrate', *self.vms.migrate(vm_name, new_host, **kws))
             if 404 == ctx.code and callback(ctx):
                 return False, ctx
@@ -340,10 +339,20 @@ def vm_checker(api_client, wait_timeout, sleep_timeout, vm_shell):
             endtime = endtime or self._endtime()
             while endtime > datetime.now():
                 ctx = ResponseContext('vm.get_status', *self.vms.get_status(vm_name, **kws))
+
+                pod_name = ctx.data.get('status', {}).get('migrationState', {}).get('sourcePod')
+                pod_migrated = next(
+                    (r.get('state') for r in ctx.data.get('metadata', {}).get('relationships', [])
+                     if r.get('toId', "").endswith(pod_name or "Pod unavailable")),
+                    "SourcePod Migrate State"
+                )
+
+                # ref: https://github.com/harvester/tests/pull/2582#discussion_r3098266646
                 if (
                     not ctx.data['metadata']['annotations'].get("harvesterhci.io/migrationState")
                     and new_host == ctx.data['status']['nodeName']
                     and "AgentConnected" == ctx.data['status']['conditions'][-1].get('type')
+                    and 'succeeded' == pod_migrated
                     and callback(ctx)
                 ):
                     break


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #2574 

#### What this PR does / why we need it:
Even check `AgentConnected`, the state of source pod may still in `unavailable`, which will cause the `test_abort_migrate` fail due to multiple active pods.

```
        "relationships": [
            {
                "fromId": "default/vm-10h40m50s850340-04-21",
                "fromType": "kubevirt.io.virtualmachine",
                "rel": "owner",
                "state": "active",
                "message": "Resource is Ready",
            },
            {
                "toId": "default/virt-launcher-vm-10h40m50s850340-04-21-jnrtn",
                "toType": "pod",
                "rel": "owner",
                "state": "unavailable",
                "message": "containers with unready status: [compute]",
                "transitioning": True,
            },
            {
                "toId": "default/virt-launcher-vm-10h40m50s850340-04-21-8rq52",
                "toType": "pod",
                "rel": "owner",
                "state": "running",
            },
        ],
...
        "migrationMethod": "BlockMigration",
        "migrationState": {
            "completed": True,
            "endTimestamp": "2026-04-21T02:44:14Z",
            "migrationConfiguration": {
                "allowAutoConverge": False,
                "allowPostCopy": False,
                "allowWorkloadDisruption": False,
                "bandwidthPerMigration": "0",
                "completionTimeoutPerGiB": 150,
                "nodeDrainTaintKey": "kubevirt.io/drain",
                "parallelMigrationsPerCluster": 5,
                "parallelOutboundMigrationsPerNode": 2,
                "progressTimeout": 150,
                "unsafeMigrationOverride": False,
            },
```

Also checking the `state` of the `relationships`, it can avoid this kind of issue.

#### Special notes for your reviewer:

#### Additional documentation or context
Test Pass
<img width="1087" height="749" alt="image" src="https://github.com/user-attachments/assets/c7b4d900-185a-4046-8857-92b09df62d44" />

