### PR TITLE
fix: add missing image_uid argument

### DIFF
--- a/harvester_e2e_tests/integrations/test_4_vm_host_cpu_pinning.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_host_cpu_pinning.py
@@ -41,7 +41,7 @@ def ubuntu_image(api_client, unique_name, image_ubuntu, image_checker):
 def ubuntu_vm(api_client, unique_name, ubuntu_image, volume_checker, wait_timeout):
     cpu, mem, unique_vm_name = 1, 2, f"pin-cpu-{unique_name}"
     vm_spec = api_client.vms.Spec(cpu, mem)
-    vm_spec.add_image("disk-0", ubuntu_image.id, ubuntu_image.uid)
+    vm_spec.add_image("disk-0", ubuntu_image.id, image_uid=ubuntu_image.uid)
     vm_spec.cpu_pinning = True
     code, data = api_client.vms.create(unique_vm_name, vm_spec)
     assert 201 == code, (


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #2578

#### What this PR does / why we need it:
To fix the missing `image_uid` argument, which cause the VM creation fail case issue

#### Special notes for your reviewer:

#### Additional documentation or context
Test Pass
<img width="1373" height="671" alt="image" src="https://github.com/user-attachments/assets/61b5cbf3-7948-41b9-83fe-d3f2cd6c2120" />
