### PR TITLE
redid the pr assign workflows and DCO to not use pull_request_target

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   check:
     name: DCO Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check if PR is from Copilot
         id: check-copilot

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,7 +1,7 @@
 name: DCO
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - master

--- a/.github/workflows/pr-management-auto-assign-check.yml
+++ b/.github/workflows/pr-management-auto-assign-check.yml
@@ -1,0 +1,25 @@
+name: "PR Management Auto Assign Collect Data"
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Save PR data to artifact
+        run: |
+          {
+            echo "PR_NUMBER=${{ github.event.pull_request.number }}"
+            echo "PR_AUTHOR=${{ github.event.pull_request.user.login }}"
+          } > pr-auto-assign-data.env
+
+      - name: Upload PR data artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: pr-auto-assign-data
+          path: pr-auto-assign-data.env

--- a/.github/workflows/pr-management-auto-assign-check.yml
+++ b/.github/workflows/pr-management-auto-assign-check.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   collect:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       actions: write

--- a/.github/workflows/pr-management-auto-assign.yml
+++ b/.github/workflows/pr-management-auto-assign.yml
@@ -1,16 +1,33 @@
-name: "[PR Management] Auto Assign"
+name: "PR Management Auto Assign"
 
 on:
-  pull_request_target:
-    types: [opened, ready_for_review]
-
-permissions:
-  pull-requests: write
+  workflow_run:
+    workflows:
+      - "PR Management Auto Assign Collect Data"
+    types: [completed]
 
 jobs:
   auto-assign:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      actions: read
+      pull-requests: write
     steps:
-      - uses: rancher/gh-issue-mgr/auto-assign-action@b70f0bdf12a03e5e3f33e4f92ccb6c89deb3ebd9 # main
+      - name: Download PR data artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          configuration-path: .github/auto-assign-config.yaml
+          name: pr-auto-assign-data
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Load PR data
+        run: |
+          cat pr-auto-assign-data.env >> $GITHUB_ENV
+
+      - name: Auto assign PR author
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Assigning PR author: $PR_AUTHOR"
+          gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" --add-assignee "$PR_AUTHOR"

--- a/.github/workflows/pr-management-auto-assign.yml
+++ b/.github/workflows/pr-management-auto-assign.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   auto-assign:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       actions: read


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:
This removes  pull_request_target from our github actions.
#### Special notes for your reviewer:
#### Additional documentation or context
This is based off of this [PR](https://github.com/harvester/docs/pull/992)
