### PR TITLE
Fix env vars retrieving and based on CLI has higher priority than .env

### DIFF
--- a/harvester_robot_tests/keywords/variables.resource
+++ b/harvester_robot_tests/keywords/variables.resource
@@ -16,8 +16,8 @@ ${RETRY_INTERVAL}               3
 ${SLEEP_TIMEOUT}                3
 
 # Images
-${OPENSUSE_IMAGE_URL}           https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.6/images/openSUSE-Leap-15.6.x86_64-NoCloud.qcow2
-${UBUNTU_IMAGE_URL}             https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-amd64.img
+${OPENSUSE_IMAGE_URL}           %{OPENSUSE_IMAGE_URL=https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.6/images/openSUSE-Leap-15.6.x86_64-NoCloud.qcow2}
+${UBUNTU_IMAGE_URL}             %{UBUNTU_IMAGE_URL=https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-amd64.img}
 
 # Network
 ${VLAN_ID}                      %{VLAN_ID=1}

--- a/harvester_robot_tests/run.sh
+++ b/harvester_robot_tests/run.sh
@@ -4,6 +4,25 @@ set -e
 # Harvester Robot Framework Test Runner
 # Usage: ./run.sh [options]
 
+# Color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# Load .env if exists
+if [ -f .env ]; then
+    echo -e "${GREEN}Loading .env file...${NC}"
+    # Export variables from .env, skip comments and empty lines
+    set -a
+    source .env
+    set +a
+    echo -e "${GREEN}Environment variables loaded from .env${NC}"
+else
+    echo -e "${YELLOW}Warning: .env file not found${NC}"
+    echo -e "${YELLOW}Copy .env.example to .env and configure: cp .env.example .env${NC}"
+fi
+
 # Default values
 TEST_CASE=""
 TEST_SUITE=""
@@ -11,14 +30,8 @@ TEST_FILE=""
 INCLUDE_TAG=""
 EXCLUDE_TAG=""
 VARIABLES=""
-LOG_LEVEL="INFO"
-OUTPUT_DIR=${OUTPUT_DIR:-/tmp/harvester-test-report}
-
-# Color codes
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
+LOG_LEVEL=${ROBOT_LOG_LEVEL:-INFO}
+OUTPUT_DIR=${ROBOT_OUTPUT_DIR:-/tmp/harvester-test-report}
 
 show_help() {
     cat << EOF
@@ -86,19 +99,6 @@ if [[ -z "$VIRTUAL_ENV" ]]; then
     read -p "Continue? (y/N) " -n 1 -r
     echo
     [[ ! $REPLY =~ ^[Yy]$ ]] && exit 1
-fi
-
-# Load .env if exists
-if [ -f .env ]; then
-    echo -e "${GREEN}Loading .env file...${NC}"
-    # Export variables from .env, skip comments and empty lines
-    set -a
-    source .env
-    set +a
-    echo -e "${GREEN}Environment variables loaded from .env${NC}"
-else
-    echo -e "${YELLOW}Warning: .env file not found${NC}"
-    echo -e "${YELLOW}Copy .env.example to .env and configure: cp .env.example .env${NC}"
 fi
 
 # Check required variables


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Not implementation but just fix minor issue during work on issue #1482

#### What this PR does / why we need it:
1. Fix and let image urls in variables.resources can read env. variables.
2. Fix and let `ROBOT_OUTPUT_DIR` and `ROBOT_LOG_LEVEL` can be read by `run.sh`
3. Drop incorrect report path message `Reports:` at the end of `run.sh` cuz robot already provide it.
    ```
    1 test, 1 passed, 0 failed
    ==============================================================================
    Output:  /home/albin/Workspace/albinsun/harvester-tests/harvester_robot_tests/results/output-20260504-175630.xml
    Log:     /home/albin/Workspace/albinsun/harvester-tests/harvester_robot_tests/results/log-20260504-175630.html
    Report:  /home/albin/Workspace/albinsun/harvester-tests/harvester_robot_tests/results/report-20260504-175630.html
    ```
   

#### Special notes for your reviewer:
Here I suppose `run.sh` should has higher priority than `.env`, so `source` it before `getopts`.

#### Additional documentation or context
<img width="1642" height="1000" alt="image" src="https://github.com/user-attachments/assets/60ad01da-da9f-4646-b8f0-e617a087c7a7" />
