### PR TITLE
[e2e] new test cases for guest memory overhead

### DIFF
--- a/harvester_e2e_tests/apis/test_settings.py
+++ b/harvester_e2e_tests/apis/test_settings.py
@@ -14,7 +14,8 @@
 #
 # To contact SUSE about this file by physical or electronic mail,
 # you may find current contact information at www.suse.com
-import warnings
+from time import sleep
+from random import uniform
 
 import pytest
 
@@ -37,30 +38,6 @@ def test_get_all_settings(api_client, expected_settings):
         "Some setting missing:\n"
         f"{expected_settings - available_settings}"
     )
-
-
-@pytest.mark.p0
-@pytest.mark.settings
-@pytest.mark.skip_if_version("< v1.1.0")
-def test_get_all_settings_v110(api_client, expected_settings):
-    expected_settings = expected_settings['default'] | expected_settings['1.1.0']
-    code, data = api_client.settings.get()
-
-    available_settings = {m['metadata']['name'] for m in data['items']}
-
-    assert 200 == code, (code, data)
-    assert expected_settings <= available_settings, (
-        "Some setting missing:\n"
-        f"{expected_settings - available_settings}"
-    )
-
-    removed = expected_settings - available_settings
-    added = available_settings - expected_settings
-
-    if removed:
-        warnings.warn(UserWarning(f"Few setting(s) been removed: {removed}."))
-    if added:
-        warnings.warn(UserWarning(f"New setting(s) added: {added}"))
 
 
 @pytest.mark.p0
@@ -194,3 +171,71 @@ class TestUpdateKubeconfigDefaultToken:
             f"Kubeconfig Default Token TTL Minutes be allowed to be set for 120 days\n"
             f"API Status({code}): {data}"
         )
+
+
+@pytest.mark.p0
+@pytest.mark.sanity
+@pytest.mark.settings
+class TestAdditionalGuestMemOverhead:
+    '''
+    Description on UI:
+      The ratio for kubevirt to adjust the VM overhead memory.
+      The value could be zero, empty value or floating number between 1.0 and 10.0, default to 1.5.
+    '''
+    def test_get(self, api_client):
+        code, data = api_client.settings.get('additional-guest-memory-overhead-ratio')
+        assert 200 == code, (
+            "Failed to get additional-guest-memory-overhead-ratio setting with error: "
+            f"{code}, {data}"
+        )
+
+    def test_empty_value(self, api_client):
+        setting_name = 'additional-guest-memory-overhead-ratio'
+
+        code, data = api_client.settings.get(setting_name)
+        assert 200 == code, (code, data)
+        original_value = data.get('value', "")
+
+        code, data = api_client.settings.update(setting_name, {"value": ""})
+        assert 200 == code, (f"Failed to {setting_name} setting with error: {code}, {data}")
+        assert not data.get('value'), (
+            f"Setting {setting_name} not be updated to default value "
+            f"when update empty value to it, the updated value: {data['value']}"
+        )
+
+        # for teardown
+        api_client.settings.update(setting_name, {"value": original_value})
+
+    def test_valid_values(self, api_client):
+        setting_name = 'additional-guest-memory-overhead-ratio'
+
+        code, data = api_client.settings.get(setting_name)
+        assert 200 == code, (code, data)
+        original_value = data.get('value', "")
+
+        for val in (str(round(uniform(1, 10), 1)) for _ in range(5)):
+            code, data = api_client.settings.update(setting_name, {"value": val})
+            assert 200 == code, (
+                f"Failed to update {setting_name} to value {val} with error: {code}, {data}"
+            )
+            sleep(0.1)
+
+        # for teardown
+        api_client.settings.update(setting_name, {"value": original_value})
+
+    @pytest.mark.negative
+    def test_invalid_values(self, api_client):
+        setting_name = 'additional-guest-memory-overhead-ratio'
+
+        code, data = api_client.settings.get(setting_name)
+        assert 200 == code, (code, data)
+        original_value = data.get('value', "")
+
+        for val in ("100", "0.1", "-1", "not_int"):
+            code, data = api_client.settings.update(setting_name, {"value": val})
+            assert 422 == code, (
+                f"Setting {setting_name} be updated to the invalid value {val}"
+            )
+
+        # for teardown
+        api_client.settings.update(setting_name, {"value": original_value})

--- a/harvester_e2e_tests/apis/test_settings.py
+++ b/harvester_e2e_tests/apis/test_settings.py
@@ -199,8 +199,8 @@ class TestAdditionalGuestMemOverhead:
         code, data = api_client.settings.update(setting_name, {"value": ""})
         assert 200 == code, (f"Failed to {setting_name} setting with error: {code}, {data}")
         assert not data.get('value'), (
-            f"Setting {setting_name} not be updated to default value "
-            f"when update empty value to it, the updated value: {data['value']}"
+            f"Setting {setting_name} should remain empty when updated with an empty value, "
+            f"but the updated value was: {data['value']}"
         )
 
         # for teardown
@@ -218,8 +218,11 @@ class TestAdditionalGuestMemOverhead:
             assert 200 == code, (
                 f"Failed to update {setting_name} to value {val} with error: {code}, {data}"
             )
-            sleep(0.1)
-
+            code, data = api_client.settings.get(setting_name)
+            assert 200 == code and val == data.get('value', ""), (
+                f"Setting {setting_name} not be updated to value {val} successfully"
+            )
+            sleep(0.5)
         # for teardown
         api_client.settings.update(setting_name, {"value": original_value})
 
@@ -236,6 +239,11 @@ class TestAdditionalGuestMemOverhead:
             assert 422 == code, (
                 f"Setting {setting_name} be updated to the invalid value {val}"
             )
+            code, data = api_client.settings.get(setting_name)
+            assert 200 == code and val != data.get('value', ""), (
+                f"Setting {setting_name} be updated to invalid value {val} silently"
+            )
+            sleep(0.5)
 
         # for teardown
         api_client.settings.update(setting_name, {"value": original_value})

--- a/harvester_e2e_tests/fixtures/api_client.py
+++ b/harvester_e2e_tests/fixtures/api_client.py
@@ -164,7 +164,6 @@ def support_bundle_state():
 @pytest.fixture(scope="session")
 def expected_settings():
     return {
-        "1.1.0": {'storage-network', 'containerd-registry', 'ui-plugin-index'},
         "default": {
             'additional-ca',
             'auto-disk-provision-paths',
@@ -186,6 +185,12 @@ def expected_settings():
             'upgrade-checker-url',
             'vip-pools',
             'vm-force-reset-policy',
+            # v1.1.0
+            'storage-network',
+            'containerd-registry',
+            'ui-plugin-index',
+            # v1.4.0
+            'additional-guest-memory-overhead-ratio',
         }
     }
 

--- a/harvester_e2e_tests/integrations/test_3_vm_functions.py
+++ b/harvester_e2e_tests/integrations/test_3_vm_functions.py
@@ -204,6 +204,22 @@ def unset_cpu_memory_overcommit(api_client):
     api_client.settings.update('overcommit-config', spec)
 
 
+@pytest.fixture(scope="class")
+def overhead_ratio(api_client):
+    setting_name = 'additional-guest-memory-overhead-ratio'
+    code, data = api_client.settings.get(setting_name)
+    assert 200 == code, (code, data)
+
+    origin_val = data.get('value', "")
+
+    code, data = api_client.settings.update(setting_name, {"value": "1.5"})
+    assert 200 == code, (code, data)
+
+    yield data
+
+    api_client.settings.update(setting_name, {"value": origin_val})
+
+
 @pytest.mark.p0
 @pytest.mark.smoke
 @pytest.mark.virtualmachines
@@ -2600,3 +2616,75 @@ class TestCpuMemHotPlug:
         for vol in vm_spec.volumes:
             vol_name = vol['volume']['persistentVolumeClaim']['claimName']
             api_client.volumes.delete(vol_name)
+
+
+@pytest.mark.smoke
+@pytest.mark.virtualmachines
+class TestVMWithMemoryOverhead:
+    _mem = 2147483648  # 2Gi == 2 * 1024 * 2 ** 20 (stopped_vm)
+
+    @pytest.mark.dependency(name="default_ratio")
+    def test_overhead_default_ratio(self, api_client, vm_checker, stopped_vm, overhead_ratio):
+        vm_name, _ = stopped_vm
+        vm_started, (code, vmi) = vm_checker.wait_started(vm_name)
+        assert vm_started, (code, vmi)
+
+        for i in vmi['metadata']['relationships']:
+            if i.get('toType') == "pod":
+                ns, name = i['toId'].split("/")
+                break
+        else:
+            raise AssertionError(
+                f"Unable to find the pod name of VM {vm_name}\n"
+                f"VMI info: {vmi}"
+            )
+
+        code, data = api_client.get_pods(name, ns)
+        assert 200 == code, (code, data)
+
+        pod_mem = int(data['spec']['containers'][0]['resources']['limits']['memory'])
+
+        overhead = pod_mem - self._mem
+        assert overhead >= 240 * 1.5 * 2 ** 20, (
+            f"Pod's memory overhead {overhead} is less than 240Mi\n"
+            f"pod memory: {pod_mem}"
+        )
+
+        overhead_ratio['_overhead'] = overhead  # side-effect for next test case
+        vm_checker.wait_stopped(vm_name)
+
+    @pytest.mark.dependency(depends=["default_ratio"])
+    def test_overhead_double_ratio(self, api_client, vm_checker, stopped_vm, overhead_ratio):
+        code, data = api_client.settings.update(
+            "additional-guest-memory-overhead-ratio",
+            dict(value="3")
+        )
+        assert 200 == code, (code, data)
+
+        vm_name, _ = stopped_vm
+        vm_started, (code, vmi) = vm_checker.wait_started(vm_name)
+        assert vm_started, (code, vmi)
+
+        for i in vmi['metadata']['relationships']:
+            if i.get('toType') == "pod":
+                ns, name = i['toId'].split("/")
+                break
+        else:
+            raise AssertionError(
+                f"Unable to find the pod name of VM {vm_name}\n"
+                f"VMI info: {vmi}"
+            )
+
+        code, data = api_client.get_pods(name, ns)
+        assert 200 == code, (code, data)
+
+        pod_mem = int(data['spec']['containers'][0]['resources']['limits']['memory'])
+
+        overhead = pod_mem - self._mem
+        expected_overhead = overhead_ratio['_overhead'] * 2
+        tolerance_bytes = 1 * 2 ** 20  # 1 MiB tolerance to avoid flaky byte-level comparisons
+        assert abs(overhead - expected_overhead) <= tolerance_bytes, (
+            "additional-guest-memory-overhead-ratio not working as expected after set to double\n"
+            f"expected overhead: {expected_overhead}, actual overhead: {overhead}, "
+            f"tolerance: {tolerance_bytes}"
+        )


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #1497

#### What this PR does / why we need it:
- **NEW** API tests to test memory overhead setting
- **UPDATE** test settings (drop v1.1.0 and merge existing)
- **NEW** test cases to test memory overhead settings is working on VM

#### Special notes for your reviewer:
We documented the overhead will be `240Mi`, but as I tested, it's not fixed as our documentation.
so test cases implemented to check:
1. When using default ratio (1.5), the overhead should be >= `240 * 1.5 Mi`
2. When using double ratio (3), the overhead should be around the double value of default ratio

#### Additional documentation or context
ref to https://docs.harvesterhci.io/v1.6/advanced/index/#additional-guest-memory-overhead-ratio