### PR TITLE
Enable LonghornV2 engine and provision disks

### DIFF
--- a/.github/workflows/ci-worflow.yml
+++ b/.github/workflows/ci-worflow.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.8]
+        python: ["3.10"]
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ __pycache__/
 *.log
 assets
 test_result.html
+log.html
+output.xml
+report.html
 *venv
 *.kube
 *provider.tf

--- a/harvester_robot_tests/keywords/common.resource
+++ b/harvester_robot_tests/keywords/common.resource
@@ -1,7 +1,8 @@
 *** Settings ***
 Documentation    Common Keywords
-Resource         variables.resource
 Library          ../libs/keywords/common_keywords.py
+Resource         variables.resource
+
 
 *** Keywords ***
 Set up test environment
@@ -18,3 +19,16 @@ Cleanup test resources
     Run Keyword And Ignore Error    common_keywords.Cleanup images
     Run Keyword And Ignore Error    common_keywords.Cleanup networks
     Run Keyword And Ignore Error    common_keywords.Cleanup backups
+
+List Pods By Label
+    [Arguments]    ${namespace}    ${label_selector}   ${status}=${None}
+    [Documentation]    Get pods by label selector
+    ${pods}=    common_keywords.list_pods_by_label    ${namespace}    ${label_selector}    ${status}
+    RETURN    ${pods}
+
+Count Pods By Label
+    [Arguments]    ${namespace}    ${label_selector}   ${status}=${None}
+    [Documentation]    Get pods by label selector
+    ${pods}=    common_keywords.list_pods_by_label    ${namespace}    ${label_selector}    ${status}
+    ${count}=   Get Length    ${pods}
+    RETURN    ${count}

--- a/harvester_robot_tests/keywords/host.resource
+++ b/harvester_robot_tests/keywords/host.resource
@@ -123,3 +123,14 @@ Cleanup test resources and restore nodes
     [Documentation]    Clean up resources and ensure all nodes are restored
     Cleanup test resources
     Restore all nodes
+
+List Standard Nodes
+    [Documentation]    Get list of standard nodes
+    ${node_names}=    host_keywords.get_standard_nodes
+    RETURN    ${node_names}
+
+Count Standard Nodes
+    [Documentation]    Get list of standard nodes
+    ${node_names}=    host_keywords.get_standard_nodes
+    ${node_count}=    Get Length    ${node_names}
+    RETURN    ${node_count}

--- a/harvester_robot_tests/keywords/setting.resource
+++ b/harvester_robot_tests/keywords/setting.resource
@@ -1,0 +1,57 @@
+*** Settings ***
+Documentation    Setting Keywords
+Library          ../libs/keywords/setting_keywords.py
+Resource         variables.resource
+Resource         storage.resource
+
+
+*** Variables ***
+${LHv2_SETTING_ID}    longhorn-v2-data-engine-enabled
+
+
+*** Keywords ***
+Enable
+    [Arguments]    ${setting_id}
+    [Documentation]    Enable setting by ID
+    ${setting}=    setting_keywords.enable    ${setting_id}
+    Sleep    ${SLEEP_TIMEOUT}    Buffer time before checking
+    RETURN    ${setting}
+
+Configured Message Should Be None
+    [Arguments]    ${setting_id}
+    [Documentation]    Assert configured condition message is None
+    ${configured_msg}=    setting_keywords.get_condition_message    ${setting_id}    configured
+    Should Be Equal    ${configured_msg}    ${None}
+
+Is Disabled
+    [Arguments]    ${setting_id}
+    [Documentation]    Assert setting is disabled
+    ${value}=    setting_keywords.get_value  ${setting_id}
+    Should Not Be Equal    ${value}    true
+    Configured Message Should Be None    ${setting_id}
+
+Is Enabled
+    [Arguments]    ${setting_id}
+    [Documentation]    Assert setting is enabled
+    ${value}=    setting_keywords.get_value  ${setting_id}
+    Should Be Equal    ${value}    true
+    Configured Message Should Be None    ${setting_id}
+
+# longhorn-v2-data-engine-enabled
+Enable LHv2 Data Engine
+    [Documentation]    Enable Setting ``${LHv2_SETTING_ID}``
+    Enable    ${LHv2_SETTING_ID}
+
+LHv2 Data Engine Is Disabled
+    [Documentation]    Check Setting ``${LHv2_SETTING_ID}`` is ``false`` and no v2 pods
+    Is Disabled    ${LHv2_SETTING_ID}
+    storage.Standard Nodes Have No v2 IM Pods
+
+LHv2 Data Engine Is Enabled
+    [Documentation]    Check Setting ``${LHv2_SETTING_ID}`` is ``true`` and v2 pods are running
+    Is Enabled    ${LHv2_SETTING_ID}
+    storage.Standard Nodes Have Running v2 IM Pods
+
+Wait Until LHv2 Data Engine Is Enabled
+    Wait Until Keyword Succeeds    ${WAIT_TIMEOUT}    ${RETRY_INTERVAL}
+    ...    LHv2 Data Engine Is Enabled

--- a/harvester_robot_tests/keywords/storage.resource
+++ b/harvester_robot_tests/keywords/storage.resource
@@ -1,0 +1,79 @@
+*** Settings ***
+Documentation    Storage Keywords
+Library          ../libs/keywords/storage_keywords.py
+Resource         variables.resource
+Resource         common.resource
+Resource         host.resource
+
+
+*** Variables ***
+&{DATA_DISK_BY_NODE}    &{EMPTY}
+${LHv2_SC_REPLICAS}    ${EMPTY}
+
+
+*** Keywords ***
+# instance-manager (IM)
+Standard Nodes Have Running v2 IM Pods
+    ${standard_nodes_count}=    host.Count Standard Nodes
+    ${running_v2_im_pods_count}=    common.Count Pods By Label
+    ...    ${LONGHORN_NAMESPACE}
+    ...    longhorn.io/data-engine=v2,longhorn.io/component=instance-manager
+    ...    status=Running
+    Should Be Equal As Integers    ${running_v2_im_pods_count}    ${standard_nodes_count}
+
+Standard Nodes Have No v2 IM Pods
+    ${standard_nodes_count}=    host.Count Standard Nodes
+    ${v2_im_pods_count}=    common.Count Pods By Label
+    ...    ${LONGHORN_NAMESPACE}
+    ...    longhorn.io/data-engine=v2,longhorn.io/component=instance-manager
+    Should Be Equal As Integers    ${v2_im_pods_count}    0
+
+# Provision LHv2 Storages
+Pick Unprovisioned Data Disks
+    [Arguments]    ${namespace}=${LONGHORN_NAMESPACE}
+    [Documentation]    Pick usable data disks per standard node as disk name by node name
+    &{disk_by_node}=    storage_keywords.pick_unprovisioned_data_disks    ${namespace}
+    RETURN    &{disk_by_node}
+
+Cluster Has Available Data Disks And Set Suite Variables
+    [Documentation]    Check if there are 1 to 3 unprovisioned data disks
+    &{DATA_DISK_BY_NODE}=    Pick Unprovisioned Data Disks
+    &{DATA_DISK_BY_NODE}=    Evaluate    dict(list($DATA_DISK_BY_NODE.items())[:3])
+    ${data_disks_count}=    Get Length    ${DATA_DISK_BY_NODE}
+    Should Be True    ${data_disks_count} >= 1    Cluster has NO available data disk
+
+    Set Suite Variable    &{DATA_DISK_BY_NODE}
+    Set Suite Metadata    DATA_DISK_BY_NODE    ${DATA_DISK_BY_NODE}
+    Set Suite Variable    ${LHv2_SC_REPLICAS}    ${data_disks_count}
+    Set Suite Metadata    LHv2_SC_REPLICAS    ${LHv2_SC_REPLICAS}
+
+Provision Storages With LHv2 Data Engine
+    [Arguments]    &{disk_by_node}
+    FOR    ${node}    ${disk}    IN    &{disk_by_node}
+        Set Test Message    \nProvision blockdevice ${LONGHORN_NAMESPACE}/${disk} with LHv2    append=yes
+        storage_keywords.provision_longhorn_storage    ${disk}    LonghornV2    ${LONGHORN_NAMESPACE}
+    END
+
+Blockdevice Is Provisioned
+    [Arguments]    ${name}    ${namespace}=${LONGHORN_NAMESPACE}
+    ${is_provisioned}=    storage_keywords.is_blockdevice_provisioned    ${name}    ${namespace}
+    Should Be True    ${is_provisioned}    Blockdevice ${namespace}/${name} is NOT provisioned
+
+Longhorn Node Disk Is ${condition}
+    [Arguments]    ${node_name}    ${disk_name}
+    [Documentation]    Check Longhorn node disk has the expected condition
+    ${cond_status}=    storage_keywords.get_lh_node_disk_status_condition    ${node_name}    ${disk_name}    ${condition}
+    Should Be True    ${cond_status}
+
+Wait Until LHv2 Storages Are Provisioned
+    [Arguments]    &{disk_by_node}
+    [Documentation]    Check provisioned storages are ``Ready``, ``Schedulable`` and ``Provisioned``
+    FOR    ${node}    ${disk}    IN    &{disk_by_node}
+        Log    Waiting storage ${disk} on node ${node} become ``Ready``, ``Schedulable`` and ``Provisioned``...
+        Wait Until Keyword Succeeds    ${WAIT_TIMEOUT}    ${RETRY_INTERVAL}
+        ...    Blockdevice Is Provisioned    ${disk}
+        Wait Until Keyword Succeeds    ${WAIT_TIMEOUT}    ${RETRY_INTERVAL}
+        ...    Longhorn Node Disk Is Ready    ${node}    ${disk}
+        Wait Until Keyword Succeeds    ${WAIT_TIMEOUT}    ${RETRY_INTERVAL}
+        ...    Longhorn Node Disk Is Schedulable    ${node}    ${disk}
+    END

--- a/harvester_robot_tests/keywords/variables.resource
+++ b/harvester_robot_tests/keywords/variables.resource
@@ -39,6 +39,7 @@ ${RETRY_COUNT}                  100
 
 # Namespaces and Labels
 ${DEFAULT_NAMESPACE}            default
+${LONGHORN_NAMESPACE}           longhorn-system
 ${LABEL_TEST}                   test-harvester
 
 # NVIDIA Driver Toolkit Addon

--- a/harvester_robot_tests/libs/blockdevice/__init__.py
+++ b/harvester_robot_tests/libs/blockdevice/__init__.py
@@ -1,0 +1,4 @@
+
+from blockdevice.blockdevice import Blockdevice
+
+__all__ = ['Blockdevice']

--- a/harvester_robot_tests/libs/blockdevice/base.py
+++ b/harvester_robot_tests/libs/blockdevice/base.py
@@ -1,0 +1,32 @@
+""" Blockdevice Component: Base Class
+
+Layer 4: Component and its implementation
+"""
+
+from abc import ABC, abstractmethod
+
+
+class Base(ABC):
+    @abstractmethod
+    def list(self, namespace):
+        """List blockdevices, optionally by namespace
+
+        Return a list of blockdevices
+        """
+        pass
+
+    @abstractmethod
+    def get(self, name, namespace):
+        """Get blockdevice, optionally by name and namespace
+
+        Return a blockdevice or None
+        """
+        pass
+
+    @abstractmethod
+    def provision_longhorn_storage(self, name, engine_version, namespace):
+        """Provision a blockdevice for Longhorn storage
+
+        Return nothing, but raise exception if operation fails
+        """
+        pass

--- a/harvester_robot_tests/libs/blockdevice/blockdevice.py
+++ b/harvester_robot_tests/libs/blockdevice/blockdevice.py
@@ -1,0 +1,37 @@
+""" Blockdevice Component
+
+Layer 4: Component and its implementation
+"""
+
+import os
+from constant import HarvesterOperationStrategy
+from .base import Base
+from .crd import CRD
+from .rest import Rest
+
+
+class Blockdevice(Base):
+    def __init__(self):
+        """Initialize Blockdevice component"""
+        try:
+            strategy_str = os.getenv("HARVESTER_OPERATION_STRATEGY", "crd").lower()
+            self._strategy = HarvesterOperationStrategy(strategy_str)
+        except ValueError:
+            self._strategy = HarvesterOperationStrategy.CRD
+
+        match self._strategy:
+            case HarvesterOperationStrategy.CRD:
+                self.blockdevice = CRD()
+            case HarvesterOperationStrategy.REST:
+                self.blockdevice = Rest()
+
+    def list(self, namespace):
+        blockdevices = self.blockdevice.list(namespace)
+        return blockdevices
+
+    def get(self, name, namespace):
+        blockdevice = self.blockdevice.get(name, namespace)
+        return blockdevice
+
+    def provision_longhorn_storage(self, name, engine_version, namespace):
+        self.blockdevice.provision_longhorn_storage(name, engine_version, namespace)

--- a/harvester_robot_tests/libs/blockdevice/crd.py
+++ b/harvester_robot_tests/libs/blockdevice/crd.py
@@ -1,0 +1,76 @@
+""" Blockdevice Component: CRD Implementation
+
+Layer 4: Component and its implementation
+"""
+
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+from crd import get_cr, patch_cr
+from constant import HARVESTER_API_GROUP, HARVESTER_API_VERSION
+from utility.utility import logging
+from .base import Base
+
+
+class CRD(Base):
+    """CRD implementation for Blockdevice operations using Kubernetes API"""
+
+    def __init__(self):
+        """Initialize Kubernetes client"""
+        self.core_api = client.CoreV1Api()
+        self.custom_api = client.CustomObjectsApi()
+        self.common_parameters = {
+            "group": HARVESTER_API_GROUP,
+            "version": HARVESTER_API_VERSION,
+            "plural": "blockdevices"
+        }
+        self.port_forward_process = None
+
+    def list(self, namespace):
+        try:
+            return self.custom_api.list_namespaced_custom_object(
+                **self.common_parameters,
+                namespace=namespace
+            ).get("items", [])
+        except ApiException as e:
+            if e.status == 404:
+                logging(f"No blockdevice under {namespace}", level='WARNING')
+                return []
+            raise Exception(f"Failed to list blockdevices under {namespace}: {e}")
+
+    def get(self, name, namespace):
+        try:
+            return get_cr(
+                **self.common_parameters,
+                namespace=namespace,
+                name=name
+            )
+        except ApiException as e:
+            if e.status == 404:
+                raise Exception(f"Blockdevice {namespace}/{name} not found", level='ERROR')
+            raise Exception(f"Failed to get blockdevice: {e}")
+
+    def provision_longhorn_storage(self, name, engine_version, namespace):
+        blockdevice = self.get(name, namespace)
+        if not blockdevice:
+            raise Exception(f"Blockdevice {namespace}/{name} not found")
+
+        patch_body = {
+            "spec": {
+                "provision": True,
+                "provisioner": {
+                    "longhorn": {
+                        "diskDriver": "auto",
+                        "engineVersion": engine_version
+                    }
+                }
+            }
+        }
+        try:
+            patch_cr(
+                **self.common_parameters,
+                namespace=namespace,
+                name=name,
+                body=patch_body
+            )
+        except ApiException as e:
+            raise Exception(f"Failed to provision blockdevice {namespace}/{name}: {e}")

--- a/harvester_robot_tests/libs/blockdevice/rest.py
+++ b/harvester_robot_tests/libs/blockdevice/rest.py
@@ -1,0 +1,15 @@
+""" Blockdevice Component: REST Implementation
+
+Layer 4: Component and its implementation
+"""
+
+from utility.utility import get_harvester_api_client
+from .base import Base
+
+
+class Rest(Base):
+    """REST implementation for Blockdevice operations using Harvester API"""
+
+    def __init__(self):
+        self.api_client = get_harvester_api_client()
+        self.port_forward_process = None

--- a/harvester_robot_tests/libs/constant.py
+++ b/harvester_robot_tests/libs/constant.py
@@ -17,10 +17,13 @@ HARVESTER_API_GROUP = "harvesterhci.io"
 HARVESTER_API_VERSION = "v1beta1"
 KUBEVIRT_API_GROUP = "kubevirt.io"
 KUBEVIRT_API_VERSION = "v1"
+LONGHORN_API_GROUP = "longhorn.io"
+LONGHORN_API_VERSION = "v1beta2"
 
 # Harvester Namespace
 HARVESTER_NAMESPACE = "harvester-system"
 DEFAULT_NAMESPACE = "default"
+LONGHORN_NAMESPACE = "longhorn-system"
 
 # Harvester Resource Plurals
 VIRTUALMACHINE_PLURAL = "virtualmachines"
@@ -37,6 +40,8 @@ LABEL_TEST_VALUE = "robot-framework"
 KIBIBYTE = 1024
 MEBIBYTE = (KIBIBYTE * KIBIBYTE)
 GIBIBYTE = (MEBIBYTE * KIBIBYTE)
+TEBIBYTE = (GIBIBYTE * KIBIBYTE)
+LARGE_DISK_BYTE = TEBIBYTE
 
 # VM States
 VM_STATE_STOPPED = "Stopped"

--- a/harvester_robot_tests/libs/host/crd.py
+++ b/harvester_robot_tests/libs/host/crd.py
@@ -5,20 +5,30 @@ Uses Kubernetes Node resources for host/node operations
 import time
 from kubernetes import client
 from kubernetes.client.rest import ApiException
+from crd import get_cr
 from utility.utility import logging, get_retry_count_and_interval
-from constant import DEFAULT_TIMEOUT_SHORT, DEFAULT_TIMEOUT
+from constant import (
+    DEFAULT_TIMEOUT_SHORT, DEFAULT_TIMEOUT,
+    LONGHORN_API_GROUP, LONGHORN_API_VERSION, LONGHORN_NAMESPACE
+)
 from host.base import Base
 
 
 class CRD(Base):
     """
     Host CRD implementation
-    Uses Kubernetes Node resources (not CRDs, but native K8s resources)
     """
 
     def __init__(self):
         self.core_api = client.CoreV1Api()
+        self.custom_api = client.CustomObjectsApi()
         self.retry_count, self.retry_interval = get_retry_count_and_interval()
+        self.lh_nodes_parameters = {
+            "group": LONGHORN_API_GROUP,
+            "version": LONGHORN_API_VERSION,
+            "plural": "nodes",
+            "namespace": LONGHORN_NAMESPACE
+        }
 
     def list_nodes(self):
         """List all nodes in the cluster"""
@@ -109,6 +119,36 @@ class CRD(Base):
                 control_nodes.append(node['name'])
 
         return control_nodes
+
+    def get_witness_nodes(self):
+        """Get all witness node names"""
+        nodes = self.list_nodes()
+
+        witness_nodes = []
+        for node in nodes:
+            labels = node['labels']
+            is_witness_node = (
+                'node-role.harvesterhci.io/witness' in labels
+            )
+            if is_witness_node:
+                witness_nodes.append(node['name'])
+
+        return witness_nodes
+
+    def get_standard_nodes(self):
+        """Get all standard (non-witness) nodes names"""
+        nodes = self.list_nodes()
+
+        standard_nodes = []
+        for node in nodes:
+            labels = node['labels']
+            is_witness_node = (
+                'node-role.harvesterhci.io/witness' in labels
+            )
+            if not is_witness_node:
+                standard_nodes.append(node['name'])
+
+        return standard_nodes
 
     def get_node_status(self, node_name):
         """Get node status"""
@@ -354,3 +394,19 @@ class CRD(Base):
                 'container_runtime': node.status.node_info.container_runtime_version if node.status.node_info else ''   # NOQA
             }
         }
+
+    # Longhorn Node
+    def get_lh_node(self, node_name):
+        """Get Longhorn Node CR for a specific node
+        Note: This is a Longhorn-specific resource that represents the node in Longhorn's context
+        """
+        try:
+            return get_cr(
+                **self.lh_nodes_parameters,
+                name=node_name
+            )
+        except ApiException as e:
+            if e.status == 404:
+                logging(f"Can not find LH node {LONGHORN_NAMESPACE}/{node_name}", level='WARNING')
+                return None
+            raise Exception(f"Fail to get LH node {LONGHORN_NAMESPACE}/{node_name}: {e}")

--- a/harvester_robot_tests/libs/host/host.py
+++ b/harvester_robot_tests/libs/host/host.py
@@ -35,6 +35,16 @@ class Host(Base):
     def get_control_plane_nodes(self):
         return self.host.get_control_plane_nodes()
 
+    def get_witness_nodes(self):
+        nodes = self.host.get_witness_nodes()
+        print(f"Witness nodes: {nodes}")
+        return nodes
+
+    def get_standard_nodes(self):
+        nodes = self.host.get_standard_nodes()
+        print(f"Standard nodes: {nodes}")
+        return nodes
+
     def get_node_status(self, node_name):
         return self.host.get_node_status(node_name)
 
@@ -67,3 +77,7 @@ class Host(Base):
 
     def cleanup(self):
         return self.host.cleanup()
+
+    # Longhorn Node
+    def get_lh_node(self, node_name):
+        return self.host.get_lh_node(node_name)

--- a/harvester_robot_tests/libs/keywords/common_keywords.py
+++ b/harvester_robot_tests/libs/keywords/common_keywords.py
@@ -7,6 +7,7 @@ import sys
 
 # Add the path to the utility module
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))) # noqa E402
+from utility.pod import get_pods_by_label    # noqa E402
 from utility.utility import generate_name_with_suffix   # noqa E402
 from utility.utility import init_harvester_api_client   # noqa E402
 from utility.utility import init_k8s_api_client  # noqa E402
@@ -52,3 +53,12 @@ class common_keywords:
     def cleanup_backups(self):
         """Cleanup backups"""
         logging('Cleanup backups requested')
+
+    def list_pods_by_label(self, namespace, label_selector, status=None):
+        """List pods by label"""
+        pods = get_pods_by_label(namespace, label_selector)
+        if status:
+            pods = [pod for pod in pods if pod.status.phase == status]
+        logging(f"Found {len(pods)} pods by label {label_selector} in namespace {namespace}: \
+                {[pod.metadata.name for pod in pods]}")
+        return pods

--- a/harvester_robot_tests/libs/keywords/host_keywords.py
+++ b/harvester_robot_tests/libs/keywords/host_keywords.py
@@ -52,6 +52,12 @@ class host_keywords:
         logging('Getting control-plane nodes')
         return self.host.get_control_plane_nodes()
 
+    def get_witness_nodes(self):
+        return self.host.get_witness_nodes()
+
+    def get_standard_nodes(self):
+        return self.host.get_standard_nodes()
+
     def get_node_status(self, node_name):
         """Get node status"""
         logging(f'Getting status for node {node_name}')
@@ -100,3 +106,8 @@ class host_keywords:
         """Get VMs on node"""
         logging(f'Getting VMs on node {node_name}')
         return self.host.get_node_vms(node_name)
+
+    # Longhorn Node
+    def get_lh_node(self, node_name):
+        """Get Longhorn-specific node details"""
+        return self.host.get_lh_node(node_name)

--- a/harvester_robot_tests/libs/keywords/setting_keywords.py
+++ b/harvester_robot_tests/libs/keywords/setting_keywords.py
@@ -1,0 +1,44 @@
+""" Setting Keyword Wrapper
+
+Layer 3: Keyword wrapper (NO direct API calls)
+"""
+
+import os
+import sys
+
+# Add the path to the utility module
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))) # noqa E402
+from setting import Setting  # noqa E402
+from utility.utility import logging  # noqa E402
+
+
+class setting_keywords:
+    """Setting keyword wrapper - creates Setting component and delegates"""
+
+    def __init__(self):
+        """Initialize setting keywords with lazy loading"""
+        self._setting = None
+
+    @property
+    def setting(self):
+        """Lazy initialize setting to allow API client setup first"""
+        if self._setting is None:
+            self._setting = Setting()
+        return self._setting
+
+    def get(self, setting_id):
+        return self.setting.get(setting_id)
+
+    def get_value(self, setting_id):
+        return self.setting.get(setting_id).get('value')
+
+    def get_condition_message(self, setting_id: str, condition_type: str):
+        conditions = self.setting.get(setting_id).get('status', {}).get('conditions', [])
+        for condition in conditions:
+            if condition.get('type') == condition_type:
+                return condition.get('message')
+        return None
+
+    def enable(self, setting_id):
+        setting = self.setting.enable(setting_id)
+        return setting

--- a/harvester_robot_tests/libs/keywords/storage_keywords.py
+++ b/harvester_robot_tests/libs/keywords/storage_keywords.py
@@ -1,0 +1,120 @@
+""" Storage Keyword Wrapper
+
+Layer 3: Keyword wrapper (NO direct API calls)
+"""
+
+import os
+import sys
+
+# Add the path to the utility module
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))) # noqa E402
+from constant import LARGE_DISK_BYTE  # noqa E402
+from utility.utility import logging  # noqa E402
+from blockdevice import Blockdevice  # noqa E402
+from host_keywords import host_keywords  # noqa E402
+
+
+class storage_keywords:
+    """Storage keyword wrapper"""
+
+    def __init__(self):
+        """Initialize storage keywords with lazy loading"""
+        self._blockdevice = None
+        self._host = None
+
+    @property
+    def blockdevice(self):
+        """Lazy initialize blockdevice to allow API client setup first"""
+        if self._blockdevice is None:
+            self._blockdevice = Blockdevice()
+        return self._blockdevice
+
+    @property
+    def host(self):
+        """Lazy initialize host_keywords to allow API client setup first"""
+        if self._host is None:
+            self._host = host_keywords()
+        return self._host
+
+    def list_blockdevices(self, namespace):
+        return self.blockdevice.list(namespace)
+
+    def get_blockdevice(self, name, namespace):
+        return self.blockdevice.get(name, namespace)
+
+    def list_large_blockdevices(self, namespace):
+        blockdevices = self.list_blockdevices(namespace)
+        large_blockdevices = []
+
+        logging(f"Finding blockdevices in namespace {namespace} >= {LARGE_DISK_BYTE} bytes")
+        for blockdevice in blockdevices:
+            try:
+                size_bytes = int(
+                    blockdevice.get("status", {})
+                    .get("deviceStatus", {})
+                    .get("capacity", {})
+                    .get("sizeBytes")
+                )
+            except Exception:
+                size_bytes = 0
+                logging(
+                    f"Unable to parse blockdevice sizeBytes for {blockdevice}", level="WARNING"
+                )
+
+            if size_bytes >= LARGE_DISK_BYTE:
+                large_blockdevices.append(blockdevice)
+
+        logging(f"Found {len(large_blockdevices)} large blockdevices in namespace {namespace}")
+        return large_blockdevices
+
+    def pick_unprovisioned_data_disks(self, namespace: str) -> dict:
+        standard_node_names = self.host.get_standard_nodes()
+        logging(f"Standard nodes: {standard_node_names}")
+
+        large_disks = self.list_large_blockdevices(namespace)
+        unprovisioned_disk_by_node = {}
+        for blockdevice in large_disks:
+            node_name = blockdevice.get("spec", {}).get("nodeName")
+            if not node_name or node_name not in standard_node_names:
+                continue
+            if node_name in unprovisioned_disk_by_node:
+                continue
+
+            disk_name = blockdevice.get("metadata", {}).get("name")
+            if not disk_name:
+                continue
+
+            disk_provision_phase = blockdevice.get("status", {}).get("provisionPhase")
+            if disk_provision_phase != "Unprovisioned":
+                continue
+
+            unprovisioned_disk_by_node[node_name] = disk_name
+
+        logging(f"Picked unprovisioned data disks: {unprovisioned_disk_by_node}")
+        return unprovisioned_disk_by_node
+
+    def provision_longhorn_storage(self, disk_name: str, engine_version: str, namespace: str):
+        self.blockdevice.provision_longhorn_storage(disk_name, engine_version, namespace)
+
+    def is_blockdevice_provisioned(self, name: str, namespace: str) -> bool:
+        blockdevice = self.get_blockdevice(name, namespace)
+        provision_phase = blockdevice and blockdevice.get("status", {}).get("provisionPhase")
+        state = blockdevice and blockdevice.get("status", {}).get("state")
+
+        if provision_phase == "Provisioned" and state == "Active":
+            return True
+        return False
+
+    def get_lh_node(self, node_name: str):
+        return self.host.get_lh_node(node_name)
+
+    def get_lh_node_disk_status(self, node_name: str, disk_name: str):
+        lh_node = self.get_lh_node(node_name)
+        disk_status = lh_node.get("status", {}).get("diskStatus", {}).get(disk_name, {})
+        return disk_status
+
+    def get_lh_node_disk_status_condition(self, node_name, disk_name, condition_type):
+        disk_status = self.get_lh_node_disk_status(node_name, disk_name)
+        for condition in disk_status.get("conditions", []):
+            if condition.get("type") == condition_type:
+                return condition.get("status")

--- a/harvester_robot_tests/libs/setting/__init__.py
+++ b/harvester_robot_tests/libs/setting/__init__.py
@@ -1,0 +1,7 @@
+"""
+Addon module for Harvester addon operations
+"""
+
+from setting.setting import Setting
+
+__all__ = ['Setting']

--- a/harvester_robot_tests/libs/setting/base.py
+++ b/harvester_robot_tests/libs/setting/base.py
@@ -1,0 +1,20 @@
+""" Setting Component: Base Class
+
+Layer 4: Component and its implementation
+"""
+
+from abc import ABC, abstractmethod
+
+
+class Base(ABC):
+    """Base class for Setting implementations"""
+
+    @abstractmethod
+    def get(self, setting_id):
+        """Get setting details"""
+        pass
+
+    @abstractmethod
+    def enable(self, setting_id):
+        """Enable a setting"""
+        pass

--- a/harvester_robot_tests/libs/setting/crd.py
+++ b/harvester_robot_tests/libs/setting/crd.py
@@ -1,0 +1,56 @@
+""" Setting Component: CRD Implementation
+
+Layer 4: Component and its implementation
+"""
+
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+from crd import get_cr, patch_cr
+from constant import (
+    HARVESTER_API_GROUP, HARVESTER_API_VERSION,
+)
+from .base import Base
+
+
+class CRD(Base):
+    """CRD implementation for Setting operations using Kubernetes API"""
+
+    def __init__(self):
+        """Initialize Kubernetes client"""
+        self.core_api = client.CoreV1Api()
+        self.custom_api = client.CustomObjectsApi()
+        self.common_parameters = {
+            "group": HARVESTER_API_GROUP,
+            "version": HARVESTER_API_VERSION,
+            "namespace": "",
+            "plural": "settings"
+        }
+        self.port_forward_process = None
+
+    def get(self, setting_id):
+        """Get setting details by id"""
+        try:
+            setting = get_cr(
+                **self.common_parameters,
+                name=setting_id
+            )
+            return setting
+        except ApiException as e:
+            if e.status == 404:
+                raise Exception(f"Setting {setting_id} not found", level='ERROR')
+            raise Exception(f"Failed to get setting {setting_id}: {e}")
+
+    def enable(self, setting_id):
+        """Enable a setting by id"""
+        try:
+            patch_body = {
+                "value": "true"
+            }
+            setting = patch_cr(
+                **self.common_parameters,
+                name=setting_id,
+                body=patch_body
+            )
+            return setting
+        except ApiException as e:
+            raise Exception(f"Failed to enable setting {setting_id}: {e}")

--- a/harvester_robot_tests/libs/setting/rest.py
+++ b/harvester_robot_tests/libs/setting/rest.py
@@ -1,0 +1,15 @@
+""" Setting Component: REST Implementation
+
+Layer 4: Component and its implementation
+"""
+
+from utility.utility import get_harvester_api_client
+from .base import Base
+
+
+class Rest(Base):
+    """REST implementation for Setting operations using Harvester API"""
+
+    def __init__(self):
+        self.api_client = get_harvester_api_client()
+        self.port_forward_process = None

--- a/harvester_robot_tests/libs/setting/setting.py
+++ b/harvester_robot_tests/libs/setting/setting.py
@@ -1,0 +1,35 @@
+""" Setting Component
+
+Layer 4: Component and its implementation
+"""
+
+import os
+from constant import HarvesterOperationStrategy
+from .base import Base
+from .crd import CRD
+from .rest import Rest
+
+
+class Setting(Base):
+    def __init__(self):
+        try:
+            strategy_str = os.getenv("HARVESTER_OPERATION_STRATEGY", "crd").lower()
+            self._strategy = HarvesterOperationStrategy(strategy_str)
+        except ValueError:
+            self._strategy = HarvesterOperationStrategy.CRD
+
+        match self._strategy:
+            case HarvesterOperationStrategy.CRD:
+                self.setting = CRD()
+            case HarvesterOperationStrategy.REST:
+                self.setting = Rest()
+
+    def get(self, setting_id):
+        """Get setting details - delegates to implementation"""
+        setting = self.setting.get(setting_id)
+        return setting
+
+    def enable(self, setting_id):
+        """Enable a setting - delegates to implementation"""
+        setting = self.setting.enable(setting_id)
+        return setting

--- a/harvester_robot_tests/libs/utility/pod.py
+++ b/harvester_robot_tests/libs/utility/pod.py
@@ -1,0 +1,18 @@
+"""
+Shared Pod utilities for Harvester test framework
+"""
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+
+
+def get_pods_by_label(namespace, label_selector):
+    """Get Pods filtered by label selector
+
+    label_selector example: "app=harvester,component=controller"
+    """
+    core_api = client.CoreV1Api()
+    try:
+        pod_list = core_api.list_namespaced_pod(namespace=namespace, label_selector=label_selector)
+        return pod_list.items
+    except ApiException as e:
+        raise Exception(f"Failed to get pods: {e}")

--- a/harvester_robot_tests/tests/regression/__init__.robot
+++ b/harvester_robot_tests/tests/regression/__init__.robot
@@ -1,0 +1,3 @@
+*** Settings ***
+Documentation    Regression Test Suite
+Test Tags        regression

--- a/harvester_robot_tests/tests/regression/test_longhorn_v2.robot
+++ b/harvester_robot_tests/tests/regression/test_longhorn_v2.robot
@@ -1,0 +1,31 @@
+*** Settings ***
+Documentation    Longhorn V2 Data Engine Test Cases
+Test Tags        longhorn    LHv2    LonghornV2    storage    experimental
+
+Resource         ../../keywords/variables.resource
+Resource         ../../keywords/setting.resource
+
+Suite Setup       Local Suite Setup
+Suite Teardown    Cleanup test resources
+
+
+*** Variables ***
+&{DATA_DISK_BY_NODE}    &{EMPTY}
+${LHv2_SC_REPLICAS}    ${EMPTY}
+
+
+*** Test Cases ***
+Provision LHv2 Storages
+    [Tags]    p1
+    [Documentation]    Provision at most 3 storages with LHv2 Data Engine
+    When Provision Storages With LHv2 Data Engine    &{DATA_DISK_BY_NODE}
+    Then Wait Until LHv2 Storages Are Provisioned    &{DATA_DISK_BY_NODE}
+
+
+*** Keywords ***
+Local Suite Setup
+    Given Set up test environment
+    And storage.Cluster Has Available Data Disks And Set Suite Variables
+    And setting.LHv2 Data Engine Is Disabled
+    When setting.Enable LHv2 Data Engine
+    Then setting.Wait Until LHv2 Data Engine Is Enabled


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #2178, including enable LonghornV2 and provision LonghornV2 disks. 

#### What this PR does / why we need it:
1. Add `setting` resource and component
2. Add `storage` resource and the `blockdevice` component
3. Enhance `host` resource to support
  * standard and witness node querying
  * longhorn nodes querying
5. Enhance `common` resource to support pod query


#### Special notes for your reviewer:
1. Put longhorn nodes into `host` for intuitive operation
2. CRD first, implement REST when feature is not covered by CRD.
   Ref. https://github.com/harvester/tests/pull/2239#issuecomment-3515438745


#### Additional documentation or context
* Record

  https://github.com/user-attachments/assets/1ceb5730-0b0d-48e2-a4d8-e37005e3cb05

* Report
  <img width="1646" height="919" alt="image" src="https://github.com/user-attachments/assets/9ad0cd30-e482-43ea-9344-8a3b91702ea9" />
