### PR TITLE
Add version check in custom_filename_setting

### DIFF
--- a/harvester_e2e_tests/apis/test_support_bundle.py
+++ b/harvester_e2e_tests/apis/test_support_bundle.py
@@ -21,6 +21,7 @@ from io import BytesIO
 from time import sleep
 from zipfile import ZipFile
 from datetime import datetime, timedelta
+from pkg_resources import parse_version
 
 import yaml
 import pytest
@@ -423,6 +424,8 @@ class TestSupportBundleExtraNamespaces:
 @pytest.fixture(scope="class")
 def custom_filename_setting(api_client):
     """Setup and teardown for custom support bundle filename pattern"""
+    if api_client.cluster_version < parse_version("1.8.0"):
+        pytest.skip("https://github.com/harvester/harvester/issues/9257 new feature in v1.8.0")
     # Get original setting
     code, data = api_client.settings.get("support-bundle-file-name")
     assert 200 == code, (code, data)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #2654

#### What this PR does / why we need it:
Since automation call `custom_filename_setting` before `skip_if_version`, so it will shows error if the version doesn't support custom file setting.

#### Special notes for your reviewer:

#### Additional documentation or context
Pass in `v1.7.2-rc1`, `v1.6.1` and `v1.8.0`
<img width="1214" height="603" alt="image" src="https://github.com/user-attachments/assets/99c06c73-079a-4d4c-8497-bd2bc8495d40" />
<img width="1214" height="603" alt="image" src="https://github.com/user-attachments/assets/c79e96e3-548a-405e-9fa9-ddb0e68378fd" />
<img width="1214" height="603" alt="image" src="https://github.com/user-attachments/assets/ce3629d6-ea9f-4ef8-abd4-939a568800e4" />

