### PR TITLE
Add image_uid in VolumeSpec for lower version

### DIFF
--- a/apiclient/harvester_api/models/volumes.py
+++ b/apiclient/harvester_api/models/volumes.py
@@ -14,7 +14,7 @@ class VolumeSpec:
         self.description = description
         self.annotations = annotations or dict()
 
-    def to_dict(self, name, namespace, image_id=None):
+    def to_dict(self, name, namespace, image_id=None, image_uid=None):
         annotations = self.annotations
         size = f"{self.size}Gi" if isinstance(self.size, (int, float)) else self.size
         data = {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #2653

#### What this PR does / why we need it:
Since in test_1_volumes, we send `image_uid=ubuntu_image_bad_checksum['info']['metadata']['uid']` into `VolumeSpec`
But there is no `image_uid` in `to_dict` of `VolumeSpec`
Add `image_uid` in `VolumeSpec` for supporting lower version

#### Special notes for your reviewer:

#### Additional documentation or context
Pass in `v1.7.2-rc1`, `v1.6.1`, and `v1.8.0`
<img width="1299" height="957" alt="image" src="https://github.com/user-attachments/assets/25cce837-9c80-4b7a-9681-14299c547285" />
<img width="1299" height="957" alt="image" src="https://github.com/user-attachments/assets/9129bec9-8e66-44ec-ab98-145f04e945ba" />
<img width="1299" height="957" alt="image" src="https://github.com/user-attachments/assets/48417dad-7108-4c14-979a-2a746274781a" />
