### PR TITLE
Update xfail range for those fixed in v1.7.1

### DIFF
--- a/harvester_e2e_tests/integrations/test_4_vm_host_cpu_pinning.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_host_cpu_pinning.py
@@ -288,7 +288,7 @@ class TestPinCPUonVM:
         )
 
     @pytest.mark.xfail_if_version(
-            ">= v1.7.0", "< v1.8.0", reason="https://github.com/harvester/harvester/issues/9557")
+            ">= v1.7.0", "< v1.7.1", reason="https://github.com/harvester/harvester/issues/9557")
     @pytest.mark.negative
     @pytest.mark.dependency(depends=["pin_cpu_on_vm"])
     def test_disable_cpu_manager_when_vm_on_it(

--- a/harvester_e2e_tests/integrations/test_4_vm_host_powercycle.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_host_powercycle.py
@@ -105,7 +105,7 @@ def vm_force_reset_policy(api_client):
 @pytest.mark.p1
 class TestHostState:
     @pytest.mark.xfail_if_version(
-        ">= v1.7.0", "< v1.8.0", reason="https://github.com/harvester/harvester/issues/9759")
+        ">= v1.7.0", "< v1.7.1", reason="https://github.com/harvester/harvester/issues/9759")
     @pytest.mark.dependency(name="host_poweroff")
     def test_poweroff_state(self, api_client, host_state, wait_timeout, available_node_names):
         """


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
No issue ID, just update the xfail range for those issues were fixed in v1.7.1, to let those test cases can be run in those fixed version.

#### What this PR does / why we need it:
Since in mark `xfail_if_version`, it will show xfail directly if the tested harvester version in the range when the setup step.
In this case, it won't run the test case, so with this PR, the test cases can be run and we can check the test result in those fixed version.
