### PR TITLE
Use retry to wait node state change

### DIFF
--- a/harvester_e2e_tests/integrations/test_4_vm_host_powercycle.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_host_powercycle.py
@@ -138,8 +138,19 @@ class TestHostState:
                 f", script path: {host_state.path}"
             )
 
-        _, node = api_client.hosts.get(node['id'])
-        assert node["metadata"]["state"]["name"] in ("in-progress", "unavailable")
+        # Retry for the node status change from draining to unavailable
+        endtime = datetime.now() + timedelta(seconds=wait_timeout)
+        expected_states = ("in-progress", "unavailable")
+        while endtime > datetime.now():
+            _, node = api_client.hosts.get(node['id'])
+            if node["metadata"]["state"]["name"] in expected_states:
+                break
+            sleep(5)
+        else:
+            raise AssertionError(
+                f"Node {node['id']} state is {node['metadata']['state']['name']}"
+                f", but we expected it to be {expected_states}"
+            )
 
     @pytest.mark.dependency(name="host_poweron", depends=["host_poweroff"])
     def test_poweron_state(self, api_client, host_state, wait_timeout, available_node_names):


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #2697

#### What this PR does / why we need it:
Automation check the node state right after the node return 404
But in current design, the node state will change to `unavailable` after around 5 mins.
Change the assert to Retry to wait the state change.

#### Special notes for your reviewer:

#### Additional documentation or context
Test pass
<img width="1085" height="566" alt="image" src="https://github.com/user-attachments/assets/29e4117e-da4f-4bea-8db2-f747aca74e07" />
