### PR TITLE
Enhance run.sh and Dockerfile for Robot framework containerized testing

### DIFF
--- a/harvester_robot_tests/.gitignore
+++ b/harvester_robot_tests/.gitignore
@@ -29,6 +29,7 @@ report.html
 *.swp
 *.swo
 *~
+.pabotsuitenames
 
 # OS
 .DS_Store

--- a/harvester_robot_tests/Dockerfile
+++ b/harvester_robot_tests/Dockerfile
@@ -1,23 +1,28 @@
-# https://apps.rancher.io/artifacts/6b458a91fc2c37c904bce4a9cd888f8d5f6d91bfb1b7fc9395ad52de1d639db7
-FROM dp.apps.rancher.io/containers/kubectl@sha256:6b458a91fc2c37c904bce4a9cd888f8d5f6d91bfb1b7fc9395ad52de1d639db7 AS kubectl-binary-1-35-3
+FROM registry.suse.com/bci/python:3.10
 
-FROM python:3.11.15-slim@sha256:9358444059ed78e2975ada2c189f1c1a3144a5dab6f35bff8c981afb38946634
 LABEL maintainer="Harvester Team"
 LABEL description="Harvester Robot Framework E2E Test Suite"
+
+ARG ARCH=amd64
+ENV ARCH=${ARCH}
 
 # Set working directory
 WORKDIR /harvester-robot-tests
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
-    git \
-    curl \
-    openssh-client \
-    && rm -rf /var/lib/apt/lists/*
+RUN zypper rm -y container-suseconnect && \
+    zypper --no-gpg-checks ref && \
+    zypper in -y git curl openssh-clients iputils vim && zypper clean -a
 
-# Install kubectl
-COPY --from=kubectl-binary-1-35-3 /usr/bin/kubectl /usr/local/bin/kubectl
-RUN chmod +x /usr/local/bin/kubectl
+ARG KUBECTL_VERSION=v1.35.5
+ARG KUBECTL_SHA256_amd64=90f75ea6ecc9ea5633262e1c0b83a40560003b30fc94a04cb099404fcef0c224
+ARG KUBECTL_SHA256_arm64=ac69e06fd6860d69786692f5af1c3a1208ed54f8366a4d97ab15c172e99765ee
+
+RUN KUBECTL_SHA256=KUBECTL_SHA256_${ARCH} && \
+    curl -sfL https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
+    echo "${!KUBECTL_SHA256}  /usr/bin/kubectl" | sha256sum -c - && \
+    chmod +x /usr/bin/kubectl
+
+RUN --mount=from=dir_apiclient,target=/tmp/apiclient cp -r /tmp/apiclient /
 
 # Copy requirements and install Python dependencies
 COPY requirements.txt .
@@ -35,5 +40,8 @@ RUN mkdir -p /tmp/harvester-test-report
 # Set permissions
 RUN chmod +x run.sh
 
+# hack to avoid permission denied error when running pabot in container
+RUN touch .pabotsuitenames && chmod 666 .pabotsuitenames
+
 # Default command
-CMD ["./run.sh"]
+ENTRYPOINT ["./run.sh"]

--- a/harvester_robot_tests/docker-run.sh
+++ b/harvester_robot_tests/docker-run.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Usage: ./docker-run.sh [options] [-- args]
+#
+# Builds and runs the Harvester Robot Framework E2E test suite in a container.
+#
+# Options:
+#   --kubeconfig <path>  Kubeconfig file on the host (can be empty)
+#                        If not provided, the script will look for KUBECONFIG in the .env file.
+#   --env <file>         ENV file (default: .env in script directory)
+#   --output <path>      Output path bind-mounted into container (default: /tmp/harvester-test-report)
+#   --                   Pass remaining arguments to the run.sh script inside container
+#
+# Prepare .env and specify the KUBECONFIG path in it before running this script.
+#
+# Examples:
+#   # make sure .env is edited correctly
+#   ./docker-run.sh -s "Tests.Regression.Image.Test Image"
+#   ./docker-run.sh --kubeconfig ~/.kube/config --output ./reports -- -s "Tests.Regression.Image.Test Image"
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- Option parsing ---
+ENV_FILE="$SCRIPT_DIR/.env"
+KUBECONFIG_FILE=""
+OUTPUT_PATH="/tmp/harvester-test-report"
+DOCKER_RUN_ARGS=()
+USER_ID="$(id -u):$(id -g)"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --kubeconfig)
+      KUBECONFIG_FILE="$2"
+      shift 2
+      ;;
+    --env)
+      ENV_FILE="$2"
+      shift 2
+      ;;
+    --output)
+      OUTPUT_PATH="$2"
+      shift 2
+      ;;
+    --)
+      shift
+      DOCKER_RUN_ARGS=("$@")
+      break
+      ;;
+    *)
+      echo "Error: Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Validate ENV file exists
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Error: ENV file not found: $ENV_FILE"
+  exit 1
+fi
+
+# Resolve kubeconfig: CLI arg takes priority, otherwise fall back to the one inside .env
+if [[ -z "$KUBECONFIG_FILE" ]]; then
+  KUBECONFIG_FILE=$( ( set -a; source "$ENV_FILE"; echo "${KUBECONFIG:-}" ) )
+fi
+if [[ -z "$KUBECONFIG_FILE" ]]; then
+  echo "Error: KUBECONFIG not provided (via --kubeconfig or in $ENV_FILE)"
+  exit 1
+fi
+
+# Ensure output directory exists locally (for the bind mount)
+mkdir -p "$OUTPUT_PATH"
+
+echo "Using KUBECONFIG file: $KUBECONFIG_FILE"
+echo "Using ENV file: $ENV_FILE"
+echo "Using output path: $OUTPUT_PATH"
+
+# Create a temporary .env file to bind-mount into the container
+ENV_TMPFILE=$(mktemp)
+trap 'rm -f "$ENV_TMPFILE"' EXIT INT TERM
+cp "$ENV_FILE" "$ENV_TMPFILE"
+echo "KUBECONFIG=/kubeconfig" >> "$ENV_TMPFILE"
+
+# build a docker image to run tests
+export DOCKER_BUILDKIT=1
+# Build the image
+# Generate image tag from script directory path
+IMG_HASH=$(echo -n "$SCRIPT_DIR" | sha256sum | cut -c1-8)
+IMAGE_NAME="harvester-robot-tests:${IMG_HASH}"
+echo "Building Docker image: ${IMAGE_NAME}"
+docker build --progress=plain \
+  --build-context dir_apiclient="${SCRIPT_DIR}/../apiclient" \
+  -f ${SCRIPT_DIR}/Dockerfile \
+  -t "${IMAGE_NAME}" "${SCRIPT_DIR}"
+
+# Run the container
+echo "Running tests with image $IMAGE_NAME"
+
+DOCKER_EXTRA_ARGS="-it"
+if [ -n "${CI:-}" ]; then
+  DOCKER_EXTRA_ARGS="-e PYTHONUNBUFFERED=1"
+fi
+
+set -x
+docker run $DOCKER_EXTRA_ARGS --rm \
+  --user "${USER_ID}" \
+  -e "KUBECONFIG=/kubeconfig" \
+  -v "${ENV_TMPFILE}:/harvester-robot-tests/.env:ro" \
+  -v "${KUBECONFIG_FILE}:/kubeconfig:ro" \
+  -v "${OUTPUT_PATH}:/test-output:rw" \
+  "${IMAGE_NAME}" -W -d /test-output "${DOCKER_RUN_ARGS[@]}"

--- a/harvester_robot_tests/run.sh
+++ b/harvester_robot_tests/run.sh
@@ -52,6 +52,7 @@ Options:
     -d output_dir      Set output directory
     -p N               Run suites in parallel with pabot (N processes)
     -S strategy        Operation strategy: crd (default) or rest (sets HARVESTER_OPERATION_STRATEGY)
+    -W                 Skip virtual environment check
     -h                 Show this help
 
 Examples:
@@ -77,7 +78,7 @@ EOF
 }
 
 # Parse arguments
-while getopts "t:s:f:i:e:v:L:d:p:S:h" opt; do
+while getopts "t:s:f:i:e:v:L:d:p:S:Wh" opt; do
     case $opt in
         t) TEST_CASE="--test \"$OPTARG\"" ;;
         s) TEST_SUITE="--suite \"$OPTARG\"" ;;
@@ -89,6 +90,7 @@ while getopts "t:s:f:i:e:v:L:d:p:S:h" opt; do
         d) OUTPUT_DIR=$OPTARG ;;
         p) PROCESSES=$OPTARG ;;
         S) STRATEGY=$OPTARG ;;
+        W) SKIP_VENV_CHECK=true ;;
         h) show_help; exit 0 ;;
         \?) echo "Invalid option: -$OPTARG" >&2; show_help; exit 1 ;;
     esac
@@ -111,8 +113,8 @@ if [ -n "$PROCESSES" ] && ! command -v pabot &> /dev/null; then
     exit 1
 fi
 
-# Check virtual environment
-if [[ -z "$VIRTUAL_ENV" ]]; then
+# Check virtual environment (skip if -W is set)
+if [[ "$SKIP_VENV_CHECK" != "true" ]] && [[ -z "$VIRTUAL_ENV" ]]; then
     echo -e "${YELLOW}Warning: Virtual environment not activated${NC}"
     read -p "Continue? (y/N) " -n 1 -r
     echo


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Chore. See below.


#### What this PR does / why we need it:

The pull request https://github.com/harvester/tests/pull/2730 introduces a dependency on the `apiclient` module (out of context). We need to update the Dockerfile to include the dependency.

#### Special notes for your reviewer:

- Enhancement Dockerfile:
    - Switch to BCI image
    - Download kubectl with hash check. The AppCo image requires auth, and it's not easy to use in CI env.
    - Pass the apiclient context
- Add docker-run.sh script as a helper
   - The script builds an intermediate container image and runs the `run.sh` script with the image inside a container with proper file setup.

Example run of the upcoming e2e CI runs in the harvester/harvester repo: 
https://github.com/bk201/harvester/actions/runs/28561367436/job/84681891610#step:6:100

#### Additional documentation or context

```bash
#!/usr/bin/env bash
# Usage: ./docker-run.sh [options] [-- args]
#
# Builds and runs the Harvester Robot Framework E2E test suite in a container.
#
# Options:
#   --kubeconfig <path>  Kubeconfig file on the host (can be empty)
#                        If not provided, the script will look for KUBECONFIG in the .env file.
#   --env <file>         ENV file (default: .env in script directory)
#   --output <path>      Output path bind-mounted into container (default: /tmp/harvester-test-report)
#   --                   Pass remaining arguments to the run.sh script inside container
#
# Prepare .env and specify the KUBECONFIG path in it before running this script.
#
# Examples:
#   # make sure .env is edited correctly
#   ./docker-run.sh -s "Tests.Regression.Image.Test Image"
#   ./docker-run.sh --kubeconfig ~/.kube/config --output ./reports -- -s "Tests.Regression.Image.Test Image"
```