### PR TITLE
robot_tests: use precise=True for general case

### DIFF
--- a/harvester_robot_tests/keywords/common.resource
+++ b/harvester_robot_tests/keywords/common.resource
@@ -12,13 +12,17 @@ Set up test environment
     common_keywords.init k8s api client
 
 Generate Unique Name
-    [Arguments]    ${prefix1}=${EMPTY}    ${prefix2}=${EMPTY}    ${precise}=${FALSE}
-    [Documentation]    Generate a name with timestamp suffix and optional prefixes
-    ...  The timestamp format is `%m%d%H%M` by default and `%m%d%H%M%S%f` when precise=${TRUE}
+    [Arguments]    ${prefix1}=${EMPTY}    ${prefix2}=${EMPTY}    ${precise}=${TRUE}
+    [Documentation]    Generate a name with timestamp suffix and optional prefixes.
+    ...  The default `%m%d%H%M%S%f` timestamp has sub-second precision so
+    ...  concurrent pabot suites never collide (colliding names also make their
+    ...  local teardowns delete each other's resources). Pass precise=${FALSE}
+    ...  to get the short `%m%d%H%M` form ONLY for resources with tight name
+    ...  length limits (e.g. cluster networks).
     ...  Examples:
-    ...  Generate Unique Name            -> '06181015'
-    ...  Generate Unique Name  foo       -> 'foo-06181015'
-    ...  Generate Unique Name  foo  bar  precise=${TRUE}-> 'foo-bar-0618101519681156'
+    ...  Generate Unique Name            -> '0618101519681156'
+    ...  Generate Unique Name  foo       -> 'foo-0618101519681156'
+    ...  Generate Unique Name  foo  bar  precise=${FALSE}  -> 'foo-bar-06181015'
     ${name}=    common_keywords.generate_name_with_suffix    ${prefix1}    ${prefix2}    ${precise}
     RETURN    ${name}
 

--- a/harvester_robot_tests/libs/utility/utility.py
+++ b/harvester_robot_tests/libs/utility/utility.py
@@ -56,11 +56,15 @@ def get_timestamp():
     return datetime.now().strftime("%Y%m%d%H%M%S")
 
 
-def generate_name_with_suffix(kind, suffix, precise=False):
+def generate_name_with_suffix(kind, suffix, precise=True):
     """Generate unique name with timestamp suffix
     e.g.
-    * %m%d%H%M -> 06181015 (general, covers resources with limited length like cluster network)
-    * %m%d%H%M%S%f -> 0618101519681156 (precise, for highly concurrent tests to avoid collisions)
+    * %m%d%H%M%S%f -> 0618101519681156 (default; sub-second precision so
+      concurrent pabot suites never collide — colliding names also make their
+      local teardowns delete each other's resources)
+    * %m%d%H%M -> 06181015 (precise=False; ONLY for resources with tight name
+      length limits, e.g. cluster networks whose bridge interface name is
+      capped at 15 chars — callers opt in and accept the collision risk)
     """
     format_str = "%m%d%H%M%S%f" if precise else "%m%d%H%M"
     timestamp = datetime.now().strftime(format_str)

--- a/harvester_robot_tests/tests/regression/test_0_storage_network.robot
+++ b/harvester_robot_tests/tests/regression/test_0_storage_network.robot
@@ -35,7 +35,9 @@ Test Disable Storage Network
 *** Keywords ***
 Local Suite Setup
     Set Up Test Environment
-    ${name}=    Generate Unique Name    qa
+    # Cluster network names must stay short (the bridge interface name is
+    # capped at 15 chars), so opt into the minute-precision short form.
+    ${name}=    Generate Unique Name    qa    precise=${FALSE}
     Set Suite Variable    ${CNET_NAME}    ${name}
 
 Get VLAN Network CIDR


### PR DESCRIPTION
    - That would help us to ignore the naming conflict

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:
We encountered an image naming conflict after the storage network PR
See action: https://github.com/harvester/harvester/actions/runs/29403559958/job/87313917494
We need to use precise=True for general cases

#### Special notes for your reviewer:

#### Additional documentation or context
