### PR TITLE
fix: missing harvesterhci.io/sshNames issue

### DIFF
--- a/apiclient/harvester_api/models/virtualmachines.py
+++ b/apiclient/harvester_api/models/virtualmachines.py
@@ -296,6 +296,9 @@ class VMSpec:
                 "runStrategy": self.run_strategy,
                 "template": {
                     "metadata": {
+                        "annotations": {
+                            "harvesterhci.io/sshNames": '[]'
+                        },
                         "labels": {
                             "harvesterhci.io/vmName": name
                         }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #2756 

#### What this PR does / why we need it:
Python script is missing the `harvesterhci.io/sshNames` annotation when creating the VM template, which causes a JSON unmarshalling error (AssertionError: (500, 'unexpected end of JSON input')) at [handler.go#L1501](https://github.com/harvester/harvester/blob/master/pkg/api/vm/handler.go#L1501).
After adding the `harvesterhci.io/sshNames`, the issue is gone.

#### Special notes for your reviewer:

#### Additional documentation or context
The test pass.
<img width="1227" height="459" alt="image" src="https://github.com/user-attachments/assets/e8da3a77-8c01-40f2-a655-7ef4ecb69499" />
<img width="1227" height="459" alt="image" src="https://github.com/user-attachments/assets/ce31a85b-b4f6-4760-afbc-1fe446617caa" />
<img width="1227" height="495" alt="image" src="https://github.com/user-attachments/assets/c2896fb8-509b-4bc4-a6cd-6f7095fe936c" />

