### PR TITLE
Reenable cases skipped by 10220

### DIFF
--- a/harvester_e2e_tests/integrations/test_upgrade.py
+++ b/harvester_e2e_tests/integrations/test_upgrade.py
@@ -419,7 +419,8 @@ def stopped_vm(request, api_client, ssh_keypair, wait_timeout, unique_name, imag
 @pytest.mark.negative
 @pytest.mark.any_nodes
 class TestInvalidUpgrade:
-    @pytest.mark.skip(reason="https://github.com/harvester/harvester/issues/10220")
+    @pytest.mark.skip_if_version(
+            "< v1.8.0", reason="https://github.com/harvester/harvester/issues/10220")
     @pytest.mark.skip_if_version(
             "< v1.5.0",
             reason="https://github.com/harvester/harvester/issues/7654 fix after `v1.5.0`")
@@ -452,7 +453,8 @@ class TestInvalidUpgrade:
         api_client.upgrades.delete(upgrade_name)
         api_client.versions.delete(version)
 
-    @pytest.mark.skip(reason="https://github.com/harvester/harvester/issues/10220")
+    @pytest.mark.skip_if_version(
+            "< v1.8.0", reason="https://github.com/harvester/harvester/issues/10220")
     @pytest.mark.skip_if_version(
             "< v1.5.0",
             reason="https://github.com/harvester/harvester/issues/7654 fix after `v1.5.0`")
@@ -491,7 +493,8 @@ class TestInvalidUpgrade:
         api_client.upgrades.delete(upgrade_name)
         api_client.versions.delete(version)
 
-    @pytest.mark.skip(reason="https://github.com/harvester/harvester/issues/10220")
+    @pytest.mark.skip_if_version(
+            "< v1.8.0", reason="https://github.com/harvester/harvester/issues/10220")
     def test_version_compatibility(
         self, api_client, unique_name, upgrade_target, upgrade_timeout
     ):
@@ -517,7 +520,8 @@ class TestInvalidUpgrade:
         api_client.upgrades.delete(data['metadata']['name'])
         api_client.versions.delete(version)
 
-    @pytest.mark.skip(reason="https://github.com/harvester/harvester/issues/10220")
+    @pytest.mark.skip_if_version(
+            "< v1.8.0", reason="https://github.com/harvester/harvester/issues/10220")
     def test_degraded_volume(
         self, api_client, unique_name, vm_shell_from_host, upgrade_target, stopped_vm,
         vm_checker, volume_checker, upgrade_checker


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Not fix but just re-enable upgrade test cases which skipped by harvester/harvester/issues/10220

#### What this PR does / why we need it:
As #10220 seems covered by early fix (see https://github.com/harvester/harvester/issues/10220#issuecomment-4987641111), and a quick check on `v1.8` -> `v1.9` passed too, we can re-enable it and observe for more runs.

#### Special notes for your reviewer:
According to the fixed version, enable them since `v1.8`.

#### Additional documentation or context
`v1.8.1` -> `v1.9.0-rc1`
<img width="1408" height="799" alt="image" src="https://github.com/user-attachments/assets/403aa986-3f3a-4b20-af16-f1d265488802" />
