### PR TITLE
fix: let name length limits test get 422

### DIFF
--- a/harvester_e2e_tests/integrations/test_1_images.py
+++ b/harvester_e2e_tests/integrations/test_1_images.py
@@ -873,8 +873,8 @@ class TestImageEnhancements:
         delete_image(api_client, original_image, wait_timeout)
         delete_image(api_client, exported_image_id, wait_timeout)
 
-    @pytest.mark.xfail(
-            reason="https://github.com/harvester/harvester/issues/9515")
+    @pytest.mark.xfail_if_version(
+            "<= v1.8.0", reason="https://github.com/harvester/harvester/issues/9515")
     @pytest.mark.p1
     @pytest.mark.images
     @pytest.mark.negative
@@ -898,8 +898,9 @@ class TestImageEnhancements:
             resp = api_client.images.create_by_file(invalid_long_name, Path(f.name))
             assert not resp.ok, f"Expected failure with long name but" \
                                 f" got success: {resp.status_code}"
-            assert resp.status_code in [400, 422], f"Expected 400/422 for " \
-                                                   f"invalid name, got: {resp.status_code}"
+            # Add 404 into expected code, ref: https://github.com/harvester/harvester/pull/10490
+            assert resp.status_code in [400, 422, 404], f"Expected 400/422 for " \
+                                                        f"invalid name, got: {resp.status_code}"
 
             # Test 2: Valid name (should PASS)
             valid_base = "valid-image-name"


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #2778 

#### What this PR does / why we need it:
1. In current test case, it use `create_by_file` for invalid long name, which will get 404 since the file is not created due to invalid long name. Use `create_by_url` instead to get 422 as expected
2. Change `xfail` to `xfail_if_version` since the issue is fixed.

#### Special notes for your reviewer:

#### Additional documentation or context
<img width="1182" height="601" alt="image" src="https://github.com/user-attachments/assets/63bae395-6a6d-4e2d-9488-1f48d4010ecf" />
