### PR TITLE
ci: add containerized smoke test runner

### DIFF
--- a/Dockerfile.smoke
+++ b/Dockerfile.smoke
@@ -1,0 +1,15 @@
+FROM FROM python:3.10.16-bookworm@sha256:b240c5813c2fa23506dc314bb370da0e890dadce666c7886780757976dc3b54b
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential findutils wget && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# bake the test dependencies into the image so a test run needs no network
+COPY test-requirements.txt /tmp/test-requirements.txt
+RUN pip install --no-cache-dir -r /tmp/test-requirements.txt
+
+# the local API client package; --no-deps mirrors the tox setup so its
+# dependencies keep coming from the hashed requirements above
+COPY apiclient /tmp/apiclient
+RUN pip install --no-cache-dir --no-deps /tmp/apiclient
+
+WORKDIR /app

--- a/smoke-run.sh
+++ b/smoke-run.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+# Containerized smoke test runner, used by the harvester/release smoke
+# workflows. Extra arguments are passed through to pytest.
+#
+# Outcome contract: results/ carries the HTML report and the marker file
+# results/fail exists if the test run failed. The exit code stays 0 for
+# infrastructure-level success so callers can distinguish "tests failed"
+# from "could not run tests".
+
+cd "$(dirname "$0")"
+
+IMAGE="${SMOKE_IMAGE:-harvester-smoke-tests}"
+MARKER="${SMOKE_MARKER:-smoke}"
+
+docker build -t "$IMAGE" -f Dockerfile.smoke .
+
+mkdir -p results
+rm -f results/fail
+
+if ! docker run --rm --network host \
+    --user "$(id -u):$(id -g)" \
+    -e HOME=/tmp \
+    -v "$PWD:/app" \
+    "$IMAGE" \
+    pytest harvester_e2e_tests -v -m "$MARKER" --html=results/api.html "$@"; then
+  touch results/fail
+  echo "Smoke tests failed, see results/"
+fi


### PR DESCRIPTION
    Add smoke-run.sh and Dockerfile.smoke to run the pytest smoke marker
    inside a container. Dependencies are baked into the image, so a test
    run itself needs no network and repeated runs hit the docker layer
    cache. Used by the harvester/release smoke workflows.

    Related issue: harvester/harvester#10211

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:
Used for the harvester release smoke test

#### Special notes for your reviewer:

#### Additional documentation or context
