### PR TITLE
Add optional cpu_model to VMSpec

### DIFF
--- a/apiclient/harvester_api/models/virtualmachines.py
+++ b/apiclient/harvester_api/models/virtualmachines.py
@@ -49,6 +49,7 @@ class VMSpec:
         self.acpi = True
         # initial data
         self.cpu_cores = cpu_cores
+        self.cpu_model = None
         self.memory = memory
         self.mgmt_network = mgmt_network
         self.guest_agent = guest_agent
@@ -274,6 +275,8 @@ class VMSpec:
 
         machine = dict(type=self.machine_type)
         cpu = dict(cores=self.cpu_cores, sockets=self.cpu_sockets, thread=self.cpu_threads)
+        if self.cpu_model is not None:
+            cpu['model'] = self.cpu_model
         resources = dict(cpu=self.cpu_cores, memory=mem)
 
         volume_claims = dumps([v['claim'] for v in volumes if 'claim' in v])
@@ -382,6 +385,7 @@ class VMSpec:
 
         obj = cls(cpu['cores'], mem, desc, reserved_mem, os_type)
         obj.cpu_sockets, obj.cpu_threads = cpu.get('sockets', 1), cpu.get('threads', 1)
+        obj.cpu_model = cpu.get('model')
         obj.run_strategy = run_strategy
         obj.eviction_strategy = eviction_strategy
         obj.hostname = hostname

--- a/apiclient/harvester_api/models/virtualmachines.pyi
+++ b/apiclient/harvester_api/models/virtualmachines.pyi
@@ -17,6 +17,7 @@ class VMSpec:
     usbtablet: ClassVar[bool]
 
     cpu_cores: int
+    cpu_model: Optional[str]
     memory: int | United_S
     description: str
     reserved_mem: int | float | United_S

--- a/harvester_e2e_tests/integrations/test_upgrade.py
+++ b/harvester_e2e_tests/integrations/test_upgrade.py
@@ -655,6 +655,7 @@ class TestAnyNodesUpgrade:
 
         cpu, mem, size = 1, 2, 10
         vm_spec = api_client.vms.Spec(cpu, mem, mgmt_network=False)
+        vm_spec.cpu_model = "host-passthrough"
         vm_spec.add_image('disk-0', image['id'], size=size, image_uid=image.get('uid'))
         vm_spec.add_network('nic-1', f"{vm_network['namespace']}/{vm_network['name']}")
         userdata = yaml.safe_load(vm_spec.user_data)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
1. harvester/tests/issues/2840



#### What this PR does / why we need it:
1. Support CPU Model in VM spec
3. Temporally config CPU model to `host-passthrough` as a workaround for harvester/harvester/issues/11358

#### Special notes for your reviewer:

#### Additional documentation or context
VM CPU Model is configured and does not Off after upgrade
<img width="1414" height="650" alt="image" src="https://github.com/user-attachments/assets/b22d2a28-dc8a-4d6b-b66e-c729bc1b1bfc" />
<img width="1414" height="790" alt="image" src="https://github.com/user-attachments/assets/7b9b6b72-9cf1-4df7-aeea-3fa96f188d3b" />
