### PR TITLE
fix: vgpu operator robot section

### DIFF
--- a/harvester_robot_tests/tests/regression/addon/test_gpu_operator.robot
+++ b/harvester_robot_tests/tests/regression/addon/test_gpu_operator.robot
@@ -99,7 +99,7 @@ Test GPU Node Discovery And CUDA Validation
     And CUDA Output Should Be Correct
 
 
-*** Setup/Teardown Keywords ***
+*** Keywords ***
 GPU Operator Suite Setup
     [Documentation]    Initialise the test environment and skip if conflicting addons
     ...               are already enabled.


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

#### What this PR does / why we need it:

Fix section issue.

```
===================================================
Output:  /test-output/output-20260818-053940.xml
From Internal Rebot: [ ERROR ] Error in file '/harvester-robot-tests/tests/regression/addon/test_gpu_operator.robot' on line 102: Unrecognized section header '*** Setup/Teardown Keywords ***'. Valid sections: 'Settings', 'Variables', 'Test Cases', 'Tasks', 'Keywords' and 'Comments'.
Log:     /test-output/log-20260818-053940.html
Report:  /test-output/report-20260818-053940.html
Finalizing Pabot execution...
```

#### Special notes for your reviewer:

#### Additional documentation or context
