### PR TITLE
Handle possible inactive Paramiko transports and API availability gap during system upgrade

### DIFF
--- a/harvester_e2e_tests/fixtures/api_client.py
+++ b/harvester_e2e_tests/fixtures/api_client.py
@@ -261,12 +261,12 @@ def host_shell(request):
         pkey = RSAKey.from_private_key(StringIO(pkey))
 
     class HostShell:
-        _client = _jump = None
-
         def __init__(self, username, password=None, pkey=None):
             self.username = username
             self.password = password
             self.pkey = pkey
+            self._client = None
+            self._jump = False
 
         def __enter__(self):
             return self
@@ -278,20 +278,26 @@ def host_shell(request):
         def client(self):
             return self._client
 
+        def _is_connected(self):
+            transport = self.client and self.client.get_transport()
+            return bool(transport and transport.is_active())
+
         def reconnect(self, ipaddr, port=22, **kwargs):
             if self.client:
                 self.client.close()
-                self._client = cli = SSHClient()
-                cli.set_missing_host_key_policy(MissingHostKeyPolicy())
-                kws = dict(username=self.username, password=self.password, pkey=self.pkey)
-                kws.update(kwargs)
-                cli.connect(ipaddr, port, **kws)
+            self._client = cli = SSHClient()
+            cli.set_missing_host_key_policy(MissingHostKeyPolicy())
+            kws = dict(username=self.username, password=self.password, pkey=self.pkey)
+            kws.update(kwargs)
+            cli.connect(ipaddr, port, **kws)
 
         def login(self, ipaddr, port=22, jumphost=False, allow_agent=False,
                   look_for_keys=False, **kwargs):
-            if not self.client:
-                cli = SSHClient()
-                cli.set_missing_host_key_policy(MissingHostKeyPolicy())
+            if not self._is_connected():
+                if self.client:
+                    self.client.close()
+                self._client = None
+                self._jump = False
                 kws = dict(username=self.username, password=self.password, pkey=self.pkey)
                 kws.update(kwargs)
 
@@ -302,8 +308,7 @@ def host_shell(request):
                     kws.update(dict(allow_agent=allow_agent,
                                     look_for_keys=look_for_keys))
 
-                cli.connect(ipaddr, port, **kws)
-                self._client = cli
+                self.reconnect(ipaddr, port, **kws)
 
                 if jumphost:
                     self.jumphost_policy()
@@ -313,11 +318,15 @@ def host_shell(request):
             return self
 
         def logout(self):
-            if self.client and self.client.get_transport():
-                if self._jump:
+            try:
+                if self._jump and self._is_connected():
+                    # Restore the original sshd_config to disable jumphost
+                    # e.g. AllowTcpForwarding no and AllowAgentForwarding no
                     self.jumphost_policy(False)
-                    self._jump = None
-                self.client.close()
+            finally:
+                self._jump = False
+                if self.client:
+                    self.client.close()
                 self._client = None
 
         def exec_command(self, command, bufsize=-1, timeout=None, get_pty=False, env=None,

--- a/harvester_e2e_tests/integrations/test_upgrade.py
+++ b/harvester_e2e_tests/integrations/test_upgrade.py
@@ -894,8 +894,8 @@ class TestAnyNodesUpgrade:
         assert len(masters) > 0, "No master nodes found"
 
         script = ("sudo tail /var/lib/rancher/rke2/server/logs/audit.log | awk 'END{print}' "
-                  "| jq .requestReceivedTimestamp "
-                  "| xargs -I {} date -d \"{}\" +%s")
+                  "| jq -r '.requestReceivedTimestamp' "
+                  "| xargs -r -I {} date -d '{}' +%s")
 
         node_ips = [n["metadata"]["annotations"][NODE_INTERNAL_IP_ANNOTATION] for n in masters]
         cmp = dict()
@@ -1127,7 +1127,9 @@ class TestAnyNodesUpgrade:
         assert "true" == names[created_sc]["storageclass.kubernetes.io/is-default-class"]
 
     @pytest.mark.dependency(depends=["any_nodes_upgrade"])
-    def test_verify_os_version(self, request, api_client, cluster_state, host_shell):
+    def test_verify_os_version(
+        self, request, api_client, cluster_state, host_shell, wait_timeout
+    ):
         # Verify /etc/os-release on all nodes
         script = "cat /etc/os-release"
         if not cluster_state.version_verify:
@@ -1138,18 +1140,25 @@ class TestAnyNodesUpgrade:
         assert 200 == code, (code, data)
         for node in data['data']:
             node_ip = node["metadata"]["annotations"][NODE_INTERNAL_IP_ANNOTATION]
-
-            with host_shell.login(node_ip) as sh:
-                lines, stderr = sh.exec_command(script, get_pty=True, splitlines=True)
-                assert not stderr, (
-                    f"Failed to execute {script} on {node_ip}: {stderr}")
+            endtime = datetime.now() + timedelta(seconds=wait_timeout)
+            while endtime > datetime.now():
+                try:
+                    with host_shell.login(node_ip) as sh:
+                        lines, stderr = sh.exec_command(script, get_pty=True, splitlines=True)
+                except (SSHException, NoValidConnectionsError, ConnectionResetError, TimeoutError):
+                    sleep(5)
+                    continue
+                assert not stderr, f"Failed to execute {script} on {node_ip}: {stderr}"
 
                 # eg: PRETTY_NAME="Harvester v1.1.0"
                 assert cluster_state.version == re.findall(r"Harvester (.+?)\"", lines[3])[0], (
                     "OS version is not correct")
+                break
+            else:
+                raise AssertionError(f"Unable to connect to {node_ip} after {wait_timeout}s")
 
     @pytest.mark.dependency(depends=["any_nodes_upgrade"])
-    def test_verify_rke2_version(self, api_client, host_shell):
+    def test_verify_rke2_version(self, api_client, host_shell, wait_timeout):
         # Verify node version on all nodes
         script = "cat /etc/harvester-release.yaml"
 
@@ -1165,17 +1174,29 @@ class TestAnyNodesUpgrade:
 
             # Get except rke2 version
             if except_rke2_version == "":
-                with host_shell.login(node_ip) as sh:
-                    lines, stderr = sh.exec_command(script, get_pty=True, splitlines=True)
-                    assert not stderr, (
-                        f"Failed to execute {script} on {node_ip}: {stderr}")
+                endtime = datetime.now() + timedelta(seconds=wait_timeout)
+                while endtime > datetime.now():
+                    try:
+                        with host_shell.login(node_ip) as sh:
+                            lines, stderr = sh.exec_command(script, get_pty=True, splitlines=True)
+                    except (
+                        SSHException, NoValidConnectionsError, ConnectionResetError, TimeoutError
+                    ):
+                        sleep(5)
+                        continue
+                    assert not stderr, f"Failed to execute {script} on {node_ip}: {stderr}"
 
                     for line in lines:
                         if "kubernetes" in line:
                             except_rke2_version = re.findall(r"kubernetes: (.*)", line.strip())[0]
                             break
 
-                    assert except_rke2_version != "", ("Failed to get except rke2 version")
+                    assert except_rke2_version != "", "Failed to get except rke2 version"
+                    break
+                else:
+                    raise AssertionError(
+                        f"Unable to connect to {node_ip} after {wait_timeout}s"
+                    )
 
             assert node.get('status', {}).get('nodeInfo', {}).get(
                    "kubeletVersion", "") == except_rke2_version, (

--- a/harvester_e2e_tests/integrations/test_upgrade.py
+++ b/harvester_e2e_tests/integrations/test_upgrade.py
@@ -2,6 +2,7 @@ import re
 import json
 import yaml
 import logging
+import requests
 from time import sleep
 from hashlib import sha512
 from operator import add
@@ -826,8 +827,21 @@ class TestAnyNodesUpgrade:
         # TODO: check every upgrade stages
         endtime = datetime.now() + timedelta(seconds=upgrade_timeout * nodes)
         while endtime > datetime.now():
-            code, data = api_client.upgrades.get(upgrade_name)
+            try:
+                code, data = api_client.upgrades.get(upgrade_name)
+            except requests.exceptions.ConnectionError as error:
+                logger.warning(
+                    "Harvester API is unavailable while checking upgrade %s; "
+                    "retrying in 10s: %s", upgrade_name, error
+                )
+                sleep(10)
+                continue
             if 200 != code:
+                logger.warning(
+                    "Harvester API returned status %s while checking upgrade %s; "
+                    "retrying in 10s", code, upgrade_name
+                )
+                sleep(10)
                 continue
             interceptor.check(data)
             conds = dict((c['type'], c) for c in data.get('status', {}).get('conditions', []))


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
* harvester/tests/issues/2841

#### What this PR does / why we need it:
1. Catch possible ConnectionError during upgrade retry checking
2. `HostShell` now detects inactive Paramiko transports, discards stale clients, and reconnects before reuse.
3. Fix audit.log parsing problem
   <img width="1414" height="299" alt="image" src="https://github.com/user-attachments/assets/19162f8c-e2cf-4f3e-b1bb-e9bde9f23610" />
   due to
    ```
    sudo tail /var/lib/rancher/rke2/server/logs/audit.log | awk 'END{print}' | jq .requestReceivedTimestamp | xargs -I {} date -d \"{}\" +%s
    date: invalid date ‘"2026-08-19T06:09:48.309341Z"’
    ```

#### Special notes for your reviewer:

#### Additional documentation or context
Test Result:
* https://ci.suse-virtualization.suse.de/job/harvester-upgrade-test/537/TestReport/
  <img width="1412" height="814" alt="image" src="https://github.com/user-attachments/assets/80176b3c-d2ea-4004-be30-9c4f5a92f900" />
