### PR TITLE
robot: make VM suite teardowns parallel-safe

### DIFF
--- a/harvester_robot_tests/tests/regression/vm/test_vm_snapshots.robot
+++ b/harvester_robot_tests/tests/regression/vm/test_vm_snapshots.robot
@@ -9,9 +9,16 @@ Resource         ../../../keywords/virtualmachine.resource
 Resource         ../../../keywords/snapshot.resource
 
 
-Suite Setup       Set up test environment
-Test Teardown    Cleanup test resources
-Suite Teardown   Common Suite Teardown
+Suite Setup       Local Suite Setup
+Suite Teardown    Local Suite Teardown
+Test Teardown     Common Test Teardown
+
+
+*** Variables ***
+# Dynamic Variables (set by Local Suite Setup)
+${IMAGE_NAME}       ${EMPTY}
+${VM_NAME}          ${EMPTY}
+${SNAPSHOT_NAME}    ${EMPTY}
 
 
 *** Test Cases ***
@@ -19,16 +26,33 @@ Test Basic VM Snapshot
     [Tags]    coretest    p0    snapshot
     [Documentation]    Test basic VM snapshot creation
 
-    # Generate unique name for vm, image and snapshot
-    ${suffix}=    Generate Unique Name
-    ${image_name}=    Set Variable    image-0-${suffix}
-    ${vm_name}=    Set Variable    vm-0-${suffix}
-    ${snapshot_name}=    Set Variable    snap-0-${suffix}
+    Given Image is available for VM creation    ${IMAGE_NAME}    ${OPENSUSE_IMAGE_URL}
+    When VM is created                 ${VM_NAME}        ${IMAGE_NAME}
+    Then VM should be running          ${VM_NAME}
+    When Snapshot is created           ${VM_NAME}        ${SNAPSHOT_NAME}
+    Then Snapshot should be ready      ${SNAPSHOT_NAME}
+    When Snapshot is deleted           ${SNAPSHOT_NAME}
+    Then Snapshot should be deleted    ${SNAPSHOT_NAME}
 
-    Given Image is available for VM creation    ${image_name}    ${OPENSUSE_IMAGE_URL}
-    When VM is created                 ${vm_name}        ${image_name}
-    Then VM should be running          ${vm_name}
-    When Snapshot is created           ${vm_name}        ${snapshot_name}
-    Then Snapshot should be ready      ${snapshot_name}
-    When Snapshot is deleted           ${snapshot_name}
-    Then Snapshot should be deleted    ${snapshot_name}
+
+*** Keywords ***
+Local Suite Setup
+    ${suffix}=    Generate Unique Name
+    Set Suite Variable    ${IMAGE_NAME}       image-0-${suffix}
+    Set Suite Variable    ${VM_NAME}          vm-0-${suffix}
+    Set Suite Variable    ${SNAPSHOT_NAME}    snap-0-${suffix}
+    Set up test environment
+
+Local Suite Teardown
+    # Parallel-safe: only delete this suite's own named resources (never a global
+    # label sweep, which would remove resources owned by sibling suites under pabot).
+    Run Keyword If All Tests Passed    Delete Suite Resources
+    Run Keyword If Any Tests Failed    Log Variables
+
+Delete Suite Resources
+    # Defensive: the snapshot is deleted by the test itself on the happy path.
+    Run Keyword And Ignore Error    Snapshot is deleted    ${SNAPSHOT_NAME}
+    Run Keyword And Ignore Error    VM is deleted    ${VM_NAME}
+    # Wait for the VM (and its volumes) to be gone so the image is no longer in use.
+    Run Keyword And Ignore Error    VM should be deleted    ${VM_NAME}
+    Run Keyword And Ignore Error    Delete image by name    ${IMAGE_NAME}

--- a/harvester_robot_tests/tests/regression/vm/test_vm_templates.robot
+++ b/harvester_robot_tests/tests/regression/vm/test_vm_templates.robot
@@ -9,8 +9,10 @@ Library          Collections
 Resource         ../../../keywords/common.resource
 Resource         ../../../keywords/vm_template.resource
 
+# Read-only suite: creates no resources, so no cleanup is needed. Must not use
+# Common Suite Teardown - its global label sweep deletes resources still owned
+# by sibling suites when running under pabot.
 Suite Setup       Set Up Test Environment
-Suite Teardown    Common Suite Teardown
 Test Teardown     Common Test Teardown
 
 


### PR DESCRIPTION
    The template and snapshot suites ended with the shared label-sweep
    cleanup, deleting resources still owned by sibling suites under
    pabot. Scope teardown to each suite's own named resources instead.

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:
Some new test suites are not parallel-safe, we need to fix them

#### Special notes for your reviewer:
make VM suite teardowns parallel-safe

#### Additional documentation or context
