### PR TITLE
integrations: fix vm_shell_do control flow and broaden SSH retry

### DIFF
--- a/harvester_e2e_tests/fixtures/virtualmachines.py
+++ b/harvester_e2e_tests/fixtures/virtualmachines.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 
 import pytest
 from paramiko import SSHClient, RSAKey, MissingHostKeyPolicy
-from paramiko.ssh_exception import ChannelException, NoValidConnectionsError
+from paramiko.ssh_exception import NoValidConnectionsError, SSHException
 
 
 @pytest.fixture(scope="session")
@@ -103,7 +103,8 @@ def vm_shell_from_host(vm_shell, host_shell, wait_timeout):
             while endtime > datetime.now():
                 try:
                     vm_sh.connect(vm_ip, jumphost=h.client)
-                except (ChannelException, NoValidConnectionsError) as e:
+                except (SSHException, NoValidConnectionsError,
+                        ConnectionResetError, TimeoutError) as e:
                     login_ex = e
                     sleep(3)
                 else:
@@ -369,7 +370,8 @@ def vm_checker(api_client, wait_timeout, sleep_timeout, vm_shell):
             while endtime > datetime.now():
                 try:
                     vm_sh.connect(vm_ip, **kws)
-                except (ChannelException, NoValidConnectionsError) as e:
+                except (SSHException, NoValidConnectionsError,
+                        ConnectionResetError, TimeoutError) as e:
                     login_ex = e
                     sleep(self.snooze)
                 else:

--- a/harvester_e2e_tests/integrations/test_4_vm_snapshot.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_snapshot.py
@@ -2,7 +2,7 @@ import yaml
 from datetime import datetime, timedelta
 from time import sleep
 
-from paramiko.ssh_exception import ChannelException
+from paramiko.ssh_exception import NoValidConnectionsError, SSHException
 import pytest
 
 
@@ -235,6 +235,8 @@ def restored_vm_2(api_client, restored_from_snapshot_name_2,
 def vm_shell_do(name, api_client, host_shell, vm_shell, user, ssh_keypair, action, wait_timeout):
     _, privatekey = ssh_keypair
 
+    # Wait until the VM is fully ready (agent connected implies cloud-init
+    # finished provisioning the SSH key) before attempting to log in.
     deadline = datetime.now() + timedelta(seconds=wait_timeout)
     while deadline > datetime.now():
         code, data = api_client.vms.get_status(name)
@@ -242,35 +244,40 @@ def vm_shell_do(name, api_client, host_shell, vm_shell, user, ssh_keypair, actio
             phase = data.get("status", {}).get("phase")
             conds = data.get("status", {}).get("conditions", [{}])
             if ("Running" == phase
-                    and "AgentConnected" == conds[-1].get("type")
-                    and data["status"].get("interfaces")):
+                    and any("AgentConnected" == c.get("type") for c in conds)
+                    and any(iface.get("ipAddress")
+                            for iface in data["status"].get("interfaces", [])
+                            if iface.get("name") == "default")):
                 break
-            sleep(3)
+        sleep(3)
+    else:
+        raise AssertionError(f"VM {name} is not ready with {wait_timeout} timed out")
 
-        vm_ip = next(iface["ipAddress"] for iface in data["status"]["interfaces"]
-                     if iface["name"] == "default")
+    vm_ip = next(iface["ipAddress"] for iface in data["status"]["interfaces"]
+                 if iface.get("name") == "default" and iface.get("ipAddress"))
 
-        code, data = api_client.hosts.get(data["status"]["nodeName"])
-        host_ip = next(addr["address"] for addr in data["status"]["addresses"]
-                       if addr["type"] == "InternalIP")
+    code, data = api_client.hosts.get(data["status"]["nodeName"])
+    host_ip = next(addr["address"] for addr in data["status"]["addresses"]
+                   if addr["type"] == "InternalIP")
 
-        with host_shell.login(host_ip, jumphost=True) as h:
-            vm_sh = vm_shell(user, pkey=privatekey)
+    with host_shell.login(host_ip, jumphost=True) as h:
+        vm_sh = vm_shell(user, pkey=privatekey)
 
-            deadline = datetime.now() + timedelta(seconds=wait_timeout)
-            while deadline > datetime.now():
-                try:
-                    vm_sh.connect(vm_ip, jumphost=h.client)
-                except ChannelException as e:
-                    print(e)
-                    sleep(3)
-                else:
-                    break
+        deadline = datetime.now() + timedelta(seconds=wait_timeout)
+        while deadline > datetime.now():
+            try:
+                vm_sh.connect(vm_ip, jumphost=h.client)
+            except (SSHException, NoValidConnectionsError,
+                    ConnectionResetError, TimeoutError) as e:
+                print(e)
+                sleep(3)
             else:
-                raise AssertionError(f"Unable to login to {name}")
+                break
+        else:
+            raise AssertionError(f"Unable to login to {name}")
 
-            with vm_sh as sh:
-                action(sh)
+        with vm_sh as sh:
+            action(sh)
 
 
 @pytest.mark.p0


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!-- none filed; observed in harvester/release smoke run 32254373183 -->
N/A (smoke flake observed in CI)

#### What this PR does / why we need it:
`TestVMSnapshot::test_vm_snapshot_create` fails intermittently in smoke runs with `paramiko AuthenticationException: transport shut down or saw EOF`. Two defects in `vm_shell_do` cause this:

1. The whole SSH-and-run-action block sits **inside** the readiness poll loop. When the VM is already Running with the guest agent connected, the loop `break`s past the SSH block, so the action is silently skipped (the data write/verify steps of the snapshot suite become no-ops). When the VM is *not* ready yet, the code falls through and logs in exactly while cloud-init has not finished installing the SSH key - which is the AuthenticationException flake.
2. The connect retry loop only catches `ChannelException`, so an auth failure during guest boot aborts immediately instead of retrying.

This PR dedents the SSH block out of the poll loop (login only happens after the agent is connected, and the poll now times out explicitly), and broadens the retry to `(SSHException, NoValidConnectionsError, ConnectionResetError, TimeoutError)` following the existing pattern in `test_upgrade.py`. The same narrow catch in `fixtures/virtualmachines.py` (`vm_shell_from_host` / `vm_checker`) is broadened too, which also covers the long-standing paramiko flake seen in the clone/hotplug tests.

#### Special notes for your reviewer:
`ChannelException` is a subclass of `SSHException`, so the previous catches remain covered. The retry loops are still bounded by `wait_timeout`, so a genuine auth misconfiguration still fails - just at the deadline instead of on first attempt.

#### Additional documentation or context
Flake instance: harvester/release smoke run 32254373183 (`test_vm_snapshot_create`, guest sshd accepted TCP but key provisioning had not completed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)