### PR TITLE
Fix e2e ssh retry and teardown

### DIFF
--- a/harvester_e2e_tests/fixtures/settings.py
+++ b/harvester_e2e_tests/fixtures/settings.py
@@ -22,6 +22,18 @@ def setting_checker(api_client, wait_timeout, sleep_timeout):
             return False, (code, data)
 
         @wait_until(wait_timeout, sleep_timeout)
+        def enable_storage_net(self, vlan_id, cluster_network, cidr):
+            """Update the storage-network setting, retrying while the webhook
+            rejects it because a node's VlanStatus is not Ready yet - enabling
+            right after VlanConfig creation races the per-node network setup.
+            Returns on success or on any other rejection; callers assert 200.
+            """
+            spec = self.settings.StorageNetworkSpec.enable_with(vlan_id, cluster_network, cidr)
+            code, data = self.settings.update('storage-network', spec)
+            retryable = 422 == code and 'not Ready' in str(data)
+            return not retryable, (code, data)
+
+        @wait_until(wait_timeout, sleep_timeout)
         def wait_storage_net_enabled_on_harvester(self):
             snet_configured, (code, data) = self._storage_net_configured()
             if snet_configured and data.get('value'):

--- a/harvester_e2e_tests/fixtures/virtualmachines.py
+++ b/harvester_e2e_tests/fixtures/virtualmachines.py
@@ -359,8 +359,51 @@ def vm_checker(api_client, wait_timeout, sleep_timeout, vm_shell):
                     break
                 sleep(self.snooze)
             else:
+                self._attach_migration_diagnosis(ctx, vm_name, **kws)
                 return False, ctx
             return True, ctx
+
+        def _attach_migration_diagnosis(self, ctx, vm_name, **kws):
+            """Attach VMIM status and related events to a failed-migration context.
+
+            A timed-out migration where the target pod never scheduled leaves no
+            migrationState on the VMI, so the VMI dump alone cannot explain the
+            failure; the reason only shows up in the VMIM and the events. Attach
+            them to ctx.data so existing assertion dumps include them. Must never
+            raise - diagnosis is best-effort and the original failure wins.
+            """
+            ns = kws.get('namespace', 'default')
+            diagnosis = {}
+            try:
+                code, data = self.vms._get(
+                    f"v1/harvester/kubevirt.io.virtualmachineinstancemigrations/{ns}")
+                diagnosis['migrations'] = [
+                    {'name': m.get('metadata', {}).get('name'),
+                     'status': m.get('status', {})}
+                    for m in data.get('data', [])
+                    if m.get('spec', {}).get('vmiName') == vm_name
+                ] if 200 == code else f"HTTP {code}: {data}"
+            except Exception as e:
+                diagnosis['migrations'] = f"unavailable: {e}"
+            try:
+                code, data = self.vms._get(f"v1/events/{ns}")
+                events = [
+                    {'lastTimestamp': ev.get('lastTimestamp'),
+                     'type': ev.get('type'),
+                     'reason': ev.get('reason'),
+                     'kind': ev.get('involvedObject', {}).get('kind'),
+                     'name': ev.get('involvedObject', {}).get('name'),
+                     'message': ev.get('message')}
+                    for ev in data.get('data', [])
+                    if vm_name in ev.get('involvedObject', {}).get('name', '')
+                ] if 200 == code else f"HTTP {code}: {data}"
+                if isinstance(events, list):
+                    events = sorted(events, key=lambda e: e['lastTimestamp'] or '')[-20:]
+                diagnosis['events'] = events
+            except Exception as e:
+                diagnosis['events'] = f"unavailable: {e}"
+            if isinstance(ctx.data, dict):
+                ctx.data['diagnosis'] = diagnosis
 
         def wait_ssh_connected(
             self, vm_ip, username, password=None, pkey=None, endtime=None, **kws

--- a/harvester_e2e_tests/integrations/test_0_storage_network.py
+++ b/harvester_e2e_tests/integrations/test_0_storage_network.py
@@ -137,10 +137,7 @@ def test_enable_storage_network(
     vlan_cidr = route['cidr']
 
     # Create storage-network
-    enable_spec = api_client.settings.StorageNetworkSpec.enable_with(
-        vlan_id, cluster_network, vlan_cidr
-    )
-    code, data = api_client.settings.update('storage-network', enable_spec)
+    _, (code, data) = setting_checker.enable_storage_net(vlan_id, cluster_network, vlan_cidr)
     assert 200 == code, (code, data)
     snet_enabled, (code, data) = setting_checker.wait_storage_net_enabled_on_harvester()
     assert snet_enabled, (code, data)

--- a/harvester_e2e_tests/integrations/test_1_images.py
+++ b/harvester_e2e_tests/integrations/test_1_images.py
@@ -169,10 +169,7 @@ def vlan_cidr(api_client, cluster_network, vlan_id, wait_timeout, sleep_timeout)
 def storage_network(api_client, cluster_network, vlan_id, vlan_cidr, setting_checker):
     ''' Ref. https://docs.harvesterhci.io/v1.3/advanced/storagenetwork/#configuration-example
     '''
-    enable_spec = api_client.settings.StorageNetworkSpec.enable_with(
-        vlan_id, cluster_network, vlan_cidr
-    )
-    code, data = api_client.settings.update('storage-network', enable_spec)
+    _, (code, data) = setting_checker.enable_storage_net(vlan_id, cluster_network, vlan_cidr)
     assert 200 == code, (code, data)
     snet_enabled, (code, data) = setting_checker.wait_storage_net_enabled_on_harvester()
     assert snet_enabled, (code, data)

--- a/harvester_e2e_tests/integrations/test_3_vm.py
+++ b/harvester_e2e_tests/integrations/test_3_vm.py
@@ -316,9 +316,19 @@ def test_migrate_vm_with_user_data(
     vm_deleted, (code, data) = vm_checker.wait_deleted(unique_name)
     assert vm_deleted, (code, data)
 
-    for vol in api_client.vms.Spec.from_dict(vm_data).volumes:
-        if vol['volume'].get('persistentVolumeClaim', {}).get('claimName', "") != "":
-            api_client.volumes.delete(vol['volume']['persistentVolumeClaim']['claimName'])
+    claims = [
+        vol['volume']['persistentVolumeClaim']['claimName']
+        for vol in api_client.vms.Spec.from_dict(vm_data).volumes
+        if vol['volume'].get('persistentVolumeClaim', {}).get('claimName', "") != ""
+    ]
+    for claim in claims:
+        api_client.volumes.delete(claim)
+    # the module-scoped image fixture teardown fails with 422 (image in use)
+    # until the volumes are actually gone, not merely marked for deletion
+    endtime = datetime.now() + timedelta(seconds=wait_timeout)
+    while endtime > datetime.now() and claims:
+        claims = [c for c in claims if api_client.volumes.get(c)[0] != 404]
+        sleep(5)
 
 
 @pytest.mark.p0
@@ -384,9 +394,19 @@ def test_migrate_vm_with_multiple_volumes(
     vm_deleted, (code, data) = vm_checker.wait_deleted(unique_name)
     assert vm_deleted, (code, data)
 
-    for vol in api_client.vms.Spec.from_dict(vm_data).volumes:
-        if vol['volume'].get('persistentVolumeClaim', {}).get('claimName', "") != "":
-            api_client.volumes.delete(vol['volume']['persistentVolumeClaim']['claimName'])
+    claims = [
+        vol['volume']['persistentVolumeClaim']['claimName']
+        for vol in api_client.vms.Spec.from_dict(vm_data).volumes
+        if vol['volume'].get('persistentVolumeClaim', {}).get('claimName', "") != ""
+    ]
+    for claim in claims:
+        api_client.volumes.delete(claim)
+    # the module-scoped image fixture teardown fails with 422 (image in use)
+    # until the volumes are actually gone, not merely marked for deletion
+    endtime = datetime.now() + timedelta(seconds=wait_timeout)
+    while endtime > datetime.now() and claims:
+        claims = [c for c in claims if api_client.volumes.get(c)[0] != 404]
+        sleep(5)
 
 
 @pytest.mark.p1

--- a/harvester_e2e_tests/integrations/test_3_vm_functions.py
+++ b/harvester_e2e_tests/integrations/test_3_vm_functions.py
@@ -6,7 +6,7 @@ import re
 
 import pytest
 import yaml
-from paramiko.ssh_exception import ChannelException
+from paramiko.ssh_exception import NoValidConnectionsError, SSHException
 
 pytest_plugins = [
     "harvester_e2e_tests.fixtures.api_client",
@@ -1016,7 +1016,8 @@ class TestVMClone:
             while endtime > datetime.now():
                 try:
                     vm_sh.connect(vm_ip, jumphost=h.client)
-                except ChannelException as e:
+                except (SSHException, NoValidConnectionsError,
+                        ConnectionResetError, TimeoutError) as e:
                     login_ex = e
                     sleep(3)
                 else:
@@ -1067,7 +1068,8 @@ class TestVMClone:
             while endtime > datetime.now():
                 try:
                     vm_sh.connect(vm_ip, jumphost=h.client)
-                except ChannelException as e:
+                except (SSHException, NoValidConnectionsError,
+                        ConnectionResetError, TimeoutError) as e:
                     login_ex = e
                     sleep(3)
                 else:
@@ -1153,7 +1155,8 @@ class TestVMClone:
             while endtime > datetime.now():
                 try:
                     vm_sh.connect(vm_ip, jumphost=h.client)
-                except ChannelException as e:
+                except (SSHException, NoValidConnectionsError,
+                        ConnectionResetError, TimeoutError) as e:
                     login_ex = e
                     sleep(3)
                 else:
@@ -1222,7 +1225,8 @@ class TestVMClone:
             while endtime > datetime.now():
                 try:
                     vm_sh.connect(vm_ip, jumphost=h.client)
-                except ChannelException as e:
+                except (SSHException, NoValidConnectionsError,
+                        ConnectionResetError, TimeoutError) as e:
                     login_ex = e
                     sleep(3)
                 else:
@@ -1375,7 +1379,8 @@ class TestVMWithVolumes:
             while endtime > datetime.now():
                 try:
                     vm_sh.connect(vm_ip, jumphost=h.client)
-                except ChannelException as e:
+                except (SSHException, NoValidConnectionsError,
+                        ConnectionResetError, TimeoutError) as e:
                     login_ex = e
                     sleep(3)
                 else:
@@ -1492,7 +1497,8 @@ class TestVMWithVolumes:
             while endtime > datetime.now():
                 try:
                     vm_sh.connect(vm_ip, jumphost=h.client)
-                except ChannelException as e:
+                except (SSHException, NoValidConnectionsError,
+                        ConnectionResetError, TimeoutError) as e:
                     login_ex = e
                     sleep(3)
                 else:
@@ -2109,7 +2115,8 @@ class TestHotPlugVolume:
             while endtime > datetime.now():
                 try:
                     vm_sh.connect(vm_ip, jumphost=host_sh.client)
-                except ChannelException as e:
+                except (SSHException, NoValidConnectionsError,
+                        ConnectionResetError, TimeoutError) as e:
                     login_ex = e
                     sleep(3)
                 else:

--- a/harvester_e2e_tests/integrations/test_4_vm_backup_restore.py
+++ b/harvester_e2e_tests/integrations/test_4_vm_backup_restore.py
@@ -19,7 +19,7 @@ from datetime import datetime, timedelta
 
 import yaml
 import pytest
-from paramiko.ssh_exception import ChannelException
+from paramiko.ssh_exception import NoValidConnectionsError, SSHException
 
 pytest_plugins = [
     'harvester_e2e_tests.fixtures.api_client',
@@ -773,7 +773,8 @@ class TestMultipleBackupRestore:
                 while endtime > datetime.now():
                     try:
                         vm_sh.connect(vm_ip, jumphost=h.client)
-                    except ChannelException as e:
+                    except (SSHException, NoValidConnectionsError,
+                            ConnectionResetError, TimeoutError) as e:
                         login_ex = e
                         sleep(3)
                     else:
@@ -904,7 +905,8 @@ class TestMultipleBackupRestore:
             while endtime > datetime.now():
                 try:
                     vm_sh.connect(vm_ip, jumphost=h.client)
-                except ChannelException as e:
+                except (SSHException, NoValidConnectionsError,
+                        ConnectionResetError, TimeoutError) as e:
                     login_ex = e
                     sleep(3)
                 else:
@@ -1000,7 +1002,8 @@ class TestMultipleBackupRestore:
             while endtime > datetime.now():
                 try:
                     vm_sh.connect(vm_ip, jumphost=h.client)
-                except ChannelException as e:
+                except (SSHException, NoValidConnectionsError,
+                        ConnectionResetError, TimeoutError) as e:
                     login_ex = e
                     sleep(3)
                 else:
@@ -1096,7 +1099,8 @@ class TestMultipleBackupRestore:
             while endtime > datetime.now():
                 try:
                     vm_sh.connect(vm_ip, jumphost=h.client)
-                except ChannelException as e:
+                except (SSHException, NoValidConnectionsError,
+                        ConnectionResetError, TimeoutError) as e:
                     login_ex = e
                     sleep(3)
                 else:


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:
- Ensure the SSH login retry mechanism on test_3_vm_functions.py and test_4_vm_backup_restore.py
- Migrate test teardowns; now wait for volume deletion before deleting the source image

#### Special notes for your reviewer:

#### Additional documentation or context

These flaky cases were found by following smoke testing:
- https://github.com/harvester/release/actions/runs/33520980330
- https://github.com/harvester/release/actions/runs/33460089214